### PR TITLE
feat(react-native-payments): support multiple Apple Pay merchant identifiers

### DIFF
--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -118,7 +118,7 @@ export default {
 };
 ```
 
-`merchantIdentifier` accepts either a single identifier or an array of identifiers. Pass an array when your app resolves the Apple Pay merchant per country/environment at runtime — every identifier is then declared in the `com.apple.developer.in-app-payments` entitlement:
+`merchantIdentifier` accepts either a single identifier or an array of identifiers. Pass an array when your app resolves the Apple Pay merchant per country/environment at runtime — every identifier is then declared in the `com.apple.developer.in-app-payments` entitlement. Empty identifiers are ignored; if no non-empty identifier remains, prebuild fails with an error:
 
 ```js
 {

--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -118,6 +118,14 @@ export default {
 };
 ```
 
+`merchantIdentifier` accepts either a single identifier or an array of identifiers. Pass an array when your app resolves the Apple Pay merchant per country/environment at runtime — every identifier is then declared in the `com.apple.developer.in-app-payments` entitlement:
+
+```js
+{
+    "merchantIdentifier": ["merchant.react-native-payments.fr", "merchant.react-native-payments.mg"]
+}
+```
+
 2. Prebuild your project:
 
 ```bash

--- a/packages/react-native-payments/src/expo-plugins/plugin.props.ts
+++ b/packages/react-native-payments/src/expo-plugins/plugin.props.ts
@@ -1,3 +1,3 @@
 export interface ReactNativePaymentsPluginProps {
-    merchantIdentifier: string;
+    merchantIdentifier: string | string[];
 }

--- a/packages/react-native-payments/src/expo-plugins/with-apple-pay.spec.ts
+++ b/packages/react-native-payments/src/expo-plugins/with-apple-pay.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { withApplePay } from './with-apple-pay';
+
+jest.mock('expo/config-plugins', () => ({
+    withEntitlementsPlist: jest.fn((config: unknown, modifier: (config: unknown) => unknown) => modifier(config)),
+}));
+
+const ENTITLEMENT_KEY = 'com.apple.developer.in-app-payments';
+
+const createConfig = (entitlements: Record<string, unknown> = {}) => ({
+    name: 'test',
+    slug: 'test',
+    modResults: entitlements,
+});
+
+const runPlugin = (merchantIdentifier: string | string[], entitlements?: Record<string, unknown>) => {
+    const result = withApplePay(createConfig(entitlements) as never, { merchantIdentifier }) as unknown as {
+        modResults: Record<string, string[]>;
+    };
+
+    return result.modResults[ENTITLEMENT_KEY];
+};
+
+describe('withApplePay', () => {
+    it('should add a single merchant identifier', () => {
+        expect.assertions(1);
+
+        expect(runPlugin('merchant.com.example')).toStrictEqual(['merchant.com.example']);
+    });
+
+    it('should add multiple merchant identifiers', () => {
+        expect.assertions(1);
+
+        expect(runPlugin(['merchant.com.example.fr', 'merchant.com.example.mg'])).toStrictEqual([
+            'merchant.com.example.fr',
+            'merchant.com.example.mg',
+        ]);
+    });
+
+    it('should preserve already declared merchant identifiers', () => {
+        expect.assertions(1);
+
+        const existing = { [ENTITLEMENT_KEY]: ['merchant.com.existing'] };
+
+        expect(runPlugin('merchant.com.example', existing)).toStrictEqual([
+            'merchant.com.existing',
+            'merchant.com.example',
+        ]);
+    });
+
+    it('should not duplicate an already declared merchant identifier', () => {
+        expect.assertions(1);
+
+        const existing = { [ENTITLEMENT_KEY]: ['merchant.com.example'] };
+
+        expect(runPlugin(['merchant.com.example', 'merchant.com.example.mg'], existing)).toStrictEqual([
+            'merchant.com.example',
+            'merchant.com.example.mg',
+        ]);
+    });
+
+    it('should ignore empty identifiers', () => {
+        expect.assertions(1);
+
+        expect(runPlugin(['', 'merchant.com.example'])).toStrictEqual(['merchant.com.example']);
+    });
+
+    it('should throw when no merchant identifier is provided', () => {
+        expect.assertions(1);
+
+        expect(() => withApplePay(createConfig() as never, {} as never)).toThrow(
+            'Please provide "@rnw-community/react-native-payments" plugin option "merchantIdentifier"'
+        );
+    });
+
+    it('should throw when every provided identifier is empty', () => {
+        expect.assertions(2);
+
+        expect(() => runPlugin([])).toThrow(
+            'Please provide "@rnw-community/react-native-payments" plugin option "merchantIdentifier"'
+        );
+        expect(() => runPlugin([''])).toThrow(
+            'Please provide "@rnw-community/react-native-payments" plugin option "merchantIdentifier"'
+        );
+    });
+});

--- a/packages/react-native-payments/src/expo-plugins/with-apple-pay.spec.ts
+++ b/packages/react-native-payments/src/expo-plugins/with-apple-pay.spec.ts
@@ -43,10 +43,7 @@ describe('withApplePay', () => {
 
         const existing = { [ENTITLEMENT_KEY]: ['merchant.com.existing'] };
 
-        expect(runPlugin('merchant.com.example', existing)).toStrictEqual([
-            'merchant.com.existing',
-            'merchant.com.example',
-        ]);
+        expect(runPlugin('merchant.com.example', existing)).toStrictEqual(['merchant.com.existing', 'merchant.com.example']);
     });
 
     it('should not duplicate an already declared merchant identifier', () => {
@@ -75,8 +72,11 @@ describe('withApplePay', () => {
     });
 
     it('should throw when every provided identifier is empty', () => {
-        expect.assertions(2);
+        expect.assertions(3);
 
+        expect(() => runPlugin('')).toThrow(
+            'Please provide "@rnw-community/react-native-payments" plugin option "merchantIdentifier"'
+        );
         expect(() => runPlugin([])).toThrow(
             'Please provide "@rnw-community/react-native-payments" plugin option "merchantIdentifier"'
         );

--- a/packages/react-native-payments/src/expo-plugins/with-apple-pay.ts
+++ b/packages/react-native-payments/src/expo-plugins/with-apple-pay.ts
@@ -6,19 +6,23 @@ import type { ReactNativePaymentsPluginProps } from './plugin.props';
 import type { ConfigPlugin } from 'expo/config-plugins';
 
 export const withApplePay: ConfigPlugin<ReactNativePaymentsPluginProps> = (initialConfig, { merchantIdentifier }) => {
-    if (!isDefined(merchantIdentifier)) {
-        throw new Error(`Pleas provide "@rnw-community/react-native-payments" plugin option "merchantIdentifier"`);
+    const merchantIdentifiers = (Array.isArray(merchantIdentifier) ? merchantIdentifier : [merchantIdentifier]).filter(
+        Boolean
+    );
+
+    if (merchantIdentifiers.length === 0) {
+        throw new Error(`Please provide "@rnw-community/react-native-payments" plugin option "merchantIdentifier"`);
     }
 
     return withEntitlementsPlist(initialConfig, configWithEntitlements => {
-        if (merchantIdentifier) {
-            if (!isDefined(configWithEntitlements.modResults['com.apple.developer.in-app-payments'])) {
-                configWithEntitlements.modResults['com.apple.developer.in-app-payments'] = [];
-            }
+        if (!isDefined(configWithEntitlements.modResults['com.apple.developer.in-app-payments'])) {
+            configWithEntitlements.modResults['com.apple.developer.in-app-payments'] = [];
+        }
 
-            const applePayArray = configWithEntitlements.modResults['com.apple.developer.in-app-payments'] as string[];
-            if (!applePayArray.includes(merchantIdentifier)) {
-                applePayArray.push(merchantIdentifier);
+        const applePayArray = configWithEntitlements.modResults['com.apple.developer.in-app-payments'] as string[];
+        for (const identifier of merchantIdentifiers) {
+            if (!applePayArray.includes(identifier)) {
+                applePayArray.push(identifier);
             }
         }
 

--- a/packages/react-native-payments/src/expo-plugins/with-apple-pay.ts
+++ b/packages/react-native-payments/src/expo-plugins/with-apple-pay.ts
@@ -1,16 +1,16 @@
 import { withEntitlementsPlist } from 'expo/config-plugins';
 
-import { isDefined } from '@rnw-community/shared';
+import { isDefined, isEmptyArray, isNotEmptyString } from '@rnw-community/shared';
 
 import type { ReactNativePaymentsPluginProps } from './plugin.props';
 import type { ConfigPlugin } from 'expo/config-plugins';
 
 export const withApplePay: ConfigPlugin<ReactNativePaymentsPluginProps> = (initialConfig, { merchantIdentifier }) => {
     const merchantIdentifiers = (Array.isArray(merchantIdentifier) ? merchantIdentifier : [merchantIdentifier]).filter(
-        Boolean
+        isNotEmptyString
     );
 
-    if (merchantIdentifiers.length === 0) {
+    if (isEmptyArray(merchantIdentifiers)) {
         throw new Error(`Please provide "@rnw-community/react-native-payments" plugin option "merchantIdentifier"`);
     }
 


### PR DESCRIPTION
This PR adds support for declaring multiple Apple Pay merchant identifiers through the Expo config plugin. The `merchantIdentifier` plugin option now accepts either a single `string` (unchanged) or a `string[]`.

The `com.apple.developer.in-app-payments` entitlement is natively an array, and the existing plugin already pushed into it with a de-duplication guard — it was just capped to a single identifier by the option type. Apps that resolve the Apple Pay merchant per country or per environment at runtime need every candidate identifier declared in the entitlement, otherwise Apple Pay fails for the merchants that were left out. This unlocks that case without any native change.

- `merchantIdentifier: string | string[]` in the plugin props
- `withApplePay` normalizes the input to an array and registers each identifier, keeping the existing de-duplication so re-running prebuild or composing with another plugin stays idempotent
- readme documents the array form with a multi-country example
- added a spec covering single, multiple, pre-existing, de-duplicated, and missing-identifier cases

Backward compatible for all valid configs: passing a single non-empty string behaves exactly as before. One edge case changes deliberately: `merchantIdentifier: ""` (or `[]` / `[""]`), which previously prebuilt silently while writing no entitlement, now fails prebuild with an explicit error — a silently missing Apple Pay entitlement was never a working state. Empty identifiers inside an array are ignored. Also fixes a small typo in the thrown error message (`Pleas` → `Please`) on the line that was already being changed.

For reviewers: the behavior change is isolated to `with-apple-pay.ts`; Google Pay does not use `merchantIdentifier` and is untouched.

Closes #365


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support multiple Apple Pay merchant identifiers in `react-native-payments` config plugin
> - Changes `merchantIdentifier` in `ReactNativePaymentsPluginProps` from `string` to `string | string[]`, normalizing to an array internally.
> - Appends all non-empty, non-duplicate identifiers to the `com.apple.developer.in-app-payments` entitlement, preserving any existing entries.
> - Throws an error at prebuild time if no non-empty identifier remains after filtering.
> - Adds Jest tests covering single/multiple identifiers, deduplication, empty-string filtering, and error cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89b89d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
