### PR TITLE
fix(react-native-payments): support Google Pay totalPriceStatus, checkoutOption and zero totals

### DIFF
--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -183,6 +183,7 @@ const methodData = [
             requestBillingAddress: true,
             requestPayerEmail: true,
             requestShipping: true,
+            totalPriceStatus: 'ESTIMATED',
             gatewayConfig: {
                 gateway: 'example',
                 gatewayMerchantId: 'exampleGatewayMerchantId',
@@ -209,6 +210,9 @@ const paymentRequest = new PaymentRequest(methodData, paymentDetails);
 Depending on the platform and payment method, you can provide additional data to the `methodData.data` property:
 
 - `environment`: This property represents the Android environment for the payment.
+- `totalPriceStatus`: An optional Google Pay field describing how the total price will change: `'FINAL'` (default), `'ESTIMATED'` or `'NOT_CURRENTLY_KNOWN'`. A zero total amount (`'0.00'`) is valid per the W3C spec and can be combined with a non-final status when the price is not known upfront. See [TransactionInfo](https://developers.google.com/pay/api/android/reference/request-objects#TransactionInfo).
+- `checkoutOption`: An optional Google Pay field selecting the payment sheet submit behavior: `'DEFAULT'` or `'COMPLETE_IMMEDIATE_PURCHASE'`. Google Pay only allows `'COMPLETE_IMMEDIATE_PURCHASE'` together with the `'FINAL'` `totalPriceStatus`, so the constructor throws on any other combination.
+- `transactionId`: An optional Google Pay field with a unique identifier for correlating the payment attempt in Google Pay transaction events.
 - `requestPayerName`: "An optional boolean field that, when present and set to true, indicates that the `PaymentResponse` will include the name of the payer.
 - `requestPayerPhone`: "An optional boolean field that, when present and set to true, indicates that the `PaymentResponse` will include the phone of the payer.
 - `requestBillingAddress`: An optional boolean field that, when present and set to true, indicates that the `PaymentResponse` will

--- a/packages/react-native-payments/src/@standard/android/mapping/android-payment-method-data-data.interface.ts
+++ b/packages/react-native-payments/src/@standard/android/mapping/android-payment-method-data-data.interface.ts
@@ -3,12 +3,18 @@ import type { GenericPaymentMethodDataDataInterface } from '../../../interface/g
 import type { AndroidAllowedAuthMethodsEnum } from '../enum/android-allowed-auth-methods.enum';
 import type { AndroidTokenizationDirectSpecification } from '../request/android-tokenization-direct-specification';
 import type { AndroidTokenizationGatewaySpecification } from '../request/android-tokenization-gateway-specification';
+import type { AndroidTransactionInfo } from '../request/android-transaction-info';
 
 interface AndroidGenericPaymentMethodDataInterface extends GenericPaymentMethodDataDataInterface {
     // PAN_ONLY and CRYPTOGRAM_3DS by default. https://developers.google.com/pay/api/android/reference/request-objects#CardParameters
     allowedAuthMethods?: AndroidAllowedAuthMethodsEnum[];
+    // Requires totalPriceStatus FINAL. https://developers.google.com/pay/api/android/reference/request-objects#TransactionInfo
+    checkoutOption?: AndroidTransactionInfo['checkoutOption'];
     // Android environment https://developers.google.com/android/reference/com/google/android/gms/wallet/Wallet.WalletOptions.Builder#setEnvironment(int)
     environment: EnvironmentEnum;
+    // FINAL by default. https://developers.google.com/pay/api/android/reference/request-objects#TransactionInfo
+    totalPriceStatus?: AndroidTransactionInfo['totalPriceStatus'];
+    transactionId?: AndroidTransactionInfo['transactionId'];
 }
 
 export type AndroidPaymentMethodDataDataInterface = AndroidGenericPaymentMethodDataInterface &

--- a/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
@@ -1,4 +1,3 @@
- 
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { Platform } from 'react-native';
 
@@ -15,6 +14,8 @@ import { NativePayments } from '../native-payments/native-payments';
 import { PaymentRequest } from './payment-request';
 
 import type { AndroidPaymentMethodDataInterface } from '../../@standard/android/mapping/android-payment-method-data.interface';
+import type { AndroidPaymentDataRequest } from '../../@standard/android/request/android-payment-data-request';
+import type { AndroidTransactionInfo } from '../../@standard/android/request/android-transaction-info';
 import type { AndroidPaymentData } from '../../@standard/android/response/android-payment-data';
 import type { IosPaymentMethodDataInterface } from '../../@standard/ios/mapping/ios-payment-method-data.interface';
 import type { IosPKPayment } from '../../@standard/ios/response/ios-pk-payment';
@@ -36,7 +37,6 @@ jest.mock('react-native', () => ({
     },
 }));
 
- 
 describe('PaymentRequest', () => {
     const paymentDetails = {
         total: {
@@ -45,12 +45,10 @@ describe('PaymentRequest', () => {
         },
     };
 
-     
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-     
     describe('validation', () => {
         const methodData: AndroidPaymentMethodDataInterface = {
             supportedMethods: PaymentMethodNameEnum.AndroidPay,
@@ -168,6 +166,20 @@ describe('PaymentRequest', () => {
                 );
             });
 
+            it('should NOT throw when total.amount.value is zero', () => {
+                expect.assertions(2);
+
+                const zeroTotal = { label: 'Total', amount: { currency: 'USD', value: '0.00' } };
+
+                expect(() => new PaymentRequest([methodData], { total: zeroTotal })).not.toThrow();
+                expect(
+                    () =>
+                        new PaymentRequest([methodData], {
+                            total: { ...zeroTotal, amount: { currency: 'USD', value: '0' } },
+                        })
+                ).not.toThrow();
+            });
+
             it('should throw when total.amount.value ends with dot', () => {
                 expect.assertions(1);
 
@@ -251,7 +263,6 @@ describe('PaymentRequest', () => {
         });
     });
 
-     
     describe('PaymentRequest on Android', () => {
         const androidMethodData: AndroidPaymentMethodDataInterface = {
             supportedMethods: PaymentMethodNameEnum.AndroidPay,
@@ -267,7 +278,6 @@ describe('PaymentRequest', () => {
             },
         };
 
-         
         beforeEach(() => {
             Platform.OS = 'android';
         });
@@ -481,9 +491,78 @@ describe('PaymentRequest', () => {
                 new DOMException(PaymentsErrorEnum.NotSupportedError)
             );
         });
+
+        describe('transactionInfo serialization', () => {
+            const getSerializedTransactionInfo = async (
+                requestMethodData: AndroidPaymentMethodDataInterface,
+                details: PaymentDetailsInit = paymentDetails
+            ): Promise<AndroidTransactionInfo> => {
+                jest.mocked(NativePayments.canMakePayments).mockResolvedValue(true);
+
+                await new PaymentRequest([requestMethodData], details).canMakePayment();
+
+                const [[serializedMethodData]] = jest.mocked(NativePayments.canMakePayments).mock.calls;
+
+                return (JSON.parse(serializedMethodData) as AndroidPaymentDataRequest).transactionInfo;
+            };
+
+            it('should serialize FINAL totalPriceStatus and no optional fields by default', async () => {
+                expect.assertions(3);
+
+                const transactionInfo = await getSerializedTransactionInfo(androidMethodData);
+
+                expect(transactionInfo.totalPriceStatus).toBe('FINAL');
+                expect(transactionInfo).not.toHaveProperty('checkoutOption');
+                expect(transactionInfo).not.toHaveProperty('transactionId');
+            });
+
+            it('should serialize provided totalPriceStatus and transactionId with zero total', async () => {
+                expect.assertions(3);
+
+                const transactionInfo = await getSerializedTransactionInfo(
+                    {
+                        ...androidMethodData,
+                        data: { ...androidMethodData.data, totalPriceStatus: 'NOT_CURRENTLY_KNOWN', transactionId: 'txn-1' },
+                    },
+                    { total: { label: 'Total', amount: { currency: 'USD', value: '0.00' } } }
+                );
+
+                expect(transactionInfo.totalPriceStatus).toBe('NOT_CURRENTLY_KNOWN');
+                expect(transactionInfo.transactionId).toBe('txn-1');
+                expect(transactionInfo.totalPrice).toBe('0.00');
+            });
+
+            it('should serialize checkoutOption with default FINAL totalPriceStatus', async () => {
+                expect.assertions(2);
+
+                const transactionInfo = await getSerializedTransactionInfo({
+                    ...androidMethodData,
+                    data: { ...androidMethodData.data, checkoutOption: 'COMPLETE_IMMEDIATE_PURCHASE' },
+                });
+
+                expect(transactionInfo.checkoutOption).toBe('COMPLETE_IMMEDIATE_PURCHASE');
+                expect(transactionInfo.totalPriceStatus).toBe('FINAL');
+            });
+
+            it('should throw when checkoutOption COMPLETE_IMMEDIATE_PURCHASE is combined with non-FINAL totalPriceStatus', () => {
+                expect.assertions(1);
+
+                const invalidMethodData: AndroidPaymentMethodDataInterface = {
+                    ...androidMethodData,
+                    data: {
+                        ...androidMethodData.data,
+                        checkoutOption: 'COMPLETE_IMMEDIATE_PURCHASE',
+                        totalPriceStatus: 'ESTIMATED',
+                    },
+                };
+
+                expect(() => new PaymentRequest([invalidMethodData], paymentDetails)).toThrow(
+                    new ConstructorError(`checkoutOption 'COMPLETE_IMMEDIATE_PURCHASE' requires totalPriceStatus 'FINAL'`)
+                );
+            });
+        });
     });
 
-     
     describe('PaymentRequest on iOS', () => {
         const iosMethodData: IosPaymentMethodDataInterface = {
             supportedMethods: PaymentMethodNameEnum.ApplePay,
@@ -500,7 +579,6 @@ describe('PaymentRequest', () => {
             },
         };
 
-         
         beforeEach(() => {
             Platform.OS = 'ios';
         });
@@ -685,6 +763,30 @@ describe('PaymentRequest', () => {
 
             expect(() => new PaymentRequest(invalidMethodData, paymentDetails)).toThrow(
                 new DOMException(PaymentsErrorEnum.NotSupportedError)
+            );
+        });
+
+        it('should throw when Android methodData combines checkoutOption COMPLETE_IMMEDIATE_PURCHASE with non-FINAL totalPriceStatus', () => {
+            expect.assertions(1);
+
+            const invalidAndroidMethodData: AndroidPaymentMethodDataInterface = {
+                supportedMethods: PaymentMethodNameEnum.AndroidPay,
+                data: {
+                    currencyCode: 'USD',
+                    countryCode: 'US',
+                    supportedNetworks: [SupportedNetworkEnum.Visa],
+                    environment: EnvironmentEnum.TEST,
+                    gatewayConfig: {
+                        gateway: 'exampleGateway',
+                        gatewayMerchantId: 'exampleMerchantId',
+                    },
+                    checkoutOption: 'COMPLETE_IMMEDIATE_PURCHASE',
+                    totalPriceStatus: 'ESTIMATED',
+                },
+            };
+
+            expect(() => new PaymentRequest([iosMethodData, invalidAndroidMethodData], paymentDetails)).toThrow(
+                new ConstructorError(`checkoutOption 'COMPLETE_IMMEDIATE_PURCHASE' requires totalPriceStatus 'FINAL'`)
             );
         });
     });

--- a/packages/react-native-payments/src/class/payment-request/payment-request.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.ts
@@ -17,6 +17,7 @@ import { SupportedNetworkEnum } from '../../enum/supported-networks.enum';
 import { ConstructorError } from '../../error/constructor.error';
 import { DOMException } from '../../error/dom.exception';
 import { PaymentsError } from '../../error/payments.error';
+import { validateAndroidTransactionInfo } from '../../util/validate-android-transaction-info.util';
 import { validateDisplayItems } from '../../util/validate-display-items.util';
 import { validatePaymentMethods } from '../../util/validate-payment-methods.util';
 import { validateTotal } from '../../util/validate-total.util';
@@ -48,7 +49,6 @@ export class PaymentRequest {
 
     private acceptPromiseRejecter: (reason: unknown) => void = emptyFn;
 
-     
     constructor(
         readonly methodData: PaymentMethodData[],
         public details: PaymentDetailsInit
@@ -63,6 +63,7 @@ export class PaymentRequest {
 
         // 4. Process payment methods
         validatePaymentMethods(methodData);
+        validateAndroidTransactionInfo(methodData, ConstructorError);
 
         // 5. Process the total
         validateTotal(details.total, ConstructorError);
@@ -113,7 +114,7 @@ export class PaymentRequest {
 
                         return void 0;
                     })
-                     
+
                     .catch(reject);
             } else {
                 reject(new DOMException(PaymentsErrorEnum.InvalidStateError));
@@ -162,7 +163,6 @@ export class PaymentRequest {
         return platformMethod.data;
     }
 
-     
     private getAndroidPaymentMethodData(
         methodData: AndroidPaymentMethodDataDataInterface,
         details: PaymentDetailsInit
@@ -171,6 +171,8 @@ export class PaymentRequest {
             methodData.requestBillingAddress === true ||
             methodData.requestPayerName === true ||
             methodData.requestPayerPhone === true;
+
+        const totalPriceStatus = methodData.totalPriceStatus ?? defaultAndroidTransactionInfo.totalPriceStatus;
 
         return {
             ...defaultAndroidPaymentDataRequest,
@@ -183,6 +185,9 @@ export class PaymentRequest {
                 totalPrice: details.total.amount.value,
                 totalPriceLabel: details.total.label,
                 countryCode: methodData.countryCode,
+                totalPriceStatus,
+                ...(isDefined(methodData.checkoutOption) && { checkoutOption: methodData.checkoutOption }),
+                ...(isDefined(methodData.transactionId) && { transactionId: methodData.transactionId }),
             },
             allowedPaymentMethods: [
                 {
@@ -226,7 +231,6 @@ export class PaymentRequest {
         };
     }
 
-     
     private getIosPaymentMethodData(methodData: IosPaymentMethodDataDataInterface): IosPaymentDataRequest {
         // TODO: Add mappings for other systems if needed
         const supportedNetworkMap: Record<SupportedNetworkEnum, IosPKPaymentNetworksEnum> = {
@@ -277,7 +281,6 @@ export class PaymentRequest {
         };
     }
 
-     
     private getRequestedBillingFields(methodData: IosPaymentMethodDataDataInterface): IOSPKContactField[] {
         const requiredBillingFields: IOSPKContactField[] = [];
         if (methodData.requestBillingAddress ?? false) {
@@ -287,7 +290,6 @@ export class PaymentRequest {
         return requiredBillingFields;
     }
 
-     
     private getRequestedShippingFields(methodData: IosPaymentMethodDataDataInterface): IOSPKContactField[] {
         const requiredShippingFields: IOSPKContactField[] = [];
         if (methodData.requestPayerEmail ?? false) {

--- a/packages/react-native-payments/src/util/validate-android-transaction-info.util.ts
+++ b/packages/react-native-payments/src/util/validate-android-transaction-info.util.ts
@@ -1,0 +1,22 @@
+import { defaultAndroidTransactionInfo } from '../@standard/android/request/android-transaction-info';
+import { PaymentMethodNameEnum } from '../enum/payment-method-name.enum';
+
+import type { PaymentMethodData } from '../@standard/w3c/payment-method-data';
+import type { PaymentsError } from '../error/payments.error';
+import type { ClassType } from '@rnw-community/shared';
+
+export const validateAndroidTransactionInfo = (
+    methodData: PaymentMethodData[],
+    ErrorType: ClassType<PaymentsError>
+): void => {
+    const hasInvalidCheckoutOption = methodData.some(
+        paymentMethodData =>
+            paymentMethodData.supportedMethods === PaymentMethodNameEnum.AndroidPay &&
+            paymentMethodData.data.checkoutOption === 'COMPLETE_IMMEDIATE_PURCHASE' &&
+            (paymentMethodData.data.totalPriceStatus ?? defaultAndroidTransactionInfo.totalPriceStatus) !== 'FINAL'
+    );
+
+    if (hasInvalidCheckoutOption) {
+        throw new ErrorType(`checkoutOption 'COMPLETE_IMMEDIATE_PURCHASE' requires totalPriceStatus 'FINAL'`);
+    }
+};

--- a/packages/react-native-payments/src/util/validate-total.util.ts
+++ b/packages/react-native-payments/src/util/validate-total.util.ts
@@ -17,7 +17,7 @@ export const validateTotal = (total: PaymentItem, ErrorType: ClassType<PaymentsE
     }
 
     // Check that there is a total
-    if (!isDefined(total.amount) || !isDefined(total.amount.value) || Number(total.amount.value) === 0) {
+    if (!isDefined(total.amount) || !isDefined(total.amount.value)) {
         throw new ErrorType(`Missing required member(s): amount, label.`);
     }
 


### PR DESCRIPTION
Google Pay's `transactionInfo.totalPriceStatus` was pinned to `FINAL` by `defaultAndroidTransactionInfo` with no consumer-reachable override, and `validateTotal` rejected a `0.00` total outright. Together these blocked any flow where the final price is not known at request time.

## Changes

- `methodData.data` for Android Pay accepts three new optional [TransactionInfo](https://developers.google.com/pay/api/android/reference/request-objects#TransactionInfo) fields, forwarded verbatim into the serialized request:
  - `totalPriceStatus`: `'FINAL'` (unchanged default) | `'ESTIMATED'` | `'NOT_CURRENTLY_KNOWN'`
  - `checkoutOption`: `'DEFAULT'` | `'COMPLETE_IMMEDIATE_PURCHASE'`
  - `transactionId`
- Zero totals (`'0.00'`) are accepted: the W3C *check and canonicalize total amount* algorithm only rejects negative values, Google Pay's `totalPrice` format accepts `0.00`, and Apple Pay allows a zero grand total since iOS 12. The previous rejection also blocked the standard zero-total `canMakePayment()` capability-check idiom and $0 card-verification flows.
- New constructor-time validation: Google Pay only permits `COMPLETE_IMMEDIATE_PURCHASE` together with a `FINAL` `totalPriceStatus`, so any other combination throws a `ConstructorError` on every platform — surfacing the misconfiguration at construction instead of as a Google Pay `DEVELOPER_ERROR` at `show()` time on Android only.
- No native changes required: the Android module hands the serialized JSON directly to `PaymentDataRequest.fromJson`, which already understands all three status values.
- Tests cover the `FINAL` default, override serialization (including a zero total with `NOT_CURRENTLY_KNOWN`), the valid and invalid `checkoutOption` combinations, and zero-total acceptance. Readme documents the new options and includes `totalPriceStatus` in the Google Pay example.

Backward compatible: omitting the new fields produces byte-identical serialized requests, except that previously-rejected zero totals now construct successfully.

Out of scope, tracked separately: wiring `PaymentItem.pending` to `PKPaymentSummaryItemTypePending` on iOS (#370) and Google Pay merchant-initiated transaction objects for true deferred flows (#371).

Closes #368


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support `totalPriceStatus`, `checkoutOption`, and zero totals in Google Pay payments
> - Adds `totalPriceStatus` (defaults to `FINAL`), `checkoutOption`, and `transactionId` as optional fields in `AndroidGenericPaymentMethodDataInterface` and serializes them into the `transactionInfo` sent to `NativePayments`.
> - Adds `validateAndroidTransactionInfo` to enforce that `checkoutOption: 'COMPLETE_IMMEDIATE_PURCHASE'` is only used with `totalPriceStatus: 'FINAL'`, throwing a `ConstructorError` otherwise.
> - Removes the zero-value rejection in [`validate-total.util.ts`](https://github.com/rnw-community/rnw-community/pull/401/files#diff-79c9cfcddc4c11d023a7f5f12eef1e5c6bf79caef102cc92ae97dd8a56b43a23), allowing totals like `'0.00'`.
> - Behavioral Change: `PaymentRequest` construction now throws when `checkoutOption` is `COMPLETE_IMMEDIATE_PURCHASE` and `totalPriceStatus` is not `FINAL`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0fa3ec3. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->