### PR TITLE
feat(react-native-payments): implement event listeners and update methods for Apple Pay

### DIFF
--- a/packages/react-native-payments/android/src/main/java/com/payments/PaymentsModule.java
+++ b/packages/react-native-payments/android/src/main/java/com/payments/PaymentsModule.java
@@ -84,6 +84,40 @@ public class PaymentsModule extends PaymentsSpec {
         return NAME;
     }
 
+    @Override
+    public void addListener(String eventName) {
+        // Required for React Native built-in Event Emitter when the TurboModule spec declares addListener.
+    }
+
+    @Override
+    public void removeListeners(double count) {
+        // Required for React Native built-in Event Emitter when the TurboModule spec declares removeListeners.
+    }
+
+    @Override
+    public void updatePaymentItems(ReadableMap details, Promise promise) {
+        // Apple Pay only; Google Pay does not use payment-method change updates via this API.
+        promise.resolve(null);
+    }
+
+    @Override
+    public void updateShippingContact(ReadableMap details, ReadableMap shippingMethods, ReadableMap errors, Promise promise) {
+        // Apple Pay only.
+        promise.resolve(null);
+    }
+
+    @Override
+    public void updateShippingMethod(ReadableMap details, Promise promise) {
+        // Apple Pay only.
+        promise.resolve(null);
+    }
+
+    @Override
+    public void updateCouponCode(ReadableMap details, ReadableMap shippingMethods, ReadableMap errors, Promise promise) {
+        // Apple Pay only.
+        promise.resolve(null);
+    }
+
     // Implementation See https://reactnative.dev/docs/native-modules-android
 
     // https://developers.google.com/android/reference/com/google/android/gms/wallet/PaymentsClient#isReadyToPay(com.google.android.gms.wallet.IsReadyToPayRequest)

--- a/packages/react-native-payments/ios/Payments.h
+++ b/packages/react-native-payments/ios/Payments.h
@@ -2,16 +2,17 @@
 #import <PassKit/PassKit.h>
 
 #import <React/RCTUtils.h>
+#import <React/RCTEventEmitter.h>
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import "RNPaymentsSpec.h"
 
-@interface Payments : NSObject<NativePaymentsSpec, PKPaymentAuthorizationViewControllerDelegate>
+@interface Payments : RCTEventEmitter<NativePaymentsSpec, PKPaymentAuthorizationViewControllerDelegate>
 
 #else
 
 #import <React/RCTBridgeModule.h>
-@interface Payments : NSObject<RCTBridgeModule, PKPaymentAuthorizationViewControllerDelegate>
+@interface Payments : RCTEventEmitter<RCTBridgeModule, PKPaymentAuthorizationViewControllerDelegate>
 
 #endif
 
@@ -19,5 +20,9 @@
 @property (nonatomic, copy) void (^__strong _Nonnull completion)(PKPaymentAuthorizationResult * _Nonnull __strong);
 @property (nonatomic, copy) RCTPromiseResolveBlock _Nullable paymentResolve;
 @property (nonatomic, copy) RCTPromiseRejectBlock _Nullable paymentReject;
+@property (nonatomic, copy, nullable) void (^paymentMethodCompletion)(PKPaymentRequestPaymentMethodUpdate * _Nonnull);
+@property (nonatomic, copy, nullable) void (^shippingContactCompletion)(PKPaymentRequestShippingContactUpdate * _Nonnull);
+@property (nonatomic, copy, nullable) void (^shippingMethodCompletion)(PKPaymentRequestShippingMethodUpdate * _Nonnull);
+@property (nonatomic, copy, nullable) void (^couponCodeCompletion)(PKPaymentRequestCouponCodeUpdate * _Nonnull);
 
 @end

--- a/packages/react-native-payments/ios/Payments.mm
+++ b/packages/react-native-payments/ios/Payments.mm
@@ -2,7 +2,19 @@
 
 #import <React/RCTLog.h>
 #import <Foundation/Foundation.h>
+#import <objc/message.h>
 #import <objc/runtime.h>
+
+static id RNPayments_PKPaymentNetworkFromClassMethod(Class cls, NSString *methodName)
+{
+    if (cls == nil || methodName.length == 0) {
+        return nil;
+    }
+    SEL sel = NSSelectorFromString(methodName);
+    typedef id (*MsgSend)(Class, SEL);
+    MsgSend msgSend = (MsgSend)objc_msgSend;
+    return msgSend(cls, sel);
+}
 
 // TODO: Add logs
 @implementation Payments
@@ -17,6 +29,20 @@ static const PKPaymentNetwork PKPaymentNetworkUnknown = 0;
 {
     return dispatch_get_main_queue();
 }
+
+// RCTEventEmitter required methods
+- (NSArray<NSString *> *)supportedEvents
+{
+    return @[
+        @"onCouponCodeChange",
+        @"onPaymentMethodChange",
+        @"onShippingContactChange",
+        @"onShippingMethodChange"
+    ];
+}
+
+- (void)startObserving { }
+- (void)stopObserving { }
 
 RCT_EXPORT_METHOD(show:(NSString *)methodDataString
                         details:(NSDictionary *)details
@@ -221,14 +247,200 @@ RCT_EXPORT_METHOD(canMakePayments: (NSString *)methodDataString
     resolve(@([PKPaymentAuthorizationViewController canMakePayments]));
 }
 
+RCT_EXPORT_METHOD(updatePaymentItems:(NSDictionary *)details
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+    if (!self.paymentMethodCompletion) {
+        reject(@"no_completion", @"No payment method completion handler available", nil);
+        return;
+    }
+
+    NSArray<PKPaymentSummaryItem *> *items = [self getPaymentSummaryItemsFromDetails:details];
+
+    PKPaymentRequestPaymentMethodUpdate *update =
+        [[PKPaymentRequestPaymentMethodUpdate alloc] initWithPaymentSummaryItems:items];
+
+    self.paymentMethodCompletion(update);
+    self.paymentMethodCompletion = nil;
+
+    resolve(nil);
+}
+
+RCT_EXPORT_METHOD(updateShippingContact:(NSDictionary *)details
+                  shippingMethods:(NSArray<NSDictionary *> *)shippingMethods
+                  errors:(NSArray<NSDictionary *> *)errors
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+    if (!self.shippingContactCompletion) {
+        reject(@"no_completion", @"No shipping contact completion handler available", nil);
+        return;
+    }
+
+    NSArray<PKPaymentSummaryItem *> *items = [self getPaymentSummaryItemsFromDetails:details];
+    NSArray<PKShippingMethod *> *pkShippingMethods = [self getShippingMethodsFromArray:shippingMethods];
+    NSArray<NSError *> *pkErrors = [self getErrorsFromArray:errors];
+
+    PKPaymentRequestShippingContactUpdate *update =
+        [[PKPaymentRequestShippingContactUpdate alloc] initWithErrors:pkErrors
+                                                 paymentSummaryItems:items
+                                                     shippingMethods:pkShippingMethods];
+
+    self.shippingContactCompletion(update);
+    self.shippingContactCompletion = nil;
+
+    resolve(nil);
+}
+
+RCT_EXPORT_METHOD(updateShippingMethod:(NSDictionary *)details
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+    if (!self.shippingMethodCompletion) {
+        reject(@"no_completion", @"No shipping method completion handler available", nil);
+        return;
+    }
+
+    NSArray<PKPaymentSummaryItem *> *items = [self getPaymentSummaryItemsFromDetails:details];
+
+    PKPaymentRequestShippingMethodUpdate *update =
+        [[PKPaymentRequestShippingMethodUpdate alloc] initWithPaymentSummaryItems:items];
+
+    self.shippingMethodCompletion(update);
+    self.shippingMethodCompletion = nil;
+
+    resolve(nil);
+}
+
+RCT_EXPORT_METHOD(updateCouponCode:(NSDictionary *)details
+                  shippingMethods:(NSArray<NSDictionary *> *)shippingMethods
+                  errors:(NSArray<NSDictionary *> *)errors
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+    if (!self.couponCodeCompletion) {
+        reject(@"no_completion", @"No coupon code completion handler available", nil);
+        return;
+    }
+
+    NSArray<PKPaymentSummaryItem *> *items = [self getPaymentSummaryItemsFromDetails:details];
+    NSArray<PKShippingMethod *> *pkShippingMethods = [self getShippingMethodsFromArray:shippingMethods];
+    NSArray<NSError *> *pkErrors = [self getErrorsFromArray:errors];
+
+    PKPaymentRequestCouponCodeUpdate *update =
+        [[PKPaymentRequestCouponCodeUpdate alloc] initWithPaymentSummaryItems:items
+                                                              shippingMethods:pkShippingMethods
+                                                                       errors:pkErrors];
+
+    self.couponCodeCompletion(update);
+    self.couponCodeCompletion = nil;
+
+    resolve(nil);
+}
+
 // DELEGATES https://developer.apple.com/documentation/passkit/pkpaymentauthorizationviewcontrollerdelegate?language=objc
 
 // https://developer.apple.com/documentation/passkit/pkpaymentauthorizationviewcontrollerdelegate/1616180-paymentauthorizationviewcontroll?language=objc
 - (void) paymentAuthorizationViewControllerDidFinish:(PKPaymentAuthorizationViewController *)controller
 {
+    self.paymentMethodCompletion = nil;
+    self.shippingContactCompletion = nil;
+    self.shippingMethodCompletion = nil;
+    self.couponCodeCompletion = nil;
     [controller dismissViewControllerAnimated:YES completion:^{
         [self rejectPromise:@"payment_error" message:@"Payment process canceled by user." error:nil];
     }];
+}
+
+// https://developer.apple.com/documentation/passkit/pkpaymentauthorizationviewcontrollerdelegate/2865749-paymentauthorizationviewcontroll?language=objc
+- (void) paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller
+                   didSelectShippingContact:(PKContact *)contact
+                                    handler:(void (^)(PKPaymentRequestShippingContactUpdate * _Nonnull))completion
+{
+    self.shippingContactCompletion = completion;
+
+    NSMutableDictionary *contactDict = [NSMutableDictionary dictionary];
+
+    contactDict[@"emailAddress"] = contact.emailAddress ?: @"";
+
+    CNPhoneNumber *phoneNumber = contact.phoneNumber;
+    NSMutableDictionary *phoneNumberDict = [NSMutableDictionary dictionary];
+    phoneNumberDict[@"stringValue"] = phoneNumber.stringValue ?: @"";
+    contactDict[@"phoneNumber"] = phoneNumberDict;
+
+    CNPostalAddress *postalAddress = contact.postalAddress;
+    NSMutableDictionary *postalAddressDict = [NSMutableDictionary dictionary];
+    if (postalAddress) {
+        postalAddressDict[@"street"] = postalAddress.street ?: @"";
+        postalAddressDict[@"city"] = postalAddress.city ?: @"";
+        postalAddressDict[@"state"] = postalAddress.state ?: @"";
+        postalAddressDict[@"postalCode"] = postalAddress.postalCode ?: @"";
+        postalAddressDict[@"country"] = postalAddress.country ?: @"";
+        postalAddressDict[@"ISOCountryCode"] = postalAddress.ISOCountryCode ?: @"";
+        postalAddressDict[@"subAdministrativeArea"] = postalAddress.subAdministrativeArea ?: @"";
+        postalAddressDict[@"subLocality"] = postalAddress.subLocality ?: @"";
+    }
+    contactDict[@"postalAddress"] = postalAddressDict;
+
+    NSPersonNameComponents *nameComponents = contact.name;
+    NSMutableDictionary *nameDict = [NSMutableDictionary dictionary];
+    if (nameComponents) {
+        nameDict[@"givenName"] = nameComponents.givenName ?: @"";
+        nameDict[@"familyName"] = nameComponents.familyName ?: @"";
+        nameDict[@"middleName"] = nameComponents.middleName ?: @"";
+        nameDict[@"namePrefix"] = nameComponents.namePrefix ?: @"";
+        nameDict[@"nameSuffix"] = nameComponents.nameSuffix ?: @"";
+        nameDict[@"nickname"] = nameComponents.nickname ?: @"";
+    }
+    contactDict[@"name"] = nameDict;
+
+    [self sendEventWithName:@"onShippingContactChange" body:contactDict];
+}
+
+// https://developer.apple.com/documentation/passkit/pkpaymentauthorizationviewcontrollerdelegate/1616199-paymentauthorizationviewcontroll?language=objc
+- (void) paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller
+                    didSelectShippingMethod:(PKShippingMethod *)shippingMethod
+                                    handler:(void (^)(PKPaymentRequestShippingMethodUpdate * _Nonnull))completion
+{
+    self.shippingMethodCompletion = completion;
+
+    NSDictionary *methodInfo = @{
+        @"identifier": shippingMethod.identifier ?: @"",
+        @"detail": shippingMethod.detail ?: @""
+    };
+
+    [self sendEventWithName:@"onShippingMethodChange" body:methodInfo];
+}
+
+// https://developer.apple.com/documentation/passkit/pkpaymentauthorizationviewcontrollerdelegate/3567281-paymentauthorizationviewcontroll?language=objc
+- (void) paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller
+                      didSelectCouponCode:(NSString *)couponCode
+                                    handler:(void (^)(PKPaymentRequestCouponCodeUpdate * _Nonnull))completion
+{
+    self.couponCodeCompletion = completion;
+
+    NSDictionary *couponInfo = @{
+        @"couponCode": couponCode ?: @""
+    };
+
+    [self sendEventWithName:@"onCouponCodeChange" body:couponInfo];
+}
+
+// https://developer.apple.com/documentation/passkit/pkpaymentauthorizationviewcontrollerdelegate/1616203-paymentauthorizationviewcontroll?language=objc
+- (void) paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller
+                    didSelectPaymentMethod:(PKPaymentMethod *)paymentMethod
+                                   handler:(void (^)(PKPaymentRequestPaymentMethodUpdate * _Nonnull))completion
+{
+    self.paymentMethodCompletion = completion;
+
+    NSDictionary *methodInfo = @{
+        @"type": [self stringFromPaymentMethodType:paymentMethod.type],
+        @"network": paymentMethod.network ?: @"",
+        @"displayName": paymentMethod.displayName ?: @""
+    };
+
+    [self sendEventWithName:@"onPaymentMethodChange" body:methodInfo];
 }
 
 // https://developer.apple.com/documentation/passkit/pkpaymentauthorizationviewcontrollerdelegate/2865759-paymentauthorizationviewcontroll?language=objc
@@ -268,7 +480,13 @@ RCT_EXPORT_METHOD(canMakePayments: (NSString *)methodDataString
             postalAddressDict[@"state"] = postalAddress.state;
             postalAddressDict[@"postalCode"] = postalAddress.postalCode;
             postalAddressDict[@"country"] = postalAddress.country;
-            postalAddressDict[@"ISOCountryCode"] = postalAddress.ISOCountryCode;
+        }
+
+        NSPersonNameComponents *billingName = billingContact.name;
+        if (billingName) {
+            postalAddressDict[@"givenName"] = billingName.givenName;
+            postalAddressDict[@"familyName"] = billingName.familyName;
+            postalAddressDict[@"middleName"] = billingName.middleName;
         }
 
         billingContactDict[@"postalAddress"] = postalAddressDict;
@@ -357,6 +575,52 @@ RCT_EXPORT_METHOD(canMakePayments: (NSString *)methodDataString
     return paymentSummaryItems;
 }
 
+- (NSArray<PKShippingMethod *> *_Nonnull)getShippingMethodsFromArray:(NSArray<NSDictionary *> *_Nullable)methods
+{
+    if (!methods || methods.count == 0) {
+        return @[];
+    }
+
+    NSMutableArray<PKShippingMethod *> *shippingMethods = [NSMutableArray array];
+    for (NSDictionary *methodDict in methods) {
+        NSString *identifier = methodDict[@"identifier"];
+        NSString *detail = methodDict[@"detail"];
+
+        PKShippingMethod *method = [[PKShippingMethod alloc] init];
+        method.identifier = identifier ?: @"";
+        method.detail = detail ?: @"";
+
+        [shippingMethods addObject:method];
+    }
+
+    return shippingMethods;
+}
+
+- (NSArray<NSError *> *_Nonnull)getErrorsFromArray:(NSArray<NSDictionary *> *_Nullable)errors
+{
+    if (!errors || errors.count == 0) {
+        return @[];
+    }
+
+    NSMutableArray<NSError *> *nativeErrors = [NSMutableArray array];
+    for (NSDictionary *errorDict in errors) {
+        NSString *code = errorDict[@"code"] ?: @"unknown";
+        NSString *message = errorDict[@"message"] ?: @"";
+
+        NSError *error =
+            [NSError errorWithDomain:@"RNPayments"
+                                code:0
+                            userInfo:@{
+                                NSLocalizedDescriptionKey: message,
+                                @"code": code
+                            }];
+
+        [nativeErrors addObject:error];
+    }
+
+    return nativeErrors;
+}
+
 - (PKPaymentNetwork)paymentNetworkFromString:(NSString *)paymentNetworkString {
     static NSDictionary<NSString *, PKPaymentNetwork> *paymentNetworks;
     static dispatch_once_t onceToken;
@@ -387,7 +651,7 @@ RCT_EXPORT_METHOD(canMakePayments: (NSString *)methodDataString
             // Dynamically get PKPaymentNetworkBancontact to avoid linking issues
             Class pkPaymentNetworkClass = NSClassFromString(@"PKPaymentNetwork");
             if (pkPaymentNetworkClass) {
-                id bancontactNetwork = [pkPaymentNetworkClass performSelector:@selector(Bancontact)];
+                id bancontactNetwork = RNPayments_PKPaymentNetworkFromClassMethod(pkPaymentNetworkClass, @"Bancontact");
                 if (bancontactNetwork) {
                     mutablePaymentNetworks[@"PKPaymentNetworkBancontact"] = bancontactNetwork;
                 }
@@ -400,7 +664,7 @@ RCT_EXPORT_METHOD(canMakePayments: (NSString *)methodDataString
             // Dynamically get PKPaymentNetworkDankort to avoid linking issues on iOS 15.1
             Class pkPaymentNetworkClass = NSClassFromString(@"PKPaymentNetwork");
             if (pkPaymentNetworkClass) {
-                id dankortNetwork = [pkPaymentNetworkClass performSelector:@selector(Dankort)];
+                id dankortNetwork = RNPayments_PKPaymentNetworkFromClassMethod(pkPaymentNetworkClass, @"Dankort");
                 if (dankortNetwork) {
                     mutablePaymentNetworks[@"PKPaymentNetworkDankort"] = dankortNetwork;
                 }
@@ -414,7 +678,7 @@ RCT_EXPORT_METHOD(canMakePayments: (NSString *)methodDataString
             // Dynamically get PKPaymentNetworkMir to avoid linking issues
             Class pkPaymentNetworkClass = NSClassFromString(@"PKPaymentNetwork");
             if (pkPaymentNetworkClass) {
-                id mirNetwork = [pkPaymentNetworkClass performSelector:@selector(Mir)];
+                id mirNetwork = RNPayments_PKPaymentNetworkFromClassMethod(pkPaymentNetworkClass, @"Mir");
                 if (mirNetwork) {
                     mutablePaymentNetworks[@"PKPaymentNetworkMIR"] = mirNetwork;
                 }

--- a/packages/react-native-payments/src/@standard/android/response/android-full-address.ts
+++ b/packages/react-native-payments/src/@standard/android/response/android-full-address.ts
@@ -8,4 +8,7 @@ export interface AndroidFullAddress extends AndroidMinAddress {
     administrativeArea?: string;
     locality?: string;
     sortingCode?: string;
+    givenName?: string;
+    familyName?: string;
+    middleName?: string;
 }

--- a/packages/react-native-payments/src/@standard/ios/response/ios-cn-postal-address.ts
+++ b/packages/react-native-payments/src/@standard/ios/response/ios-cn-postal-address.ts
@@ -1,4 +1,5 @@
 // https://developer.apple.com/documentation/contacts/cnpostaladdress?language=objc
+// Optional name fields: merged from PKContact.name in native JSON (not part of CNPostalAddress on device).
 export interface IosCNPostalAddress {
     ISOCountryCode: string;
     city: string;
@@ -8,4 +9,7 @@ export interface IosCNPostalAddress {
     street: string;
     subAdministrativeArea: string;
     subLocality: string;
+    givenName?: string;
+    familyName?: string;
+    middleName?: string;
 }

--- a/packages/react-native-payments/src/NativePayments.ts
+++ b/packages/react-native-payments/src/NativePayments.ts
@@ -11,8 +11,13 @@ export interface Spec extends TurboModule {
     abort: () => Promise<void>;
     canMakePayments: (methodData: string) => Promise<boolean>;
     complete: (paymentComplete: string) => Promise<void>;
-    // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
-    show: (methodData: string, details: Object) => Promise<string>;
+    show: (methodData: string, details: object) => Promise<string>;
+    updatePaymentItems: (details: object) => Promise<void>;
+    updateShippingContact: (details: object, shippingMethods: object, errors: object) => Promise<void>;
+    updateShippingMethod: (details: object) => Promise<void>;
+    updateCouponCode: (details: object, shippingMethods: object, errors: object) => Promise<void>;
+    addListener: (eventName: string) => void;
+    removeListeners: (count: number) => void;
 }
 
 // ts-prune-ignore-next

--- a/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
@@ -27,13 +27,34 @@ jest.mock('../native-payments/native-payments', () => ({
         canMakePayments: jest.fn(),
         show: jest.fn(),
         abort: jest.fn(),
+        updatePaymentItems: jest.fn(async () => undefined),
+        updateShippingContact: jest.fn(async () => undefined),
+        updateShippingMethod: jest.fn(async () => undefined),
+        updateCouponCode: jest.fn(async () => undefined),
     },
 }));
+
+type EventName = 'onShippingContactChange' | 'onShippingMethodChange' | 'onCouponCodeChange' | 'onPaymentMethodChange';
+
+const listenerMap: Partial<Record<EventName, (event: unknown) => void>> = {};
+const removeMocks: Array<jest.Mock> = [];
 
 jest.mock('react-native', () => ({
     Platform: {
         OS: 'android',
     },
+    NativeModules: {
+        Payments: {},
+    },
+    NativeEventEmitter: jest.fn().mockImplementation(() => ({
+        addListener: jest.fn((eventName: EventName, callback: (event: unknown) => void) => {
+            listenerMap[eventName] = callback;
+            const remove = jest.fn();
+            removeMocks.push(remove);
+
+            return { remove };
+        }),
+    })),
 }));
 
  
@@ -48,6 +69,11 @@ describe('PaymentRequest', () => {
      
     beforeEach(() => {
         jest.clearAllMocks();
+        removeMocks.length = 0;
+        for (const key of Object.keys(listenerMap)) {
+            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+            delete listenerMap[key as EventName];
+        }
     });
 
      
@@ -481,6 +507,25 @@ describe('PaymentRequest', () => {
                 new DOMException(PaymentsErrorEnum.NotSupportedError)
             );
         });
+
+        it('should not register native listeners for Apple Pay change handlers on Android', () => {
+            expect.assertions(1);
+
+            const request = new PaymentRequest([androidMethodData], paymentDetails);
+
+            request.onPaymentMethodChange(() => paymentDetails as unknown as PaymentDetailsInit);
+            request.onShippingContactChange(() => ({
+                details: paymentDetails as unknown as PaymentDetailsInit,
+            }));
+            request.onShippingMethodChange(() => ({
+                details: paymentDetails as unknown as PaymentDetailsInit,
+            }));
+            request.onCouponCodeChange(() => ({
+                details: paymentDetails as unknown as PaymentDetailsInit,
+            }));
+
+            expect(Object.keys(listenerMap)).toHaveLength(0);
+        });
     });
 
      
@@ -503,6 +548,216 @@ describe('PaymentRequest', () => {
          
         beforeEach(() => {
             Platform.OS = 'ios';
+        });
+
+        it('should register and handle onPaymentMethodChange', () => {
+            expect.assertions(3);
+
+            const request = new PaymentRequest([iosMethodData], paymentDetails);
+
+            const updatedDetails = {
+                ...paymentDetails,
+                displayItems: [{ label: 'Updated', amount: { currency: 'USD', value: '11.00' } }],
+            } as unknown as PaymentDetailsInit;
+
+            request.onPaymentMethodChange(() => updatedDetails);
+
+            expect(listenerMap.onPaymentMethodChange).toBeDefined();
+            listenerMap.onPaymentMethodChange?.({ type: 'debit', network: 'visa', displayName: 'Visa' });
+
+            expect(NativePayments.updatePaymentItems).toHaveBeenCalledWith(updatedDetails);
+            expect(request.details).toBe(updatedDetails);
+        });
+
+        it('should register and handle onShippingContactChange', () => {
+            expect.assertions(3);
+
+            const request = new PaymentRequest([iosMethodData], paymentDetails);
+
+            const updatedDetails = {
+                ...paymentDetails,
+                displayItems: [{ label: 'Item', amount: { currency: 'USD', value: '1.00' } }],
+            } as unknown as PaymentDetailsInit;
+
+            request.onShippingContactChange(() => ({
+                details: updatedDetails,
+                shippingMethods: [{ identifier: 'standard', detail: 'Standard' }],
+                errors: [{ code: 'invalid', message: 'Invalid address' }],
+            }));
+
+            expect(listenerMap.onShippingContactChange).toBeDefined();
+            listenerMap.onShippingContactChange?.({
+                emailAddress: 'test@example.com',
+                name: {
+                    givenName: 'John',
+                    familyName: 'Doe',
+                    middleName: '',
+                    namePrefix: '',
+                    nameSuffix: '',
+                    nickname: '',
+                },
+                phoneNumber: { stringValue: '+1' },
+                postalAddress: {
+                    street: '1',
+                    city: 'C',
+                    state: 'S',
+                    postalCode: 'P',
+                    country: 'US',
+                    ISOCountryCode: 'US',
+                    subAdministrativeArea: '',
+                    subLocality: '',
+                },
+            });
+
+            expect(NativePayments.updateShippingContact).toHaveBeenCalledWith(
+                updatedDetails,
+                [{ identifier: 'standard', detail: 'Standard' }],
+                [{ code: 'invalid', message: 'Invalid address' }]
+            );
+            expect(request.details).toBe(updatedDetails);
+        });
+
+        it('should register and handle onShippingMethodChange', () => {
+            expect.assertions(3);
+
+            const request = new PaymentRequest([iosMethodData], paymentDetails);
+
+            const updatedDetails = {
+                ...paymentDetails,
+                displayItems: [{ label: 'Ship', amount: { currency: 'USD', value: '2.00' } }],
+            } as unknown as PaymentDetailsInit;
+
+            request.onShippingMethodChange(() => ({
+                details: updatedDetails,
+            }));
+
+            expect(listenerMap.onShippingMethodChange).toBeDefined();
+            listenerMap.onShippingMethodChange?.({ identifier: 'express', detail: 'Express' });
+
+            expect(NativePayments.updateShippingMethod).toHaveBeenCalledWith(updatedDetails);
+            expect(request.details).toBe(updatedDetails);
+        });
+
+        it('should register and handle onCouponCodeChange', () => {
+            expect.assertions(3);
+
+            const request = new PaymentRequest([iosMethodData], paymentDetails);
+
+            const updatedDetails = {
+                ...paymentDetails,
+                displayItems: [{ label: 'Discount', amount: { currency: 'USD', value: '-1.00' } }],
+            } as unknown as PaymentDetailsInit;
+
+            request.onCouponCodeChange(() => ({
+                details: updatedDetails,
+                shippingMethods: [{ identifier: 'standard', detail: 'Standard' }],
+                errors: [],
+            }));
+
+            expect(listenerMap.onCouponCodeChange).toBeDefined();
+            listenerMap.onCouponCodeChange?.({ couponCode: 'SAVE10' });
+
+            expect(NativePayments.updateCouponCode).toHaveBeenCalledWith(
+                updatedDetails,
+                [{ identifier: 'standard', detail: 'Standard' }],
+                []
+            );
+            expect(request.details).toBe(updatedDetails);
+        });
+
+        it('should cleanup listeners when show resolves', async () => {
+            expect.assertions(2);
+
+            const request = new PaymentRequest([iosMethodData], paymentDetails);
+            request.onShippingMethodChange(() => ({ details: paymentDetails as unknown as PaymentDetailsInit }));
+
+            jest.mocked(NativePayments.show).mockResolvedValue(
+                JSON.stringify({
+                    token: {
+                        paymentData: '{}',
+                        paymentMethod: {
+                            displayName: 'Visa',
+                            network: 'Visa',
+                            type: IosPKPaymentMethodType.PKPaymentMethodTypeDebit,
+                        },
+                        transactionIdentifier: 'txn',
+                    },
+                } as unknown as IosPKPayment)
+            );
+
+            await request.show();
+
+            expect(removeMocks.length).toBe(1);
+            expect(removeMocks[0]).toHaveBeenCalled();
+        });
+
+        it('should ignore stale change listener invocations after show resolves', async () => {
+            expect.assertions(4);
+
+            const request = new PaymentRequest([iosMethodData], paymentDetails);
+
+            request.onPaymentMethodChange(() => paymentDetails as unknown as PaymentDetailsInit);
+            request.onShippingContactChange(() => ({
+                details: paymentDetails as unknown as PaymentDetailsInit,
+            }));
+            request.onShippingMethodChange(() => ({
+                details: paymentDetails as unknown as PaymentDetailsInit,
+            }));
+            request.onCouponCodeChange(() => ({
+                details: paymentDetails as unknown as PaymentDetailsInit,
+            }));
+
+            jest.mocked(NativePayments.show).mockResolvedValue(
+                JSON.stringify({
+                    token: {
+                        paymentData: '{}',
+                        paymentMethod: {
+                            displayName: 'Visa',
+                            network: 'Visa',
+                            type: IosPKPaymentMethodType.PKPaymentMethodTypeDebit,
+                        },
+                        transactionIdentifier: 'txn',
+                    },
+                } as unknown as IosPKPayment)
+            );
+
+            await request.show();
+
+            jest.mocked(NativePayments.updatePaymentItems).mockClear();
+            jest.mocked(NativePayments.updateShippingContact).mockClear();
+            jest.mocked(NativePayments.updateShippingMethod).mockClear();
+            jest.mocked(NativePayments.updateCouponCode).mockClear();
+
+            listenerMap.onPaymentMethodChange?.({ type: 'debit', network: 'visa', displayName: 'Visa' });
+            listenerMap.onShippingContactChange?.({
+                emailAddress: '',
+                name: {
+                    givenName: '',
+                    familyName: '',
+                    middleName: '',
+                    namePrefix: '',
+                    nameSuffix: '',
+                    nickname: '',
+                },
+                phoneNumber: { stringValue: '' },
+                postalAddress: {
+                    street: '',
+                    city: '',
+                    state: '',
+                    postalCode: '',
+                    country: '',
+                    ISOCountryCode: '',
+                    subAdministrativeArea: '',
+                    subLocality: '',
+                },
+            });
+            listenerMap.onShippingMethodChange?.({ identifier: 'x', detail: 'y' });
+            listenerMap.onCouponCodeChange?.({ couponCode: '' });
+
+            expect(NativePayments.updatePaymentItems).not.toHaveBeenCalled();
+            expect(NativePayments.updateShippingContact).not.toHaveBeenCalled();
+            expect(NativePayments.updateShippingMethod).not.toHaveBeenCalled();
+            expect(NativePayments.updateCouponCode).not.toHaveBeenCalled();
         });
 
         it('should initialize with the correct id', () => {

--- a/packages/react-native-payments/src/class/payment-request/payment-request.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { Platform } from 'react-native';
+import { NativeEventEmitter, NativeModules, Platform } from 'react-native';
 import uuid from 'react-native-uuid';
 
 import { emptyFn, isDefined, isNotEmptyArray, isNotEmptyString } from '@rnw-community/shared';
@@ -29,8 +29,22 @@ import type { AndroidPaymentMethodDataDataInterface } from '../../@standard/andr
 import type { AndroidPaymentDataRequest } from '../../@standard/android/request/android-payment-data-request';
 import type { IosPaymentMethodDataDataInterface } from '../../@standard/ios/mapping/ios-payment-method-data-data.interface';
 import type { IosPaymentDataRequest } from '../../@standard/ios/request/ios-payment-data-request';
+import type { IosPKContact } from '../../@standard/ios/response/ios-pk-contact';
+import type { IosPKShippingMethod } from '../../@standard/ios/response/ios-pk-shipping-method';
 import type { PaymentDetailsInit } from '../../@standard/w3c/payment-details-init';
 import type { PaymentMethodData } from '../../@standard/w3c/payment-method-data';
+import type { PaymentRequestUpdateResult } from '../../type/payment-request-update-result/payment-request-update-result.type';
+import type { EmitterSubscription, NativeModule } from 'react-native';
+
+export interface PaymentMethodChangeEvent {
+    type: string;
+    network: string;
+    displayName: string;
+}
+
+export interface CouponCodeChangeEvent {
+    couponCode: string;
+}
 
 /*
  * HINT: Troubleshooting: https://developers.google.com/pay/api/android/support/troubleshooting
@@ -47,6 +61,18 @@ export class PaymentRequest {
     private readonly platformMethodData: AndroidPaymentMethodDataDataInterface | IosPaymentMethodDataDataInterface;
 
     private acceptPromiseRejecter: (reason: unknown) => void = emptyFn;
+
+    private paymentMethodChangeSubscription: EmitterSubscription | null = null;
+    private paymentMethodChangeCallback: ((event: PaymentMethodChangeEvent) => PaymentDetailsInit) | null = null;
+
+    private shippingContactChangeSubscription: EmitterSubscription | null = null;
+    private shippingContactChangeCallback: ((event: IosPKContact) => PaymentRequestUpdateResult) | null = null;
+
+    private shippingMethodChangeSubscription: EmitterSubscription | null = null;
+    private shippingMethodChangeCallback: ((event: IosPKShippingMethod) => PaymentRequestUpdateResult) | null = null;
+
+    private couponCodeChangeSubscription: EmitterSubscription | null = null;
+    private couponCodeChangeCallback: ((event: CouponCodeChangeEvent) => PaymentRequestUpdateResult) | null = null;
 
      
     constructor(
@@ -109,12 +135,16 @@ export class PaymentRequest {
 
                 NativePayments.show(this.serializedMethodData, details)
                     .then(jsonDetails => {
+                        this.cleanupListeners();
                         resolve(this.handleAccept(jsonDetails));
 
                         return void 0;
                     })
-                     
-                    .catch(reject);
+
+                    .catch((error: unknown) => {
+                        this.cleanupListeners();
+                        reject(error instanceof Error ? error : new Error(String(error)));
+                    });
             } else {
                 reject(new DOMException(PaymentsErrorEnum.InvalidStateError));
             }
@@ -134,6 +164,139 @@ export class PaymentRequest {
         this.state = 'closed';
 
         this.acceptPromiseRejecter(new DOMException(PaymentsErrorEnum.AbortError));
+    }
+
+    // Register a callback for Apple Pay payment method changes (credit/debit selection)
+    onPaymentMethodChange(
+        callback: (event: PaymentMethodChangeEvent) => PaymentDetailsInit
+    ): void {
+        this.paymentMethodChangeCallback = callback;
+
+        if (Platform.OS !== 'ios') {
+            return;
+        }
+
+        const eventEmitter = this.getPaymentsEventEmitter();
+        this.paymentMethodChangeSubscription = eventEmitter.addListener(
+            'onPaymentMethodChange',
+            (event: PaymentMethodChangeEvent) => {
+                if (!this.paymentMethodChangeCallback) {
+                    return;
+                }
+
+                const updatedDetails = this.paymentMethodChangeCallback(event);
+                this.details = updatedDetails;
+                NativePayments.updatePaymentItems(updatedDetails).catch(emptyFn);
+            }
+        );
+    }
+
+    onShippingContactChange(callback: (event: IosPKContact) => PaymentRequestUpdateResult): void {
+        this.shippingContactChangeCallback = callback;
+
+        if (Platform.OS !== 'ios') {
+            return;
+        }
+
+        const eventEmitter = this.getPaymentsEventEmitter();
+        this.shippingContactChangeSubscription = eventEmitter.addListener(
+            'onShippingContactChange',
+            (event: IosPKContact) => {
+                if (!this.shippingContactChangeCallback) {
+                    return;
+                }
+
+                const result = this.shippingContactChangeCallback(event);
+                this.details = result.details;
+
+                NativePayments.updateShippingContact(
+                    result.details,
+                    result.shippingMethods ?? [],
+                    result.errors ?? []
+                ).catch(emptyFn);
+            }
+        );
+    }
+
+    onShippingMethodChange(callback: (event: IosPKShippingMethod) => PaymentRequestUpdateResult): void {
+        this.shippingMethodChangeCallback = callback;
+
+        if (Platform.OS !== 'ios') {
+            return;
+        }
+
+        const eventEmitter = this.getPaymentsEventEmitter();
+        this.shippingMethodChangeSubscription = eventEmitter.addListener(
+            'onShippingMethodChange',
+            (event: IosPKShippingMethod) => {
+                if (!this.shippingMethodChangeCallback) {
+                    return;
+                }
+
+                const result = this.shippingMethodChangeCallback(event);
+                this.details = result.details;
+                NativePayments.updateShippingMethod(result.details).catch(emptyFn);
+            }
+        );
+    }
+
+    onCouponCodeChange(callback: (event: CouponCodeChangeEvent) => PaymentRequestUpdateResult): void {
+        this.couponCodeChangeCallback = callback;
+
+        if (Platform.OS !== 'ios') {
+            return;
+        }
+
+        const eventEmitter = this.getPaymentsEventEmitter();
+        this.couponCodeChangeSubscription = eventEmitter.addListener(
+            'onCouponCodeChange',
+            (event: CouponCodeChangeEvent) => {
+                if (!this.couponCodeChangeCallback) {
+                    return;
+                }
+
+                const result = this.couponCodeChangeCallback(event);
+                this.details = result.details;
+
+                NativePayments.updateCouponCode(
+                    result.details,
+                    result.shippingMethods ?? [],
+                    result.errors ?? []
+                ).catch(emptyFn);
+            }
+        );
+    }
+
+    private getPaymentsNativeModule(): NativeModule | undefined {
+        const modules = NativeModules as unknown as { Payments?: NativeModule };
+
+        return modules.Payments;
+    }
+
+    private getPaymentsEventEmitter(): NativeEventEmitter {
+        return new NativeEventEmitter(this.getPaymentsNativeModule());
+    }
+
+    private cleanupSubscription(subscription: EmitterSubscription | null): null {
+        if (subscription) {
+            subscription.remove();
+        }
+
+        return null;
+    }
+
+    private cleanupListeners(): void {
+        this.paymentMethodChangeSubscription = this.cleanupSubscription(this.paymentMethodChangeSubscription);
+        this.paymentMethodChangeCallback = null;
+
+        this.shippingContactChangeSubscription = this.cleanupSubscription(this.shippingContactChangeSubscription);
+        this.shippingContactChangeCallback = null;
+
+        this.shippingMethodChangeSubscription = this.cleanupSubscription(this.shippingMethodChangeSubscription);
+        this.shippingMethodChangeCallback = null;
+
+        this.couponCodeChangeSubscription = this.cleanupSubscription(this.couponCodeChangeSubscription);
+        this.couponCodeChangeCallback = null;
     }
 
     private handleAccept(details: string): AndroidPaymentResponse | IosPaymentResponse {

--- a/packages/react-native-payments/src/class/payment-response/android-payment-response.ts
+++ b/packages/react-native-payments/src/class/payment-response/android-payment-response.ts
@@ -73,6 +73,9 @@ export class AndroidPaymentResponse extends PaymentResponse {
             administrativeArea: input?.administrativeArea ?? '',
             locality: input?.locality ?? '',
             sortingCode: input?.sortingCode ?? '',
+            givenName: input?.givenName ?? '',
+            familyName: input?.familyName ?? '',
+            middleName: input?.middleName ?? '',
         };
     }
 

--- a/packages/react-native-payments/src/class/payment-response/ios-payment-response.ts
+++ b/packages/react-native-payments/src/class/payment-response/ios-payment-response.ts
@@ -48,6 +48,9 @@ export class IosPaymentResponse extends PaymentResponse {
             administrativeArea: input?.subAdministrativeArea ?? '',
             locality: input?.subLocality ?? '',
             sortingCode: '',
+            givenName: input?.givenName ?? '',
+            familyName: input?.familyName ?? '',
+            middleName: input?.middleName ?? '',
         };
     }
 

--- a/packages/react-native-payments/src/index.ts
+++ b/packages/react-native-payments/src/index.ts
@@ -18,8 +18,14 @@ export { AndroidPaymentResponse } from './class/payment-response/android-payment
 
 export type { IosPaymentMethodDataDataInterface } from './@standard/ios/mapping/ios-payment-method-data-data.interface';
 export type { IosPaymentMethodDataInterface } from './@standard/ios/mapping/ios-payment-method-data.interface';
+export type { IosPKContact } from './@standard/ios/response/ios-pk-contact';
+export type { IosPKShippingMethod } from './@standard/ios/response/ios-pk-shipping-method';
 export type { IosPKToken } from './@standard/ios/response/ios-pk-token';
 export { IosPaymentResponse } from './class/payment-response/ios-payment-response';
 
 export { PaymentRequest } from './class/payment-request/payment-request';
+export type { PaymentMethodChangeEvent } from './class/payment-request/payment-request';
+export type { CouponCodeChangeEvent } from './class/payment-request/payment-request';
+export type { PaymentRequestUpdateError } from './type/payment-request-update-error/payment-request-update-error.type';
+export type { PaymentRequestUpdateResult } from './type/payment-request-update-result/payment-request-update-result.type';
 export { PaymentResponse } from './class/payment-response/payment-response';

--- a/packages/react-native-payments/src/interface/payment-response-address.interface.ts
+++ b/packages/react-native-payments/src/interface/payment-response-address.interface.ts
@@ -8,4 +8,7 @@ export interface PaymentResponseAddressInterface {
     locality: string;
     postalCode: string;
     sortingCode: string;
+    familyName: string;
+    givenName: string;
+    middleName: string;
 }

--- a/packages/react-native-payments/src/type/payment-request-update-error/payment-request-update-error.type.ts
+++ b/packages/react-native-payments/src/type/payment-request-update-error/payment-request-update-error.type.ts
@@ -1,0 +1,5 @@
+export interface PaymentRequestUpdateError {
+    code: string;
+    message: string;
+}
+

--- a/packages/react-native-payments/src/type/payment-request-update-result/payment-request-update-result.type.ts
+++ b/packages/react-native-payments/src/type/payment-request-update-result/payment-request-update-result.type.ts
@@ -1,0 +1,10 @@
+import type { IosPKShippingMethod } from '../../@standard/ios/response/ios-pk-shipping-method';
+import type { PaymentDetailsInit } from '../../@standard/w3c/payment-details-init';
+import type { PaymentRequestUpdateError } from '../payment-request-update-error/payment-request-update-error.type';
+
+export interface PaymentRequestUpdateResult {
+    details: PaymentDetailsInit;
+    shippingMethods?: IosPKShippingMethod[];
+    errors?: PaymentRequestUpdateError[];
+}
+


### PR DESCRIPTION
- Added methods for handling payment method changes, shipping contact updates, shipping method updates, and coupon code updates in the Payments module.
- Integrated RCTEventEmitter for event handling in iOS.
- Updated TypeScript interfaces to include new event types and error handling structures.
- Enhanced Android and iOS response models to accommodate additional address fields (givenName, familyName, middleName).
- Improved test coverage for new functionalities in payment request handling.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Apple Pay event listeners and dynamic update methods to PaymentRequest
> - Adds `onPaymentMethodChange`, `onShippingContactChange`, `onShippingMethodChange`, and `onCouponCodeChange` registration methods to `PaymentRequest`, enabling JS to respond to Apple Pay sheet changes in real time on iOS.
> - Implements the corresponding native delegates in [Payments.mm](https://github.com/rnw-community/rnw-community/pull/343/files#diff-e91a181c8ccc7cc0c8497e90cd49ae3cbec5ef73a548d3d069199ff0771e9b84), storing completion handlers and emitting events via `RCTEventEmitter` (requires `Payments` to now subclass `RCTEventEmitter` instead of `NSObject`).
> - Adds stub implementations of all update methods and event emitter hooks in the Android module so the native spec is satisfied without affecting Android behavior.
> - Extends `PaymentResponseAddressInterface` and related iOS/Android types to include `givenName`, `familyName`, and `middleName` fields, and fixes billing contact parsing to populate name fields instead of `ISOCountryCode`.
> - Listeners are cleaned up via `cleanupListeners()` when `show()` resolves or rejects to prevent stale updates and memory leaks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8165ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->