### PR TITLE
ci: modernize pull-request workflow to match release.yml action versions

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -15,15 +15,15 @@ jobs:
 
         steps:
             -   name: Checkout repository
-                uses: actions/checkout@v4
+                uses: actions/checkout@v5
                 with:
                     fetch-depth: 2
 
             -   name: Close Stale Issues
-                uses: actions/stale@v8.0.0
+                uses: actions/stale@v10
 
             -   name: Setup Node
-                uses: actions/setup-node@v4
+                uses: actions/setup-node@v5
                 with:
                     node-version: 22.x
                     cache: 'yarn'
@@ -53,7 +53,7 @@ jobs:
                 run: yarn test:coverage
 
             -   name: Upload coverage to Codecov
-                uses: codecov/codecov-action@v4
+                uses: codecov/codecov-action@v5
                 with:
                     token: ${{ secrets.CODECOV_TOKEN }}
                     fail_ci_if_error: true


### PR DESCRIPTION
## What this does

Bumps the actions missed by PR #354 — that PR only touched `release.yml`, but `pull-request.yaml` had the same stale versions. This brings them in sync:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v4` | `v5` |
| `actions/setup-node` | `v4` | `v5` |
| `codecov/codecov-action` | `v4` | `v5` |
| `actions/stale` | `v8.0.0` (exact) | `v10` |

The first three moves match the same Node-24-JS-runtime reason as `release.yml`. Stale had been pinned to exact `v8.0.0` and missed two majors — `v10` is current.

## What this does NOT do

The remaining `actions/github-script@60a0d83…` Node-20 warning on release workflow runs comes from `codecov/codecov-action@v5`'s internals, not from any action we reference directly. Can't fix it from here — waiting on upstream codecov release.

## Test plan

- [ ] PR CI (this workflow) runs green on this PR.
- [ ] Next release run shows no new warnings from `checkout`/`setup-node`/`codecov-action`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update GitHub Actions versions in pull-request workflow to match release.yml
> Updates [pull-request.yaml](.github/workflows/pull-request.yaml) to use current major versions: `actions/checkout` v4→v5, `actions/stale` v8→v10, `actions/setup-node` v4→v5, and `codecov/codecov-action` v4→v5.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b9c964e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->