### PR TITLE
fix(fast-style): adjust enum generics so it passes ts

### DIFF
--- a/packages/fast-style/src/font/font.ts
+++ b/packages/fast-style/src/font/font.ts
@@ -1,20 +1,24 @@
-import { combine } from '@rnw-community/object-field-tree';
+import { type CombineReturn3, combine } from '@rnw-community/object-field-tree';
 
 import type { Enum } from '@rnw-community/shared';
-import type { TextStyle } from 'react-native';
+import type { ColorValue, TextStyle } from 'react-native';
 
-export const getFont = <TFamily extends Enum, TSize extends Enum, TColor extends Enum>(
+export const getFont = <
+    TFamily extends Enum<string | undefined>,
+    TSize extends Enum,
+    TColor extends Enum<ColorValue | undefined>,
+>(
     fontFamilyObj: TFamily,
     fontSizeObj: TSize,
     fontColorObj: TColor,
     additionalStyle: TextStyle = {}
-): ReturnType<typeof combine> => {
+): CombineReturn3<TextStyle, TFamily, TSize, TColor> => {
     if (Object.values(fontSizeObj).some(item => typeof item === 'number')) {
         throw new Error('fontSizeObj must have string values');
     }
 
     return combine(
-        (fontFamily, fontSize, color) => ({
+        (fontFamily, fontSize, color): TextStyle => ({
             fontFamily: fontFamilyObj[fontFamily],
             fontSize: parseInt(fontSizeObj[fontSize] as string, 10),
             color: fontColorObj[color],

--- a/packages/object-field-tree/src/index.ts
+++ b/packages/object-field-tree/src/index.ts
@@ -1,28 +1,29 @@
 /* eslint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/ban-types,@typescript-eslint/ban-ts-comment */
 import type { DataFn1, DataFn2, DataFn3, DataFn4, DataFn5 } from './type/data-fn.type';
-import type { Return1, Return2, Return3, Return4, Return5 } from './type/return.type';
+import type { CombineReturn1, CombineReturn2, CombineReturn3, CombineReturn4, CombineReturn5 } from './type/return.type';
 import type { Enum } from '@rnw-community/shared';
 
 // TODO: Investigate if we can add types without specifying all combinations
-export function combine<D, T1 extends Enum>(dataFn: DataFn1<D, T1>, collection1: T1): Return1<T1, D>;
+export function combine<D, T1 extends Enum>(dataFn: DataFn1<D, T1>, collection1: T1): CombineReturn1<T1, D>;
 export function combine<D, T1 extends Enum, T2 extends Enum>(
     dataFn: DataFn2<D, T1, T2>,
     collection1: T1,
     collection2: T2
-): Return2<D, T1, T2>;
+): CombineReturn2<D, T1, T2>;
 export function combine<D, T1 extends Enum, T2 extends Enum, T3 extends Enum>(
     dataFn: DataFn3<D, T1, T2, T3>,
     collection1: T1,
     collection2: T2,
     collection3: T3
-): Return3<D, T1, T2, T3>;
+): CombineReturn3<D, T1, T2, T3>;
 export function combine<D, T1 extends Enum, T2 extends Enum, T3 extends Enum, T4 extends Enum>(
     dataFn: DataFn4<D, T1, T2, T3, T4>,
     collection1: T1,
     collection2: T2,
     collection3: T3,
     collection4: T4
-): Return4<D, T1, T2, T3, T4>;
+): CombineReturn4<D, T1, T2, T3, T4>;
+
 export function combine<D, T1 extends Enum, T2 extends Enum, T3 extends Enum, T4 extends Enum, T5 extends Enum>(
     dataFn: DataFn5<D, T1, T2, T3, T4, T5>,
     collection1: T1,
@@ -30,7 +31,7 @@ export function combine<D, T1 extends Enum, T2 extends Enum, T3 extends Enum, T4
     collection3: T3,
     collection4: T4,
     collection5: T5
-): Return5<D, T1, T2, T3, T4, T5>;
+): CombineReturn5<D, T1, T2, T3, T4, T5>;
 
 // TODO: Introduce non-recursive optimized solution
 // eslint-disable-next-line func-style
@@ -56,3 +57,4 @@ export function combine(dataFn: (...keys: any) => any, ...objects: any[]): any {
 }
 
 export type { Enum };
+export type { CombineReturn1, CombineReturn2, CombineReturn3, CombineReturn4, CombineReturn5 } from './type/return.type';

--- a/packages/object-field-tree/src/type/return.type.ts
+++ b/packages/object-field-tree/src/type/return.type.ts
@@ -1,13 +1,16 @@
 import type { Enum } from '@rnw-community/shared';
 
-export type Return1<T extends Enum, D> = Record<keyof T, D>;
-export type Return2<D, T1 extends Enum, T2 extends Enum> = Record<keyof T1, Return1<T2, D>>;
-export type Return3<D, T1 extends Enum, T2 extends Enum, T3 extends Enum> = Record<keyof T1, Return2<D, T2, T3>>;
-export type Return4<D, T1 extends Enum, T2 extends Enum, T3 extends Enum, T4 extends Enum> = Record<
+export type CombineReturn1<T extends Enum, D> = Record<keyof T, D>;
+export type CombineReturn2<D, T1 extends Enum, T2 extends Enum> = Record<keyof T1, CombineReturn1<T2, D>>;
+export type CombineReturn3<D, T1 extends Enum, T2 extends Enum, T3 extends Enum> = Record<
     keyof T1,
-    Return3<D, T2, T3, T4>
+    CombineReturn2<D, T2, T3>
 >;
-export type Return5<D, T1 extends Enum, T2 extends Enum, T3 extends Enum, T4 extends Enum, T5 extends Enum> = Record<
+export type CombineReturn4<D, T1 extends Enum, T2 extends Enum, T3 extends Enum, T4 extends Enum> = Record<
     keyof T1,
-    Return4<D, T2, T3, T4, T5>
+    CombineReturn3<D, T2, T3, T4>
+>;
+export type CombineReturn5<D, T1 extends Enum, T2 extends Enum, T3 extends Enum, T4 extends Enum, T5 extends Enum> = Record<
+    keyof T1,
+    CombineReturn4<D, T2, T3, T4, T5>
 >;


### PR DESCRIPTION
When ReactNative was updated cache for fast-style wasn't invalidated and had false positive output
When combine func was changed cache for fast-style package was invalidated revealing type error
This PR fixes type error in fast-style package
Also since font func has fixed depth of combining, used specific return type for it 
to optimise computation resources during type check
