### PR TITLE
fix(decorators-core): use absolute readme cross-links (trigger v2.0.1 republish)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
         }
     },
     "npmClient": "yarn",
-    "version": "2.0.0"
+    "version": "2.0.1"
 }


### PR DESCRIPTION
## What broke in v2.0.0

The previous release produced a mixed state on the registry:

- **15 packages at 2.0.0, correct** — shared, eslint-plugin, fast-style, platform, redux-loadable, wdio, object-field-tree, react-native-payments, rxjs-errors, nestjs-rxjs-{logger, metrics, lock, redis}, nestjs-webpack-swc, nestjs-typed-config. These went through lerna, which rewrote `workspace:^` → `^2.0.0` in the tarballs.
- **5 packages at 2.0.0, broken** — decorators-core, log-decorator, histogram-metric-decorator, lock-decorator, nestjs-enterprise. The first four had never existed on npm; lerna's per-package packument precheck returned E404, lerna aborted their publish, and that cascaded to dependents. They were bootstrapped onto the registry through a manual `npm publish --access public` fallback — which does **not** rewrite yarn's `workspace:` protocol. Their `dependencies` fields look like:
  ```
  "@rnw-community/decorators-core": "workspace:^"
  "@rnw-community/shared":          "workspace:^"
  ```
  npm chokes on the `workspace:` prefix at install time, so those 5 tarballs are installable but unusable.

## The change

Two-line readme fix under `packages/decorators-core/`: the relative cross-links `../shared` and `../../LICENSE.md` don't resolve when the readme is rendered on npmjs.com — only GitHub's tree view follows them. Swapping them for absolute GitHub URLs is a real, small docs improvement.

It also serves as the trigger commit for the release pipeline. Lerna's change detection is per-package-directory (a `lerna.json` edit alone, as on the previous revision of this PR, did not register as a package change — the last workflow run reported `No changed packages to publish`). A `fix(decorators-core):` commit that touches a file under `packages/decorators-core/` does register. Fixed-versioning then bumps all 20 packages to `2.0.1`, lerna rewrites `workspace:^` → `^2.0.1` in every tarball, and the previously-missing names now exist on the registry, so the original 404 cascade cannot repeat.

## Follow-up (after this PR merges and CI publishes v2.0.1)

1. `npm deprecate '@rnw-community/<pkg>@2.0.0' 'v2.0.0 shipped with unresolved workspace: specifiers — use >=2.0.1'` for the 5 broken versions.
2. Confirm OIDC trusted-publisher coverage for the 4 brand-new package names on npmjs.com. They were created under a personal account via the fallback publish; the org's trusted-publisher config may not yet list them. If CI fails on any of them, add trusted publishing per-package (npmjs.com → Settings → Trusted Publishers) or `npm access grant read-write <team> @rnw-community/<pkg>`.

## Test plan

- [ ] Merge to `master`; the `Release and publish to NPM` workflow runs green end-to-end.
- [ ] `npm view @rnw-community/lock-decorator@2.0.1 dependencies` shows `^2.0.1` references — no `workspace:`.
- [ ] `npm view @rnw-community/decorators-core@2.0.1` resolves (sanity check for the new names under CI's OIDC).
- [ ] Deprecate the 5 broken 2.0.0 versions after CI publishes cleanly.
