### PR TITLE
ci: fix release workflow — drop flaky npm@latest step and bump actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,19 +20,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22.x
           cache: 'yarn'
-
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: Setup Git user
         env:
@@ -57,7 +54,7 @@ jobs:
         run: yarn test:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## Why the last release failed

Run [#24872864181](https://github.com/rnw-community/rnw-community/actions/runs/24872864181) died in the `Update npm` step with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
```

`npm install -g npm@latest` races against the running npm: it replaces files while the in-flight process re-`require`s `arborist/rebuild.js`, which momentarily can't resolve `promise-retry`. The external `npm@latest` pointer moved on the current Node 22.22.2 runner image and started tripping the race — our code didn't change.

## Is the step load-bearing?

No. `yarn release` → `lerna publish` → `npm publish` works on whatever npm ships bundled with Node 22. Nothing in this workflow needs a newer npm than the runner provides. The step was pure liability.

## Changes

- Remove the `Update npm` step entirely.
- Bump `actions/checkout@v4` → `@v5` and `actions/setup-node@v4` → `@v5` so the workflow runs on the Node 24 JS action runtime instead of the deprecated Node 20 one (addresses the runner deprecation warning on the same run).
- Bump `codecov/codecov-action@v4` → `@v5` for the same reason.

## Test plan

- [ ] Merge to \`master\`; verify the \`Release and publish to NPM\` workflow runs green end-to-end.
- [ ] Confirm \`lerna publish\` reaches the registry (new version tag pushed, GitHub release created).
- [ ] Codecov upload succeeds on v5.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix release workflow by removing flaky npm@latest step and bumping actions to v5
> Updates [release.yml](.github/workflows/release.yml) to remove the `npm install -g npm@latest` step, which was a source of flakiness. Also bumps `actions/checkout`, `actions/setup-node`, and `codecov/codecov-action` from v4 to v5.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6670bee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->