### PR TITLE
docs(react-native-payments): corrected a typo in the supportedNetworks example code (MasterCard -> Mastercard)

### DIFF
--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -108,7 +108,7 @@ const methodData = [
         supportedMethods: PaymentMethodNameEnum.ApplePay,
         data: {
             merchantIdentifier: 'merchant.com.your-app.namespace',
-            supportedNetworks: [SupportedNetworkEnum.Visa, SupportedNetworkEnum.MasterCard],
+            supportedNetworks: [SupportedNetworkEnum.Visa, SupportedNetworkEnum.Mastercard],
             countryCode: 'US',
             currencyCode: 'USD',
             requestBilling: true,
@@ -120,7 +120,7 @@ const methodData = [
     {
         supportedMethods: PaymentMethodNameEnum.AndroidPay,
         data: {
-            supportedNetworks: [SupportedNetworkEnum.Visa, SupportedNetworkEnum.MasterCard],
+            supportedNetworks: [SupportedNetworkEnum.Visa, SupportedNetworkEnum.Mastercard],
             environment: EnvironmentEnum.Test,
             countryCode: 'DE',
             currencyCode: 'EUR',


### PR DESCRIPTION
This PR fixes a small casing typo in the readme (MasterCard -> Mastercard) that might negatively affect new users.