### PR TITLE
feat(wdio): getExtendedComponent  predefined default root selector from the selectors enum

### DIFF
--- a/packages/wdio/src/rooted-component$/get-extended-rooted-component$/get-extended-rooted-component$.spec.ts
+++ b/packages/wdio/src/rooted-component$/get-extended-rooted-component$/get-extended-rooted-component$.spec.ts
@@ -1,4 +1,5 @@
 import { mockDefault$Config, mockElement } from '../../element.mock';
+import { DefaultRootRootedExtendedComponent$Mock } from '../mocks/default-root-rooted-extended-component$.mock';
 import { RootedComponent$SelectorsMock } from '../mocks/rooted-component$-selectors.mock';
 import { RootedComponent$Mock } from '../mocks/rooted-component$.mock';
 
@@ -12,5 +13,13 @@ describe('getExtendedRootedComponent$', () => {
         expect(mockDefault$Config.elSelectorFn).toHaveBeenNthCalledWith(1, RootedComponent$SelectorsMock.Root$);
 
         jest.clearAllMocks();
+    });
+
+    it('can have default root selector from the selectors enum', async () => {
+        expect.assertions(1);
+
+        const component = new DefaultRootRootedExtendedComponent$Mock();
+        await component.waitForDisplayed({ reverse: true });
+        expect(mockDefault$Config.elSelectorFn).toHaveBeenNthCalledWith(1, RootedComponent$SelectorsMock.Root$);
     });
 });

--- a/packages/wdio/src/rooted-component$/get-extended-rooted-component$/get-extended-rooted-component$.ts
+++ b/packages/wdio/src/rooted-component$/get-extended-rooted-component$/get-extended-rooted-component$.ts
@@ -1,16 +1,33 @@
 import { default$ComponentConfig } from '../../config/default$-component.config';
 import { RootedComponent } from '../../rooted-component/rooted-component';
 
-import type { ComponentInputArg, RootedComponentWithSelectorsCtor } from '../../type';
+import type { ComponentInputArg } from '../../type';
+import type {
+    RootedComponentCtorWithDefaultRootSelector,
+    RootedComponentCtorWithoutDefaultRootSelector,
+} from '../../type/rooted-component-with-selectors-ctor.type';
 import type { ClassType } from '@rnw-community/shared';
 
-export const getExtendedRootedComponent$ = <T, P extends RootedComponent>(
+export function getExtendedRootedComponent$<T, P extends RootedComponent>(
     selectors: T,
     ParentComponent: ClassType<P>
-): RootedComponentWithSelectorsCtor<T, P> =>
-    // @ts-expect-error We use proxy for dynamic fields
-    class extends RootedComponent {
-        constructor(selectorOrElement: ComponentInputArg) {
+): RootedComponentCtorWithoutDefaultRootSelector<T, P>;
+
+export function getExtendedRootedComponent$<T, P extends RootedComponent>(
+    selectors: T,
+    ParentComponent: ClassType<P>,
+    rootSelector: T[keyof T]
+): RootedComponentCtorWithDefaultRootSelector<T, P>;
+
+// eslint-disable-next-line func-style
+export function getExtendedRootedComponent$<T, P extends RootedComponent>(
+    selectors: T,
+    ParentComponent: ClassType<P>,
+    rootSelector?: string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): any {
+    return class extends RootedComponent {
+        constructor(selectorOrElement: ComponentInputArg | undefined = rootSelector) {
             super(default$ComponentConfig(), selectors, selectorOrElement);
 
             if (ParentComponent !== RootedComponent) {
@@ -18,3 +35,4 @@ export const getExtendedRootedComponent$ = <T, P extends RootedComponent>(
             }
         }
     };
+}

--- a/packages/wdio/src/rooted-component$/get-rooted-component$/get-rooted-component$.spec.ts
+++ b/packages/wdio/src/rooted-component$/get-rooted-component$/get-rooted-component$.spec.ts
@@ -1,5 +1,6 @@
 import { mockDefault$Config, mockDefaultConfig, mockElement } from '../../element.mock';
 import { RootedComponentSelectorsMock } from '../../rooted-component/mocks/rooted-component-selectors.mock';
+import { DefaultRootRootedComponent$Mock } from '../mocks/default-root-rooted-component$.mock';
 import { RootedComponent$SelectorsMock } from '../mocks/rooted-component$-selectors.mock';
 import { RootedComponent$Mock } from '../mocks/rooted-component$.mock';
 import { RootedExtendedComponent$SelectorsMock } from '../mocks/rooted-extended-component$-selectors.mock';
@@ -76,5 +77,13 @@ describe('getRootedComponent$', () => {
             RootedComponentSelectorsMock.Button,
             expect.objectContaining({})
         );
+    });
+
+    it('can have default root selector from the selectors enum', async () => {
+        expect.assertions(1);
+
+        const component = new DefaultRootRootedComponent$Mock();
+        await component.waitForDisplayed({ reverse: true });
+        expect(mockDefault$Config.elSelectorFn).toHaveBeenNthCalledWith(1, RootedComponent$SelectorsMock.Root$);
     });
 });

--- a/packages/wdio/src/rooted-component$/get-rooted-component$/get-rooted-component$.ts
+++ b/packages/wdio/src/rooted-component$/get-rooted-component$/get-rooted-component$.ts
@@ -1,7 +1,24 @@
+import { isDefined } from '@rnw-community/shared';
+
 import { RootedComponent } from '../../rooted-component/rooted-component';
 import { getExtendedRootedComponent$ } from '../get-extended-rooted-component$/get-extended-rooted-component$';
 
-import type { RootedComponentWithSelectorsCtor } from '../../type';
+import type {
+    RootedComponentCtorWithDefaultRootSelector,
+    RootedComponentCtorWithoutDefaultRootSelector,
+} from '../../type/rooted-component-with-selectors-ctor.type';
 
-export const getRootedComponent$ = <T>(selectors: T): RootedComponentWithSelectorsCtor<T> =>
-    getExtendedRootedComponent$(selectors, RootedComponent);
+export function getRootedComponent$<T>(selectors: T): RootedComponentCtorWithoutDefaultRootSelector<T>;
+export function getRootedComponent$<T>(
+    selectors: T,
+    rootSelector: T[keyof T]
+): RootedComponentCtorWithDefaultRootSelector<T>;
+
+// eslint-disable-next-line func-style,@typescript-eslint/no-explicit-any
+export function getRootedComponent$<T>(selectors: T, rootSelector?: T[keyof T]): any {
+    if (isDefined(rootSelector)) {
+        return getExtendedRootedComponent$(selectors, RootedComponent, rootSelector);
+    }
+
+    return getExtendedRootedComponent$(selectors, RootedComponent);
+}

--- a/packages/wdio/src/rooted-component$/mocks/default-root-rooted-component$.mock.ts
+++ b/packages/wdio/src/rooted-component$/mocks/default-root-rooted-component$.mock.ts
@@ -1,0 +1,8 @@
+import { getRootedComponent$ } from '../get-rooted-component$/get-rooted-component$';
+
+import { RootedComponent$SelectorsMock } from './rooted-component$-selectors.mock';
+
+export class DefaultRootRootedComponent$Mock extends getRootedComponent$(
+    RootedComponent$SelectorsMock,
+    RootedComponent$SelectorsMock.Root$
+) {}

--- a/packages/wdio/src/rooted-component$/mocks/default-root-rooted-extended-component$.mock.ts
+++ b/packages/wdio/src/rooted-component$/mocks/default-root-rooted-extended-component$.mock.ts
@@ -1,0 +1,10 @@
+import { getExtendedRootedComponent$ } from '../get-extended-rooted-component$/get-extended-rooted-component$';
+
+import { RootedComponent$SelectorsMock } from './rooted-component$-selectors.mock';
+import { RootedComponent$Mock } from './rooted-component$.mock';
+
+export class DefaultRootRootedExtendedComponent$Mock extends getExtendedRootedComponent$(
+    RootedComponent$SelectorsMock,
+    RootedComponent$Mock,
+    RootedComponent$SelectorsMock.Root$
+) {}

--- a/packages/wdio/src/rooted-component/get-extended-rooted-component/get-extended-rooted-component.spec.ts
+++ b/packages/wdio/src/rooted-component/get-extended-rooted-component/get-extended-rooted-component.spec.ts
@@ -1,10 +1,12 @@
 import { mockDefaultConfig, mockElement } from '../../element.mock';
+import { DefaultRootRootedExtendedComponentMock } from '../mocks/default-root-rooted-extended-component.mock';
 import { RootedComponentSelectorsMock } from '../mocks/rooted-component-selectors.mock';
 import { RootedComponentMock } from '../mocks/rooted-component.mock';
 import { RootedExtendedComponentMock } from '../mocks/rooted-extended-component.mock';
 import { RootedOverrideComponentMock } from '../mocks/rooted-override-component.mock';
 import { RootedParentComponentSelectorsMock } from '../mocks/rooted-parent-component-selectors.mock';
 
+// eslint-disable-next-line max-lines-per-function
 describe('getExtendedRootedComponent', () => {
     it('should return RootEl using getter', async () => {
         expect.assertions(2);
@@ -115,5 +117,13 @@ describe('getExtendedRootedComponent', () => {
         const awaitedComponent = await asyncFn();
 
         await expect(awaitedComponent.Button.el()).resolves.toBe(mockElement);
+    });
+
+    it('can have default root selector from the selectors enum', async () => {
+        expect.assertions(1);
+
+        const component = new DefaultRootRootedExtendedComponentMock();
+        await component.waitForDisplayed({ reverse: true });
+        expect(mockDefaultConfig.elSelectorFn).toHaveBeenCalledWith(RootedComponentSelectorsMock.CustomRoot);
     });
 });

--- a/packages/wdio/src/rooted-component/get-extended-rooted-component/get-extended-rooted-component.ts
+++ b/packages/wdio/src/rooted-component/get-extended-rooted-component/get-extended-rooted-component.ts
@@ -1,16 +1,33 @@
 import { defaultComponentConfig } from '../../config/default-component.config';
 import { RootedComponent } from '../rooted-component';
 
-import type { ComponentInputArg, RootedComponentWithSelectorsCtor } from '../../type';
+import type { ComponentInputArg } from '../../type';
+import type {
+    RootedComponentCtorWithDefaultRootSelector,
+    RootedComponentCtorWithoutDefaultRootSelector,
+} from '../../type/rooted-component-with-selectors-ctor.type';
 import type { ClassType } from '@rnw-community/shared';
 
-export const getExtendedRootedComponent = <T, P extends RootedComponent>(
+export function getExtendedRootedComponent<T, P extends RootedComponent>(
     selectors: T,
     ParentComponent: ClassType<P>
-): RootedComponentWithSelectorsCtor<T, P> =>
-    // @ts-expect-error We use proxy for dynamic fields
-    class extends RootedComponent {
-        constructor(selectorOrElement: ComponentInputArg) {
+): RootedComponentCtorWithoutDefaultRootSelector<T, P>;
+
+export function getExtendedRootedComponent<T, P extends RootedComponent>(
+    selectors: T,
+    ParentComponent: ClassType<P>,
+    rootSelector: T[keyof T]
+): RootedComponentCtorWithDefaultRootSelector<T, P>;
+
+// eslint-disable-next-line func-style
+export function getExtendedRootedComponent<T, P extends RootedComponent>(
+    selectors: T,
+    ParentComponent: ClassType<P>,
+    rootSelector?: string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): any {
+    return class extends RootedComponent {
+        constructor(selectorOrElement: ComponentInputArg | undefined = rootSelector) {
             super(defaultComponentConfig(), selectors, selectorOrElement);
 
             if (ParentComponent !== RootedComponent) {
@@ -18,3 +35,4 @@ export const getExtendedRootedComponent = <T, P extends RootedComponent>(
             }
         }
     };
+}

--- a/packages/wdio/src/rooted-component/get-rooted-component/get-rooted-component.spec.ts
+++ b/packages/wdio/src/rooted-component/get-rooted-component/get-rooted-component.spec.ts
@@ -1,4 +1,5 @@
 import { mockDefaultConfig } from '../../element.mock';
+import { DefaultRootRootedComponentMock } from '../mocks/default-root-rooted-component.mock';
 import { RootedComponentSelectorsMock } from '../mocks/rooted-component-selectors.mock';
 import { RootedComponentMock } from '../mocks/rooted-component.mock';
 
@@ -11,5 +12,13 @@ describe('getRootedComponent', () => {
         await component.RootEl;
 
         expect(mockDefaultConfig.elSelectorFn).toHaveBeenNthCalledWith(1, RootedComponentSelectorsMock.Root);
+    });
+
+    it('can have default root selector from the selectors enum', async () => {
+        expect.assertions(1);
+
+        const component = new DefaultRootRootedComponentMock();
+        await component.waitForDisplayed({ reverse: true });
+        expect(mockDefaultConfig.elSelectorFn).toHaveBeenCalledWith(RootedComponentSelectorsMock.Root);
     });
 });

--- a/packages/wdio/src/rooted-component/get-rooted-component/get-rooted-component.ts
+++ b/packages/wdio/src/rooted-component/get-rooted-component/get-rooted-component.ts
@@ -1,7 +1,21 @@
+import { isDefined } from '@rnw-community/shared';
+
 import { getExtendedRootedComponent } from '../get-extended-rooted-component/get-extended-rooted-component';
 import { RootedComponent } from '../rooted-component';
 
-import type { RootedComponentWithSelectorsCtor } from '../../type';
+import type {
+    RootedComponentCtorWithDefaultRootSelector,
+    RootedComponentCtorWithoutDefaultRootSelector,
+} from '../../type/rooted-component-with-selectors-ctor.type';
 
-export const getRootedComponent = <T>(selectors: T): RootedComponentWithSelectorsCtor<T> =>
-    getExtendedRootedComponent(selectors, RootedComponent);
+export function getRootedComponent<T>(selectors: T): RootedComponentCtorWithoutDefaultRootSelector<T>;
+export function getRootedComponent<T>(selectors: T, rootSelector: T[keyof T]): RootedComponentCtorWithDefaultRootSelector<T>;
+
+// eslint-disable-next-line func-style,@typescript-eslint/no-explicit-any
+export function getRootedComponent<T>(selectors: T, rootSelector?: T[keyof T]): any {
+    if (isDefined(rootSelector)) {
+        return getExtendedRootedComponent(selectors, RootedComponent, rootSelector);
+    }
+
+    return getExtendedRootedComponent(selectors, RootedComponent);
+}

--- a/packages/wdio/src/rooted-component/mocks/default-root-rooted-component.mock.ts
+++ b/packages/wdio/src/rooted-component/mocks/default-root-rooted-component.mock.ts
@@ -1,0 +1,8 @@
+import { getRootedComponent } from '../get-rooted-component/get-rooted-component';
+
+import { RootedComponentSelectorsMock } from './rooted-component-selectors.mock';
+
+export class DefaultRootRootedComponentMock extends getRootedComponent(
+    RootedComponentSelectorsMock,
+    RootedComponentSelectorsMock.Root
+) {}

--- a/packages/wdio/src/rooted-component/mocks/default-root-rooted-extended-component.mock.ts
+++ b/packages/wdio/src/rooted-component/mocks/default-root-rooted-extended-component.mock.ts
@@ -1,0 +1,10 @@
+import { getExtendedRootedComponent } from '../get-extended-rooted-component/get-extended-rooted-component';
+
+import { RootedComponentSelectorsMock } from './rooted-component-selectors.mock';
+import { RootedComponentMock } from './rooted-component.mock';
+
+export class DefaultRootRootedExtendedComponentMock extends getExtendedRootedComponent(
+    RootedComponentSelectorsMock,
+    RootedComponentMock,
+    RootedComponentSelectorsMock.Root
+) {}

--- a/packages/wdio/src/rooted-component/rooted-component.ts
+++ b/packages/wdio/src/rooted-component/rooted-component.ts
@@ -8,7 +8,9 @@ import type { ChainablePromiseArray, ChainablePromiseElement } from 'webdriverio
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class RootedComponent<T = any> extends Component<T> {
-    constructor(config: ComponentConfigInterface, selectors: Enum<T>, protected readonly parentElInput: ComponentInputArg) {
+    protected readonly parentElInput: ComponentInputArg;
+
+    constructor(config: ComponentConfigInterface, selectors: Enum<T>, parentElInput: ComponentInputArg | undefined) {
         if (!isDefined(parentElInput)) {
             throw new Error('Cannot create RootedComponent - Neither root selector nor root element is passed');
         }
@@ -22,6 +24,8 @@ export class RootedComponent<T = any> extends Component<T> {
         }
 
         super(config, selectors);
+
+        this.parentElInput = parentElInput;
 
         // eslint-disable-next-line no-constructor-return
         return new Proxy(this, {

--- a/packages/wdio/src/rooted-component/rooted-componnet.spec.ts
+++ b/packages/wdio/src/rooted-component/rooted-componnet.spec.ts
@@ -106,7 +106,6 @@ describe('RootedComponent', () => {
             Button = 'Selectors.Button',
         }
 
-        // @ts-expect-error Runtime checks
         expect(() => new RootedComponent(mockDefaultConfig, SelectorsWithoutRootEnum, undefined)).toThrow(
             'Cannot create RootedComponent - Neither root selector nor root element is passed'
         );

--- a/packages/wdio/src/type/rooted-component-with-selectors-ctor.type.ts
+++ b/packages/wdio/src/type/rooted-component-with-selectors-ctor.type.ts
@@ -2,6 +2,14 @@ import type { RootedComponent } from '../rooted-component/rooted-component';
 import type { ComponentInputArg } from './component-input-arg.type';
 import type { RootedComponentWithSelectors } from './rooted-component-with-selectors.type';
 
-export type RootedComponentWithSelectorsCtor<T, A extends RootedComponent<T> = RootedComponent<T>> = new (
+export type RootedComponentCtorWithoutDefaultRootSelector<T, Parent extends RootedComponent<T> = RootedComponent<T>> = new (
     selectorOrElement: ComponentInputArg
-) => A & RootedComponentWithSelectors<T>;
+) => Parent & RootedComponentWithSelectors<T>;
+
+export type RootedComponentCtorWithDefaultRootSelector<T, Parent extends RootedComponent<T> = RootedComponent<T>> = new (
+    selectorOrElement?: ComponentInputArg
+) => Parent & RootedComponentWithSelectors<T>;
+
+export type RootedComponentWithSelectorsCtor<T, Parent extends RootedComponent<T> = RootedComponent<T>> =
+    | RootedComponentCtorWithDefaultRootSelector<T, Parent>
+    | RootedComponentCtorWithoutDefaultRootSelector<T, Parent>;


### PR DESCRIPTION
- `getExtendedComponent` and  `getExtendedComponent$` and their short versions `getComponent` and `getComponent$` can now have optional `defaultSelector` last argument which is type-safe and should be one of the `selectors` enum values which will be used as default RootEl selector upon `RootedComponent` creation.
- Created class will have correct constructor type and will force end users to specify forcibly root selector if default one was not provided.

This simplifies custom `RootedComponent` classes definition avoiding creating duplicated constructors with default root selector value