### PR TITLE
fix(nestjs-enterprise): preserve error callback message alongside Error object

### DIFF
--- a/packages/nestjs-enterprise/src/decorator/log/log-decorator.spec.ts
+++ b/packages/nestjs-enterprise/src/decorator/log/log-decorator.spec.ts
@@ -139,7 +139,7 @@ describe('LogDecorator', () => {
         const instance = new TestClass();
 
         expect(() => instance.testErrorString(2)).toThrow(errorLogText);
-        expect(Logger.error).toHaveBeenCalledWith(expect.any(Error), `${TestClass.name}::testErrorString`);
+        expect(Logger.error).toHaveBeenCalledWith(errorLogText, { err: expect.any(Error) }, `${TestClass.name}::testErrorString`);
     });
 
     it('should output error log with functions', () => {
@@ -148,7 +148,7 @@ describe('LogDecorator', () => {
         const instance = new TestClass();
 
         expect(() => instance.testErrorFunction(2)).toThrow(errorLogText);
-        expect(Logger.error).toHaveBeenCalledWith(expect.any(Error), `${TestClass.name}::testErrorFunction`);
+        expect(Logger.error).toHaveBeenCalledWith(`Error: ${errorLogText}-${errorLogText}-2`, { err: expect.any(Error) }, `${TestClass.name}::testErrorFunction`);
     });
 
     it('should NOT output error log if arg is not passed', () => {
@@ -204,9 +204,9 @@ describe('LogDecorator', () => {
 
             const instance = new TestClass();
 
-             
+
             await expect(instance.testPromiseError).rejects.toThrow(errorLogText);
-            expect(Logger.error).toHaveBeenCalledWith(expect.any(Error), `${TestClass.name}::testPromiseError`);
+            expect(Logger.error).toHaveBeenCalledWith(errorLogText, { err: expect.any(Error) }, `${TestClass.name}::testPromiseError`);
         });
 
         it('should output error log function with argument', async () => {
@@ -215,7 +215,7 @@ describe('LogDecorator', () => {
             const instance = new TestClass();
 
             await expect(() => instance.testPromiseErrorFunction(1)).rejects.toThrow(errorLogText);
-            expect(Logger.error).toHaveBeenCalledWith(expect.any(Error), `${TestClass.name}::testPromiseErrorFunction`);
+            expect(Logger.error).toHaveBeenCalledWith(`Error: ${errorLogText}-1`, { err: expect.any(Error) }, `${TestClass.name}::testPromiseErrorFunction`);
         });
 
         it('should support generic methods', async () => {

--- a/packages/nestjs-enterprise/src/decorator/log/log.decorator.ts
+++ b/packages/nestjs-enterprise/src/decorator/log/log.decorator.ts
@@ -49,12 +49,12 @@ export const Log =
                         return;
                     }
 
+                    const message = isNotEmptyString(errorLog) ? errorLog : errorLog(error, ...args);
+
                     if (error instanceof Error) {
-                        Logger.error(error, logContext);
-                    } else if (isNotEmptyString(errorLog)) {
-                        Logger.error(errorLog, logContext);
+                        Logger.error(message, { err: error }, logContext);
                     } else {
-                        Logger.error(errorLog(error, ...args), logContext);
+                        Logger.error(message, logContext);
                     }
                 };
 


### PR DESCRIPTION
## Summary

Fixes an issue where the `@Log` decorator's error callback message was discarded when the error was an `Error` instance.

## Problem

In v1.14.0, when `error instanceof Error`, the decorator called `Logger.error(error, logContext)` directly — bypassing the user's `errorLog` callback entirely. This meant contextual messages like `Failed to process order "42"` were lost, replaced by the generic `error.message`.

## Solution

The decorator now always evaluates the `errorLog` callback (or uses the static string), then passes both the descriptive message and the Error object:

```typescript
const message = isNotEmptyString(errorLog) ? errorLog : errorLog(error, ...args);

if (error instanceof Error) {
    Logger.error(message, { err: error }, logContext);
} else {
    Logger.error(message, logContext);
}
```

This allows NestJS logger implementations (e.g. pino) to:
- Use the descriptive callback message as the log message
- Serialize the Error object with full stack trace and cause chain via the `err` field