### PR TITLE
feat(shared): add isRecord type guard

### DIFF
--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -21,7 +21,7 @@ yarn lint:fix           # Fix lint issues
 src/
   type/           — TypeScript utility types (Maybe, AnyFn, ClassType, EmptyFn, Enum, MethodDecoratorType, etc.)
   type-guard/     — Runtime type narrowing functions
-    generic/      — isDefined, isError, isPromise (isObject exists but is internal-only and NOT exported)
+    generic/      — isDefined, isError, isPromise, isRecord (isObject exists but is internal-only and NOT exported)
     array/        — isArray, isEmptyArray, isNotEmptyArray, isNotEmptyArrayOf
     boolean/      — isBoolean
     number/       — isNumber, isPositiveNumber

--- a/packages/shared/readme.md
+++ b/packages/shared/readme.md
@@ -15,6 +15,7 @@ Convenient [TypeScript type guards](https://www.typescriptlang.org/docs/handbook
     - [isDefined](src/type-guard/generic/is-defined/is-defined.md)
     - [isError](src/type-guard/generic/is-error/is-error.md)
     - [isPromise](src/type-guard/generic/is-promise/is-promise.md)
+    - [isRecord](src/type-guard/generic/is-record/is-record.md) - non-array objects that are safe to index by key
 - Array:
     - [isArray](src/type-guard/array/is-array/is-array.md)
     - [isEmptyArray](src/type-guard/array/is-empty-array/is-empty-array.md)
@@ -58,4 +59,3 @@ Commonly used typescript types:
 ## License
 
 This library is licensed under The [MIT License](./LICENSE.md).
-

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -14,6 +14,7 @@ export type { ReadonlyIsNotEmptyArray } from './type/readonly-is-not-empty-array
 export { isDefined } from './type-guard/generic/is-defined/is-defined';
 export { isError } from './type-guard/generic/is-error/is-error';
 export { isPromise } from './type-guard/generic/is-promise/is-promise';
+export { isRecord } from './type-guard/generic/is-record/is-record';
 
 export { isString } from './type-guard/string/is-string/is-string';
 export { isEmptyString } from './type-guard/string/is-empty-string/is-empty-string';

--- a/packages/shared/src/type-guard/generic/is-record/is-record.md
+++ b/packages/shared/src/type-guard/generic/is-record/is-record.md
@@ -1,0 +1,20 @@
+# `isRecord`
+
+Check if variable is a non-array object and narrows its type to `Record<PropertyKey, unknown>`.
+
+Useful when a value must be indexable after runtime validation. Arrays are objects in JavaScript, but `isRecord` returns `false` for arrays.
+
+## Example
+
+```ts
+import { isRecord } from '@rnw-community/shared';
+
+const value: unknown = { id: 'product-1' };
+const array: unknown = ['product-1'];
+
+if (isRecord(value)) {
+    value['id']; // value is Record<PropertyKey, unknown>
+}
+
+isRecord(array); // returns false
+```

--- a/packages/shared/src/type-guard/generic/is-record/is-record.spec.ts
+++ b/packages/shared/src/type-guard/generic/is-record/is-record.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { isRecord as publicIsRecord } from '../../../index';
+
+import { isRecord } from './is-record';
+
+describe('isRecord', () => {
+    it('should return true if variable is a record', () => {
+        expect.hasAssertions();
+
+        expect(isRecord({})).toBe(true);
+        expect(isRecord({ key: 'value' })).toBe(true);
+    });
+
+    it('should return false if variable is not a record', () => {
+        expect.hasAssertions();
+
+        expect(isRecord(undefined)).toBe(false);
+        expect(isRecord('')).toBe(false);
+        expect(isRecord(null)).toBe(false);
+        expect(isRecord(1)).toBe(false);
+        expect(isRecord(true)).toBe(false);
+    });
+
+    it('should return false if variable is an array', () => {
+        expect.hasAssertions();
+
+        expect(isRecord([])).toBe(false);
+        expect(isRecord(['value'])).toBe(false);
+    });
+
+    it('should narrow values to an indexable record', () => {
+        expect.hasAssertions();
+
+        const value: unknown = { key: 'value' };
+        const narrowed = isRecord(value) ? (value['key'] satisfies unknown) : undefined;
+
+        expect(narrowed).toBe('value');
+    });
+
+    it('should be exported from the public package entrypoint', () => {
+        expect.hasAssertions();
+
+        const value: unknown = { key: 'value' };
+        const narrowed = publicIsRecord(value) ? (value['key'] satisfies unknown) : undefined;
+
+        expect(narrowed).toBe('value');
+        expect(publicIsRecord(['value'])).toBe(false);
+    });
+});

--- a/packages/shared/src/type-guard/generic/is-record/is-record.ts
+++ b/packages/shared/src/type-guard/generic/is-record/is-record.ts
@@ -1,0 +1,4 @@
+import { isArray } from '../../array/is-array/is-array';
+import { isObject } from '../is-object/is-object';
+
+export const isRecord = <T>(value: T): value is T & Record<PropertyKey, unknown> => isObject(value) && !isArray(value);


### PR DESCRIPTION
## Summary

- Adds `isRecord` as a public `@rnw-community/shared` type guard.
- Reuses the existing object guard behavior so arrays, nullish values, and primitives are rejected.
- Narrows accepted values to `Record<PropertyKey, unknown>` so guarded values are indexable.
- Documents the new guard in the package readme and colocated entity docs.

## Validation

- `cd packages/shared && yarn test src/type-guard/generic/is-record/is-record.spec.ts` (verified RED before implementation, GREEN after)
- `cd packages/shared && yarn test`
- `cd packages/shared && yarn ts`
- `cd packages/shared && yarn build`
- `cd packages/shared && yarn lint`
- `yarn build`
- `yarn ts`
- `yarn lint` (exited 0 with existing unrelated warnings)
- `yarn test` (exited 0 with existing post-build Jest haste-map warning in `eslint-plugin`)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `isRecord` type guard to `@rnw-community/shared`
> Adds a new `isRecord` generic type guard in [is-record.ts](https://github.com/rnw-community/rnw-community/pull/363/files#diff-cd0327d89ab23f18b4f8bf2bf31e75b5c059f8097383dbeba25b7075eadc8da7) that returns `true` for non-array objects, narrowing the type to `T & Record<PropertyKey, unknown>`. It is built on the existing internal `isObject` and `isArray` utilities and is exported from the package's public entrypoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 686efad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->