### PR TITLE
fix(decorators-core): use absolute readme cross-links (trigger v2.0.1 republish)

### DIFF
--- a/packages/decorators-core/readme.md
+++ b/packages/decorators-core/readme.md
@@ -38,7 +38,7 @@ class OrderService {
 | `ExecutionContextInterface<TArgs>` | `{ className, methodName, args, logContext }` — stable identity per invocation |
 | `CreateInterceptorOptionsInterface<TArgs, TResult>` | `{ middleware }` — the sole option |
 
-`MethodDecoratorType<K>` comes from [`@rnw-community/shared`](../shared) — import it directly, not through this package.
+`MethodDecoratorType<K>` comes from [`@rnw-community/shared`](https://github.com/rnw-community/rnw-community/tree/master/packages/shared) — import it directly, not through this package.
 
 ## Build your own decorator
 
@@ -91,4 +91,4 @@ The context identity is stable across a single invocation — middleware can cap
 
 ## License
 
-[MIT](../../LICENSE.md)
+[MIT](https://github.com/rnw-community/rnw-community/blob/master/LICENSE.md)


### PR DESCRIPTION
## Why this PR exists

v2.0.0 left 5 packages broken on npm (decorators-core, log-decorator, histogram-metric-decorator, lock-decorator, nestjs-enterprise): their tarballs carry unresolved `workspace:^` dep specifiers instead of real semver. The prior recovery PR (#355) only bumped `lerna.json`, which sits outside `packages/*/` and therefore isn't seen by lerna's per-package change detection — the merge ran lerna and it reported `No changed packages to publish`.

Lerna looks at files *under each package's folder* to decide whether that package was "changed" since the last release tag. So the trigger needs to live under `packages/<x>/`.

## The change

Two-line fix under `packages/decorators-core/readme.md`: the relative cross-links `../shared` and `../../LICENSE.md` don't resolve when the readme is rendered on npmjs.com — only on GitHub's tree view. Swapped for absolute GitHub URLs. Real, small docs improvement that also registers as a package change.

## What happens on merge

- Lerna's change detection sees `packages/decorators-core/` modified → patch bump under conventional-commits (`fix:` subject).
- Fixed versioning in `lerna.json` propagates the bump to all 20 packages → every package ships `v2.0.1`.
- Lerna rewrites `workspace:^` → `^2.0.1` during publish, so the 5 broken tarballs from v2.0.0 get correctly-resolved siblings at v2.0.1.
- All 4 previously-missing package names now exist on the registry (bootstrapped out-of-band last night), so the original 404-packument cascade from the first v2.0.0 attempt cannot recur.

## Follow-up (after CI publishes v2.0.1)

1. `npm deprecate '@rnw-community/<pkg>@2.0.0' 'v2.0.0 shipped with unresolved workspace: specifiers — use >=2.0.1'` for the 5 broken versions.
2. Confirm OIDC trusted-publisher coverage for the 4 brand-new package names on npmjs.com. They were created under a personal account via the fallback publish; if CI errors on any of them, add trusted publishing per-package (npmjs.com → Settings → Trusted Publishers) or `npm access grant read-write <team> @rnw-community/<pkg>`.

## Test plan

- [ ] Merge to `master`; `Release and publish to NPM` workflow runs green end-to-end.
- [ ] `npm view @rnw-community/lock-decorator@2.0.1 dependencies` shows `^2.0.1` refs — no `workspace:`.
- [ ] `npm view @rnw-community/decorators-core@2.0.1` resolves (sanity check for the new names under CI's OIDC).
- [ ] Deprecate the 5 broken 2.0.0 versions once CI is green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix absolute cross-links in `decorators-core` readme to trigger v2.0.1 republish
> Replaces relative links in [readme.md](https://github.com/rnw-community/rnw-community/pull/356/files#diff-fa9d8cbc6f2f72a28dd4fa2318dc454514792f51fd2fd0c06f0decb9a4a2abba) with absolute GitHub URLs for the `@rnw-community/shared` reference and the LICENSE file. This ensures the links resolve correctly when the package is viewed on npm.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69c17ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->