### PR TITLE
chore(react-native-payments): add maestro-e2e agent skill

### DIFF
--- a/.agents/skills/maestro-e2e/LICENSE
+++ b/.agents/skills/maestro-e2e/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Raphael Barbosa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/maestro-e2e/README.md
+++ b/.agents/skills/maestro-e2e/README.md
@@ -1,0 +1,73 @@
+# Maestro Skills
+
+Comprehensive Maestro E2E UI testing skill for AI coding assistants.
+
+Vendored from [raphaelbarbosaqwerty/maestro-dev-skills](https://github.com/raphaelbarbosaqwerty/maestro-dev-skills) (MIT, see `LICENSE`), with [rules/rnw-community.md](rules/rnw-community.md) added on top for this repository's package layout, run scripts, fleet labels, and artifact locations.
+
+## Installation
+
+```bash
+npx skills add raphaelbarbosaqwerty/maestro-dev-skills
+```
+
+Or via npm:
+
+```bash
+npm install @raphaelbarbosaqwerty/maestro-skills
+```
+
+## Platforms
+
+- ✅ iOS (Simulator)
+- ✅ Android (Emulator)
+- ✅ Flutter
+- ✅ React Native
+- ✅ Web (Chromium)
+
+## Usage
+
+This skill provides comprehensive documentation for AI coding assistants to generate Maestro E2E tests. The main entry point is `SKILL.md`.
+
+### Structure
+
+```text
+├── SKILL.md              # Main skill file with overview
+└── rules/
+    ├── installation.md
+    ├── test-structure.md
+    ├── commands.md       # 40+ Maestro commands
+    ├── selectors.md
+    ├── assertions.md
+    ├── interactions.md
+    ├── permissions.md
+    ├── debugging.md
+    ├── screenshots.md
+    ├── ci-integration.md
+    ├── best-practices.md
+    ├── rnw-community.md   # this repository's package, scripts, fleet labels
+    ├── platforms/
+    │   ├── android.md
+    │   ├── ios.md
+    │   ├── flutter.md
+    │   ├── react-native.md
+    │   └── web.md
+    └── advanced/
+        ├── parameters.md
+        ├── conditions.md
+        ├── nested-flows.md
+        ├── javascript.md
+        ├── waiting.md
+        └── repeat-retry.md
+```
+
+## Key Features
+
+- **40+ Commands** - Complete reference for all Maestro commands
+- **Platform-Specific** - Detailed guides for each platform
+- **Flutter Integration** - Semantics.identifier patterns
+- **CI/CD Ready** - GitHub Actions, Maestro Cloud integration
+- **Best Practices** - Naming conventions, project structure
+
+## License
+
+MIT

--- a/.agents/skills/maestro-e2e/SKILL.md
+++ b/.agents/skills/maestro-e2e/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: maestro-e2e
+description: E2E UI testing with Maestro for iOS, Android, Flutter, React Native, and Web
+metadata:
+  tags: maestro, e2e, testing, ui, automation, flutter, react-native, ios, android, web
+---
+
+## When to use
+
+Use this skill whenever you are:
+
+- Creating E2E, UI, or integration tests
+- Testing login, registration, or navigation flows
+- Handling permission dialogs (camera, location, notifications)
+- Debugging test failures or exploring UI hierarchy
+- Working with Maestro test files (.yaml)
+
+## Captions
+
+When dealing with native permission dialogs, load the [./rules/permissions.md](./rules/permissions.md) file for platform-specific information.
+
+When working with Flutter apps, load the [./rules/platforms/flutter.md](./rules/platforms/flutter.md) file for Semantics patterns.
+
+When testing `packages/react-native-payments-example` in this repo, load the [./rules/rnw-community.md](./rules/rnw-community.md) file first for the package's app targets, appIds, flow layout, local run scripts, fleet labels, and artifact locations.
+
+## How to use
+
+Read individual rule files for detailed explanations and code examples:
+
+### This repository
+
+- [rules/rnw-community.md](rules/rnw-community.md) - `packages/react-native-payments-example` app targets, appIds, flow layout, local run scripts (`yarn e2e:ios:bare` and siblings), self-hosted fleet labels, and CI artifact locations
+
+### Core
+
+- [rules/installation.md](rules/installation.md) - Installing Maestro on macOS, Linux, and Windows
+- [rules/test-structure.md](rules/test-structure.md) - YAML test structure, appId, env variables, and flow definition
+- [rules/commands.md](rules/commands.md) - Complete reference of 40+ Maestro commands
+- [rules/selectors.md](rules/selectors.md) - Element targeting with id, text, index, and matchers
+- [rules/assertions.md](rules/assertions.md) - assertVisible, assertNotVisible, assertTrue, and AI assertions
+- [rules/interactions.md](rules/interactions.md) - tapOn, inputText, scroll, swipe, and gesture commands
+- [rules/permissions.md](rules/permissions.md) - iOS vs Android permission configuration and dialog handling
+
+### Platforms
+
+- [rules/platforms/android.md](rules/platforms/android.md) - Android-specific: ADB, permission dialogs, emulators
+- [rules/platforms/ios.md](rules/platforms/ios.md) - iOS-specific: auto-dismiss dialogs, simulators, limitations
+- [rules/platforms/flutter.md](rules/platforms/flutter.md) - Flutter integration using Semantics and identifier
+- [rules/platforms/react-native.md](rules/platforms/react-native.md) - React Native with testID and accessibilityLabel
+- [rules/platforms/web.md](rules/platforms/web.md) - Desktop browser testing with Chromium
+
+### Advanced
+
+- [rules/advanced/parameters.md](rules/advanced/parameters.md) - Environment variables, external params, ${} syntax
+- [rules/advanced/conditions.md](rules/advanced/conditions.md) - Conditional execution with when: visible, platform
+- [rules/advanced/nested-flows.md](rules/advanced/nested-flows.md) - Reusable subflows with runFlow command
+- [rules/advanced/javascript.md](rules/advanced/javascript.md) - evalScript, runScript, and GraalJS support
+- [rules/advanced/waiting.md](rules/advanced/waiting.md) - extendedWaitUntil, waitForAnimationToEnd
+- [rules/advanced/repeat-retry.md](rules/advanced/repeat-retry.md) - Repeat and retry patterns for flaky tests
+
+### Additional
+
+- [rules/debugging.md](rules/debugging.md) - Maestro Studio, hierarchy inspection, troubleshooting
+- [rules/screenshots.md](rules/screenshots.md) - Screenshots, video recording, and visual evidence
+- [rules/ci-integration.md](rules/ci-integration.md) - GitHub Actions, GitLab CI, Maestro Cloud
+- [rules/best-practices.md](rules/best-practices.md) - Semantic identifiers, atomic tests, project structure

--- a/.agents/skills/maestro-e2e/package.json
+++ b/.agents/skills/maestro-e2e/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@raphaelbarbosaqwerty/maestro-skills",
+  "version": "1.0.0",
+  "description": "Maestro E2E UI testing skill for iOS, Android, Flutter, React Native, and Web",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/raphaelbarbosaqwerty/maestro-dev-skills"
+  },
+  "keywords": [
+    "maestro",
+    "e2e",
+    "testing",
+    "flutter",
+    "react-native",
+    "ios",
+    "android",
+    "skills"
+  ],
+  "author": "Raphael Barbosa",
+  "license": "MIT",
+  "files": [
+    "SKILL.md",
+    "rules"
+  ]
+}

--- a/.agents/skills/maestro-e2e/rules/advanced/conditions.md
+++ b/.agents/skills/maestro-e2e/rules/advanced/conditions.md
@@ -1,0 +1,166 @@
+---
+name: conditions
+description: Conditional execution with when visible, platform
+metadata:
+  tags: conditions, when, visible, platform, conditional
+---
+
+## Basic Condition
+
+Execute commands only when a condition is met:
+
+```yaml
+- runFlow:
+    when:
+      visible: "Cookie Banner"
+    commands:
+      - tapOn: "Accept"
+```
+
+## Condition Types
+
+### Visible
+
+Run when element is visible:
+
+```yaml
+- runFlow:
+    when:
+      visible: "Login"
+    commands:
+      - tapOn:
+          id: "login_button"
+```
+
+### Not Visible
+
+Run when element is NOT visible:
+
+```yaml
+- runFlow:
+    when:
+      notVisible: "Loading"
+    commands:
+      - assertVisible: "Dashboard"
+```
+
+### Platform
+
+Run on specific platform:
+
+```yaml
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn: "Allow" # Android permission dialog
+```
+
+```yaml
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - assertVisible: "iOS Feature"
+```
+
+### JavaScript Expression
+
+Run based on JavaScript evaluation:
+
+```yaml
+- runFlow:
+    when:
+      true: ${count > 5}
+    commands:
+      - tapOn: "Load More"
+```
+
+## Combining Conditions
+
+Use `and` for multiple conditions:
+
+```yaml
+- runFlow:
+    when:
+      visible: "Premium"
+      platform: iOS
+    commands:
+      - tapOn: "Subscribe"
+```
+
+## Subflow with Condition
+
+```yaml
+- runFlow:
+    when:
+      visible: "Login"
+    file: login_flow.yaml
+    env:
+      USERNAME: test@example.com
+```
+
+## Common Patterns
+
+### Skip Onboarding
+
+```yaml
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+```
+
+### Handle Cookie Banner
+
+```yaml
+- runFlow:
+    when:
+      visible: "Accept Cookies"
+    commands:
+      - tapOn: "Accept All"
+```
+
+### Platform Permission Dialogs
+
+```yaml
+# iOS auto-dismisses, Android needs tap
+- runFlow:
+    when:
+      platform: Android
+      visible: "Allow"
+    commands:
+      - tapOn: "While using the app"
+```
+
+### Feature Flags
+
+```yaml
+- runFlow:
+    when:
+      visible: "New Feature"
+    commands:
+      - tapOn: "Try It"
+      - assertVisible: "Feature Enabled"
+```
+
+### Error Recovery
+
+```yaml
+- runFlow:
+    when:
+      visible: "Error occurred"
+    commands:
+      - tapOn: "Retry"
+```
+
+## Negating Conditions
+
+```yaml
+- runFlow:
+    when:
+      notVisible: "Premium Badge"
+    commands:
+      - tapOn: "Upgrade"
+```

--- a/.agents/skills/maestro-e2e/rules/advanced/javascript.md
+++ b/.agents/skills/maestro-e2e/rules/advanced/javascript.md
@@ -1,0 +1,156 @@
+---
+name: javascript
+description: evalScript, runScript, and GraalJS support
+metadata:
+  tags: javascript, evalScript, runScript, graaljs, http
+---
+
+## JavaScript in Maestro
+
+Maestro supports JavaScript for custom logic, HTTP requests, and data manipulation.
+
+## Inline Script (evalScript)
+
+```yaml
+- evalScript: ${output.value = 'Hello World'}
+- inputText: ${output.value}
+```
+
+Multi-line:
+
+```yaml
+- evalScript: |
+    const timestamp = new Date().getTime();
+    output.uniqueId = 'user_' + timestamp;
+- inputText: ${output.uniqueId}
+```
+
+## External Script (runScript)
+
+```yaml
+- runScript:
+    file: scripts/generate_data.js
+```
+
+### Script File
+
+```javascript
+// scripts/generate_data.js
+const randomEmail = "user_" + Math.floor(Math.random() * 10000) + "@test.com";
+output.email = randomEmail;
+output.timestamp = new Date().toISOString();
+```
+
+### Use Output
+
+```yaml
+- runScript:
+    file: scripts/generate_data.js
+- inputText: ${output.email}
+```
+
+## HTTP Requests
+
+```javascript
+// scripts/fetch_user.js
+const response = http.get("https://api.example.com/user/1");
+output.user = JSON.parse(response.body);
+```
+
+### POST Request
+
+```javascript
+const response = http.post("https://api.example.com/login", {
+  headers: {
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    email: "test@example.com",
+    password: "secret",
+  }),
+});
+output.token = JSON.parse(response.body).token;
+```
+
+## The `output` Object
+
+Any property set on `output` is available in subsequent steps:
+
+```yaml
+- evalScript: ${output.name = 'John'}
+- assertVisible: "Hello, ${output.name}"
+```
+
+## Variable Access
+
+Access flow parameters in scripts:
+
+```yaml
+env:
+  API_URL: https://api.example.com
+---
+- runScript:
+    file: scripts/api_test.js
+```
+
+```javascript
+// scripts/api_test.js
+const apiUrl = API_URL; // From env
+const response = http.get(apiUrl + "/health");
+output.healthy = response.status === 200;
+```
+
+## Supported Features
+
+| Feature               | Supported |
+| --------------------- | --------- |
+| String manipulation   | ✅        |
+| Math operations       | ✅        |
+| Date/Time             | ✅        |
+| JSON parse/stringify  | ✅        |
+| HTTP requests         | ✅        |
+| Arrays/Objects        | ✅        |
+| require/import        | ❌        |
+| File system access    | ❌        |
+| External npm packages | ❌        |
+
+## Runtime Options
+
+### Rhino (Default)
+
+Standard JavaScript runtime.
+
+### GraalJS
+
+Enable for better performance and ES6+ features:
+
+```bash
+export MAESTRO_USE_GRAALJS=true
+maestro test flow.yaml
+```
+
+## Common Patterns
+
+### Generate Random Data
+
+```javascript
+output.randomNumber = Math.floor(Math.random() * 1000);
+output.randomString = Math.random().toString(36).substring(7);
+```
+
+### API Validation
+
+```javascript
+const response = http.get("https://api.example.com/products");
+const products = JSON.parse(response.body);
+output.productCount = products.length;
+output.hasProducts = products.length > 0;
+```
+
+### Date Manipulation
+
+```javascript
+const now = new Date();
+output.today = now.toISOString().split("T")[0];
+output.timestamp = now.getTime();
+```

--- a/.agents/skills/maestro-e2e/rules/advanced/nested-flows.md
+++ b/.agents/skills/maestro-e2e/rules/advanced/nested-flows.md
@@ -1,0 +1,174 @@
+---
+name: nested-flows
+description: Reusable subflows with runFlow command
+metadata:
+  tags: subflows, runFlow, reusable, modular
+---
+
+## What are Subflows?
+
+Subflows are reusable test files that can be called from other flows. They help:
+
+- Reduce code duplication
+- Create modular test suites
+- Share common steps (login, navigation)
+
+## Basic Usage
+
+### Create a Subflow
+
+```yaml
+# subflows/login.yaml
+appId: com.example.myApp
+env:
+  USERNAME: ${USERNAME || 'default@example.com'}
+  PASSWORD: ${PASSWORD || 'password123'}
+---
+- tapOn:
+    id: "email_field"
+- inputText: ${USERNAME}
+- tapOn:
+    id: "password_field"
+- inputText: ${PASSWORD}
+- hideKeyboard
+- tapOn:
+    id: "login_button"
+- assertVisible: "Dashboard"
+```
+
+### Call the Subflow
+
+```yaml
+# main_test.yaml
+appId: com.example.myApp
+---
+- launchApp:
+    clearState: true
+
+- runFlow:
+    file: subflows/login.yaml
+    env:
+      USERNAME: myuser@example.com
+      PASSWORD: mypassword
+
+- tapOn: "Settings"
+```
+
+## Passing Parameters
+
+Override subflow defaults:
+
+```yaml
+- runFlow:
+    file: subflows/login.yaml
+    env:
+      USERNAME: admin@example.com
+      PASSWORD: adminpass
+```
+
+## Conditional Subflows
+
+Run only when condition is met:
+
+```yaml
+- runFlow:
+    when:
+      visible: "Login"
+    file: subflows/login.yaml
+```
+
+## Inline Commands
+
+Run commands inline (without separate file):
+
+```yaml
+- runFlow:
+    when:
+      visible: "Cookie Banner"
+    commands:
+      - tapOn: "Accept"
+```
+
+## Directory Structure
+
+```
+e2e/
+├── flows/
+│   ├── login_test.yaml
+│   ├── checkout_test.yaml
+│   └── profile_test.yaml
+└── subflows/
+    ├── login.yaml
+    ├── navigate_to_cart.yaml
+    └── fill_address.yaml
+```
+
+## Common Subflows
+
+### Login
+
+```yaml
+# subflows/login.yaml
+---
+- tapOn:
+    id: "email_field"
+- inputText: ${USERNAME}
+- tapOn:
+    id: "password_field"
+- inputText: ${PASSWORD}
+- hideKeyboard
+- tapOn:
+    id: "login_button"
+```
+
+### Navigation
+
+```yaml
+# subflows/navigate_to_settings.yaml
+---
+- tapOn:
+    id: "menu_button"
+- tapOn: "Settings"
+- assertVisible: "Settings"
+```
+
+### Logout
+
+```yaml
+# subflows/logout.yaml
+---
+- tapOn:
+    id: "menu_button"
+- scroll
+- tapOn: "Logout"
+- assertVisible: "Login"
+```
+
+## Chaining Subflows
+
+```yaml
+appId: com.example.myApp
+---
+- launchApp:
+    clearState: true
+
+- runFlow:
+    file: subflows/login.yaml
+
+- runFlow:
+    file: subflows/navigate_to_settings.yaml
+
+- runFlow:
+    file: subflows/change_password.yaml
+
+- runFlow:
+    file: subflows/logout.yaml
+```
+
+## Subflow Best Practices
+
+1. **Single responsibility** - Each subflow does one thing
+2. **Use parameters** - Make subflows configurable
+3. **Include assertions** - Verify expected state
+4. **Organize in folders** - Group by feature or type
+5. **Document dependencies** - Note required parameters

--- a/.agents/skills/maestro-e2e/rules/advanced/parameters.md
+++ b/.agents/skills/maestro-e2e/rules/advanced/parameters.md
@@ -1,0 +1,149 @@
+---
+name: parameters
+description: Environment variables, external params, ${} syntax
+metadata:
+  tags: parameters, env, variables, external, cli
+---
+
+## Inline Parameters
+
+Define in the flow header:
+
+```yaml
+appId: com.example.myApp
+env:
+  USERNAME: test@example.com
+  PASSWORD: secret123
+  API_URL: https://api.example.com
+---
+- inputText: ${USERNAME}
+```
+
+## External Parameters (CLI)
+
+Pass values when running tests:
+
+```bash
+maestro test -e USERNAME=john@example.com -e PASSWORD=mypassword flow.yaml
+```
+
+## Default Values
+
+Use JavaScript logical OR for defaults:
+
+```yaml
+env:
+  USERNAME: ${USERNAME || 'default@example.com'}
+  TIMEOUT: ${TIMEOUT || 5000}
+```
+
+If `USERNAME` is passed via CLI, it's used. Otherwise, default applies.
+
+## Shell Environment Variables
+
+Variables prefixed with `MAESTRO_` are automatically available:
+
+```bash
+export MAESTRO_API_KEY=abc123
+```
+
+In flow:
+
+```yaml
+- runScript:
+    file: api_test.js
+    env:
+      API_KEY: ${MAESTRO_API_KEY}
+```
+
+## Using Parameters
+
+### In Text Input
+
+```yaml
+- inputText: ${USERNAME}
+```
+
+### In Assertions
+
+```yaml
+- assertVisible: "Welcome, ${USERNAME}"
+```
+
+### In JavaScript
+
+```yaml
+- evalScript: |
+    const url = '${API_URL}/users';
+    output.fullUrl = url;
+```
+
+### In Subflows
+
+```yaml
+- runFlow:
+    file: login.yaml
+    env:
+      USERNAME: admin@example.com
+      PASSWORD: admin123
+```
+
+## Parameter Scope
+
+Parameters flow from parent to child:
+
+```yaml
+# main_flow.yaml
+env:
+  BASE_URL: https://example.com
+---
+- runFlow:
+    file: child_flow.yaml
+    # child inherits BASE_URL
+```
+
+Child can override:
+
+```yaml
+# child_flow.yaml
+env:
+  BASE_URL: ${BASE_URL || 'https://default.com'}
+```
+
+## CI/CD Pattern
+
+```yaml
+# flow.yaml
+appId: com.example.myApp
+env:
+  USERNAME: ${USERNAME}
+  PASSWORD: ${PASSWORD}
+  ENV: ${ENV || 'staging'}
+---
+# tests...
+```
+
+```bash
+# CI pipeline
+maestro test \
+  -e USERNAME=$CI_TEST_USER \
+  -e PASSWORD=$CI_TEST_PASSWORD \
+  -e ENV=production \
+  flow.yaml
+```
+
+## Security Note
+
+Never commit sensitive values in flow files. Use external parameters:
+
+```yaml
+# ❌ Don't do this
+env:
+  API_KEY: sk_live_abc123
+
+# ✅ Do this
+env:
+  API_KEY: ${API_KEY}
+```
+
+Pass securely via CI secrets or environment.

--- a/.agents/skills/maestro-e2e/rules/advanced/repeat-retry.md
+++ b/.agents/skills/maestro-e2e/rules/advanced/repeat-retry.md
@@ -1,0 +1,164 @@
+---
+name: repeat-retry
+description: Repeat and retry patterns for flaky tests
+metadata:
+  tags: repeat, retry, loop, flaky
+---
+
+## repeat
+
+Execute commands multiple times:
+
+```yaml
+- repeat:
+    times: 3
+    commands:
+      - tapOn: "Next"
+      - takeScreenshot: "slide_${maestro.repeating.index}"
+```
+
+### Access Index
+
+Use `${maestro.repeating.index}` (0-based):
+
+```yaml
+- repeat:
+    times: 5
+    commands:
+      - tapOn:
+          id: "item_${maestro.repeating.index}"
+```
+
+### Until Visible
+
+Repeat until element appears:
+
+```yaml
+- repeat:
+    whileVisible: "Load More"
+    commands:
+      - tapOn: "Load More"
+      - extendedWaitUntil:
+          notVisible: "Loading..."
+          timeout: 5000
+```
+
+### Until Not Visible
+
+Repeat until element disappears:
+
+```yaml
+- repeat:
+    whileNotVisible: "Empty State"
+    commands:
+      - tapOn:
+          id: "delete_item"
+      - waitForAnimationToEnd
+```
+
+## retry
+
+Retry a block of commands on failure:
+
+```yaml
+- retry:
+    maxRetries: 3
+    commands:
+      - tapOn: "Retry Connection"
+      - extendedWaitUntil:
+          visible: "Connected"
+          timeout: 5000
+```
+
+### With Condition
+
+```yaml
+- retry:
+    maxRetries: 5
+    onlyIf:
+      visible: "Error"
+    commands:
+      - tapOn: "Try Again"
+```
+
+## Common Patterns
+
+### Pagination Loop
+
+```yaml
+- repeat:
+    times: 10
+    commands:
+      - scrollUntilVisible:
+          element: "End of list"
+          timeout: 2000
+          optional: true
+```
+
+### Carousel Swipe
+
+```yaml
+- repeat:
+    times: 4
+    commands:
+      - swipe:
+          direction: LEFT
+      - takeScreenshot: "carousel_${maestro.repeating.index}"
+```
+
+### Clear Notifications
+
+```yaml
+- repeat:
+    whileVisible: "Notification"
+    commands:
+      - swipe:
+          direction: RIGHT
+          element: "Notification"
+```
+
+### Retry Network Operation
+
+```yaml
+- retry:
+    maxRetries: 3
+    commands:
+      - tapOn: "Fetch Data"
+      - extendedWaitUntil:
+          visible: "Data Loaded"
+          timeout: 10000
+```
+
+### Delete All Items
+
+```yaml
+- repeat:
+    whileVisible: "Delete"
+    commands:
+      - tapOn: "Delete"
+      - tapOn: "Confirm"
+      - waitForAnimationToEnd
+```
+
+## Combining repeat and retry
+
+```yaml
+- repeat:
+    times: 5
+    commands:
+      - retry:
+          maxRetries: 2
+          commands:
+            - tapOn:
+                id: "item_${maestro.repeating.index}"
+            - assertVisible: "Item Details"
+      - back
+```
+
+## Best Practices
+
+1. **Set reasonable limits** - Prevent infinite loops
+2. **Add waits in loops** - Allow UI to update
+3. **Use whileVisible** - For dynamic content
+4. **Combine with retry** - For network stability
+5. **Take screenshots** - Debug loop issues

--- a/.agents/skills/maestro-e2e/rules/advanced/waiting.md
+++ b/.agents/skills/maestro-e2e/rules/advanced/waiting.md
@@ -1,0 +1,115 @@
+---
+name: waiting
+description: extendedWaitUntil, waitForAnimationToEnd
+metadata:
+  tags: wait, timeout, animation, loading
+---
+
+## extendedWaitUntil
+
+Wait for an element with custom timeout (default is ~5 seconds):
+
+```yaml
+- extendedWaitUntil:
+    visible: "Dashboard"
+    timeout: 15000 # 15 seconds
+```
+
+### Wait for Not Visible
+
+```yaml
+- extendedWaitUntil:
+    notVisible: "Loading..."
+    timeout: 10000
+```
+
+### Optional Wait
+
+Don't fail if timeout expires:
+
+```yaml
+- extendedWaitUntil:
+    visible: "Optional Element"
+    timeout: 5000
+    optional: true
+```
+
+## waitForAnimationToEnd
+
+Wait for all UI animations to complete:
+
+```yaml
+- tapOn: "Animate"
+- waitForAnimationToEnd
+- assertVisible: "Animation Complete"
+```
+
+Useful after:
+
+- Page transitions
+- Modal open/close
+- Loading spinners
+- Content refresh
+
+## Common Patterns
+
+### Wait for Loading
+
+```yaml
+- tapOn: "Load Data"
+- extendedWaitUntil:
+    visible: "Loading..."
+    timeout: 3000
+    optional: true
+- extendedWaitUntil:
+    notVisible: "Loading..."
+    timeout: 30000
+- assertVisible: "Data loaded"
+```
+
+### Wait and Assert
+
+```yaml
+- tapOn: "Submit"
+- extendedWaitUntil:
+    visible: "Success"
+    timeout: 10000
+- assertVisible: "Success"
+```
+
+### Slow Network Handling
+
+```yaml
+- launchApp
+- extendedWaitUntil:
+    visible: "Home"
+    timeout: 30000 # Long timeout for slow networks
+```
+
+### Wait for Element After Navigation
+
+```yaml
+- tapOn: "Next Page"
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible: "Page Title"
+    timeout: 5000
+- assertVisible: "Page Title"
+```
+
+## Best Practices
+
+1. **Use reasonable timeouts** - Too short = flaky tests, too long = slow tests
+2. **Combine with assertions** - Wait then verify
+3. **Handle loading states** - Wait for loading to appear AND disappear
+4. **Use waitForAnimationToEnd** - After transitions before interacting
+
+## Timeout Guidelines
+
+| Scenario        | Recommended Timeout |
+| --------------- | ------------------- |
+| Page navigation | 5000-10000ms        |
+| API response    | 10000-15000ms       |
+| File upload     | 30000-60000ms       |
+| Login/Auth      | 10000-15000ms       |
+| App launch      | 15000-30000ms       |

--- a/.agents/skills/maestro-e2e/rules/assertions.md
+++ b/.agents/skills/maestro-e2e/rules/assertions.md
@@ -1,0 +1,107 @@
+---
+name: assertions
+description: assertVisible, assertNotVisible, assertTrue, and AI assertions
+metadata:
+  tags: assertions, assert, visible, not-visible, ai
+---
+
+## assertVisible
+
+Assert that an element is visible on screen.
+
+```yaml
+# By text
+- assertVisible: "Welcome"
+
+# By ID
+- assertVisible:
+    id: "dashboard_header"
+
+# With timeout (milliseconds)
+- assertVisible:
+    text: "Loading complete"
+    timeout: 10000
+```
+
+## assertNotVisible
+
+Assert that an element is NOT visible.
+
+```yaml
+- assertNotVisible: "Error message"
+
+- assertNotVisible:
+    id: "loading_spinner"
+```
+
+## assertTrue
+
+Assert a JavaScript expression evaluates to true.
+
+```yaml
+# Simple condition
+- assertTrue: ${count > 0}
+
+# With stored output
+- copyTextFrom:
+    id: "price_label"
+- assertTrue: ${output.price.includes("$")}
+```
+
+## AI-Powered Assertions
+
+### assertWithAI
+
+Use natural language to describe expected state:
+
+```yaml
+- assertWithAI: "The shopping cart shows 3 items"
+- assertWithAI: "User profile picture is visible in the header"
+- assertWithAI: "The form has been submitted successfully"
+```
+
+### assertNoDefectsWithAI
+
+Check for visual defects and UI issues:
+
+```yaml
+- assertNoDefectsWithAI
+```
+
+Detects:
+
+- Overlapping elements
+- Truncated text
+- Broken layouts
+- Missing images
+
+## Assertion Patterns
+
+### Wait Then Assert
+
+```yaml
+- extendedWaitUntil:
+    visible: "Dashboard"
+    timeout: 15000
+- assertVisible: "Welcome back"
+```
+
+### Multi-Element Assertions
+
+```yaml
+- assertVisible: "Username"
+- assertVisible: "Password"
+- assertVisible: "Login"
+- assertNotVisible: "Error"
+```
+
+### Conditional Assertion
+
+```yaml
+- runFlow:
+    when:
+      visible: "Cookie Banner"
+    commands:
+      - tapOn: "Accept"
+- assertNotVisible: "Cookie Banner"
+```

--- a/.agents/skills/maestro-e2e/rules/best-practices.md
+++ b/.agents/skills/maestro-e2e/rules/best-practices.md
@@ -1,0 +1,191 @@
+---
+name: best-practices
+description: Semantic identifiers, atomic tests, project structure
+metadata:
+  tags: best-practices, patterns, structure, naming
+---
+
+## Use Semantic Identifiers
+
+Always add testable identifiers to UI elements:
+
+### Flutter
+
+```dart
+Semantics(
+  identifier: 'login_submit_button',
+  child: ElevatedButton(...),
+)
+```
+
+### React Native
+
+```jsx
+<TouchableOpacity testID="login_submit_button">
+```
+
+### Native
+
+- iOS: `accessibilityIdentifier`
+- Android: `android:contentDescription` or `resource-id`
+
+## Naming Convention
+
+Use snake*case with pattern: `{screen}*{element}\_{type}`
+
+```
+login_email_field
+login_password_field
+login_submit_button
+dashboard_profile_card
+settings_logout_button
+```
+
+## Atomic Tests
+
+Each test should be **independent** and **self-contained**:
+
+```yaml
+# ✅ Good - Independent test
+appId: com.example.app
+---
+- launchApp:
+    clearState: true  # Fresh start
+- runFlow: subflows/login.yaml
+- tapOn: "Settings"
+- assertVisible: "Settings"
+
+# ❌ Bad - Depends on previous test state
+appId: com.example.app
+---
+- tapOn: "Settings"  # Assumes already logged in
+```
+
+## Use clearState
+
+Always start with clean app state:
+
+```yaml
+- launchApp:
+    clearState: true
+```
+
+## Project Structure
+
+```
+project/
+├── e2e/
+│   ├── flows/
+│   │   ├── auth/
+│   │   │   ├── login_success.yaml
+│   │   │   ├── login_invalid.yaml
+│   │   │   └── register.yaml
+│   │   ├── checkout/
+│   │   │   ├── add_to_cart.yaml
+│   │   │   └── complete_purchase.yaml
+│   │   └── profile/
+│   │       └── update_profile.yaml
+│   └── subflows/
+│       ├── login.yaml
+│       ├── navigate_to_cart.yaml
+│       └── fill_address.yaml
+└── .agent/
+    └── workflows/
+        ├── maestro-test.md
+        └── maestro-run.md
+```
+
+## Subflows for Reusability
+
+Extract common patterns:
+
+```yaml
+# subflows/login.yaml
+---
+- tapOn:
+    id: "email_field"
+- inputText: ${USERNAME}
+- tapOn:
+    id: "password_field"
+- inputText: ${PASSWORD}
+- hideKeyboard
+- tapOn:
+    id: "submit_button"
+- assertVisible: "Dashboard"
+```
+
+Use in flows:
+
+```yaml
+- runFlow:
+    file: subflows/login.yaml
+    env:
+      USERNAME: test@example.com
+```
+
+## Always Hide Keyboard
+
+Before tapping elements that might be obscured:
+
+```yaml
+- inputText: "password"
+- hideKeyboard
+- tapOn:
+    id: "submit"
+```
+
+## Take Screenshots at Key Points
+
+```yaml
+- takeScreenshot: "01_before_action"
+- tapOn: "Submit"
+- takeScreenshot: "02_after_action"
+```
+
+## Use extendedWaitUntil for Async
+
+```yaml
+- tapOn: "Load Data"
+- extendedWaitUntil:
+    visible: "Data Loaded"
+    timeout: 15000
+```
+
+## Handle Platform Differences
+
+```yaml
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn: "Allow" # Android permission
+```
+
+## Environment Variables for Secrets
+
+```yaml
+# Never hardcode credentials
+env:
+  USERNAME: ${USERNAME}
+  PASSWORD: ${PASSWORD}
+---
+- inputText: ${USERNAME}
+```
+
+Pass via CLI:
+
+```bash
+maestro test -e USERNAME=test -e PASSWORD=secret flow.yaml
+```
+
+## Document Test Purpose
+
+Add comments at the top:
+
+```yaml
+# Test: Verify successful login with valid credentials
+# Preconditions: None (uses clearState)
+# Expected: User reaches Dashboard
+appId: com.example.app
+---
+```

--- a/.agents/skills/maestro-e2e/rules/ci-integration.md
+++ b/.agents/skills/maestro-e2e/rules/ci-integration.md
@@ -1,0 +1,175 @@
+---
+name: ci-integration
+description: GitHub Actions, GitLab CI, Maestro Cloud
+metadata:
+  tags: ci, cd, github-actions, gitlab, cloud
+---
+
+The GitHub-hosted `runs-on` values and app names below are generic reference material, not this
+repository's configuration. For this repository's actual self-hosted fleet labels, workflow file
+names, and artifact policy, see [rnw-community.md](rnw-community.md).
+
+## GitHub Actions
+
+### Basic Setup
+
+```yaml
+# .github/workflows/e2e.yml
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+
+      - name: Start iOS Simulator
+        run: |
+          xcrun simctl boot "iPhone 15 Pro"
+          xcrun simctl bootstatus "iPhone 15 Pro" -b
+
+      - name: Build iOS App
+        run: |
+          xcodebuild -workspace MyApp.xcworkspace \
+            -scheme MyApp \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 15 Pro' \
+            -derivedDataPath build
+
+      - name: Install App
+        run: |
+          xcrun simctl install booted build/Build/Products/Debug-iphonesimulator/MyApp.app
+
+      - name: Run E2E Tests
+        run: maestro test e2e/
+
+      - name: Upload Screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-screenshots
+          path: maestro_output/
+```
+
+### Android
+
+```yaml
+jobs:
+  e2e-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+
+      - name: Set up Android
+        uses: android-actions/setup-android@v3
+
+      - name: Run Android Emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 31
+          script: maestro test e2e/
+```
+
+## GitLab CI
+
+```yaml
+# .gitlab-ci.yml
+e2e:
+  image: mobile-dev-inc/maestro:latest
+  script:
+    - maestro test e2e/
+  artifacts:
+    when: always
+    paths:
+      - maestro_output/
+```
+
+## Maestro Cloud
+
+Run tests in the cloud without local infrastructure:
+
+```bash
+maestro cloud --apiKey $MAESTRO_API_KEY app.apk e2e/
+```
+
+### CI Integration
+
+```yaml
+- name: Run on Maestro Cloud
+  env:
+    MAESTRO_CLOUD_API_KEY: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
+  run: |
+    maestro cloud \
+      --apiKey $MAESTRO_CLOUD_API_KEY \
+      --app app.apk \
+      e2e/
+```
+
+## Environment Variables in CI
+
+```yaml
+- name: Run E2E Tests
+  env:
+    MAESTRO_TEST_USER: ${{ secrets.TEST_USER }}
+    MAESTRO_TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+  run: |
+    maestro test \
+      -e USERNAME=$MAESTRO_TEST_USER \
+      -e PASSWORD=$MAESTRO_TEST_PASSWORD \
+      e2e/
+```
+
+## Parallelization
+
+Run tests in parallel for faster execution:
+
+```bash
+maestro test --shards 4 --shard-index 0 e2e/
+maestro test --shards 4 --shard-index 1 e2e/
+maestro test --shards 4 --shard-index 2 e2e/
+maestro test --shards 4 --shard-index 3 e2e/
+```
+
+### GitHub Actions Matrix
+
+```yaml
+jobs:
+  e2e:
+    strategy:
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+      - run: maestro test --shards 4 --shard-index ${{ matrix.shard }} e2e/
+```
+
+## Retry Failed Tests
+
+```bash
+maestro test --retries 2 e2e/
+```
+
+## Output Formats
+
+### JUnit XML (for CI reporting)
+
+```bash
+maestro test --format junit e2e/
+```
+
+Generates `maestro-report.xml` compatible with most CI systems.

--- a/.agents/skills/maestro-e2e/rules/commands.md
+++ b/.agents/skills/maestro-e2e/rules/commands.md
@@ -1,0 +1,109 @@
+---
+name: commands
+description: Complete reference of 40+ Maestro commands
+metadata:
+  tags: commands, api, reference, launchApp, tapOn
+---
+
+## App Lifecycle
+
+| Command         | Description               | Example                             |
+| --------------- | ------------------------- | ----------------------------------- |
+| `launchApp`     | Launch app                | `- launchApp: { clearState: true }` |
+| `stopApp`       | Stop app (keep in memory) | `- stopApp`                         |
+| `killApp`       | Kill app completely       | `- killApp`                         |
+| `clearState`    | Clear app data            | `- clearState`                      |
+| `clearKeychain` | Clear iOS keychain        | `- clearKeychain`                   |
+
+### launchApp Options
+
+```yaml
+- launchApp:
+    clearState: true # Reset app data
+    clearKeychain: true # iOS only
+    permissions:
+      camera: allow
+      location: deny
+    arguments: # Launch arguments
+      env: staging
+```
+
+## Interactions
+
+| Command        | Description          | Example                                  |
+| -------------- | -------------------- | ---------------------------------------- |
+| `tapOn`        | Tap element          | `- tapOn: "Button"`                      |
+| `doubleTapOn`  | Double tap           | `- doubleTapOn: "Element"`               |
+| `longPressOn`  | Long press           | `- longPressOn: "Element"`               |
+| `inputText`    | Type text            | `- inputText: "Hello"`                   |
+| `eraseText`    | Delete text          | `- eraseText: { charactersToErase: 10 }` |
+| `pasteText`    | Paste from clipboard | `- pasteText`                            |
+| `hideKeyboard` | Dismiss keyboard     | `- hideKeyboard`                         |
+
+## Navigation
+
+| Command              | Description                  | Example                                       |
+| -------------------- | ---------------------------- | --------------------------------------------- |
+| `scroll`             | Scroll down                  | `- scroll`                                    |
+| `scrollUntilVisible` | Scroll until element visible | `- scrollUntilVisible: { element: "Footer" }` |
+| `swipe`              | Swipe gesture                | `- swipe: { direction: LEFT }`                |
+| `back`               | Android back button          | `- back`                                      |
+| `openLink`           | Open deep link               | `- openLink: "myapp://home"`                  |
+
+## Assertions
+
+| Command            | Description                  | Example                       |
+| ------------------ | ---------------------------- | ----------------------------- |
+| `assertVisible`    | Assert element visible       | `- assertVisible: "Welcome"`  |
+| `assertNotVisible` | Assert element NOT visible   | `- assertNotVisible: "Error"` |
+| `assertTrue`       | Assert JavaScript expression | `- assertTrue: ${count > 0}`  |
+
+## Screenshots & Recording
+
+| Command          | Description           | Example                      |
+| ---------------- | --------------------- | ---------------------------- |
+| `takeScreenshot` | Capture screenshot    | `- takeScreenshot: "result"` |
+| `startRecording` | Start video recording | `- startRecording: "flow"`   |
+| `stopRecording`  | Stop video recording  | `- stopRecording`            |
+
+## Device Control
+
+| Command           | Description              | Example                                                |
+| ----------------- | ------------------------ | ------------------------------------------------------ |
+| `setLocation`     | Mock GPS location        | `- setLocation: { lat: 40.7, long: -74.0 }`            |
+| `setAirplaneMode` | Toggle airplane mode     | `- setAirplaneMode: { enabled: true }`                 |
+| `setOrientation`  | Set screen orientation   | `- setOrientation: { orientation: LANDSCAPE }`         |
+| `setPermissions`  | Set permissions mid-flow | `- setPermissions: { permissions: { camera: allow } }` |
+
+## Flow Control
+
+| Command      | Description         | Example                                       |
+| ------------ | ------------------- | --------------------------------------------- |
+| `runFlow`    | Run subflow         | `- runFlow: { file: "login.yaml" }`           |
+| `runScript`  | Run JavaScript file | `- runScript: { file: "script.js" }`          |
+| `evalScript` | Inline JavaScript   | `- evalScript: ${output.value = 'test'}`      |
+| `repeat`     | Repeat commands     | `- repeat: { times: 3, commands: [...] }`     |
+| `retry`      | Retry on failure    | `- retry: { maxRetries: 3, commands: [...] }` |
+
+## Waiting
+
+| Command                 | Description         | Example                                                       |
+| ----------------------- | ------------------- | ------------------------------------------------------------- |
+| `extendedWaitUntil`     | Wait with timeout   | `- extendedWaitUntil: { visible: "Element", timeout: 10000 }` |
+| `waitForAnimationToEnd` | Wait for animations | `- waitForAnimationToEnd`                                     |
+
+## AI Commands
+
+| Command                 | Description          | Example                                       |
+| ----------------------- | -------------------- | --------------------------------------------- |
+| `assertWithAI`          | AI-powered assertion | `- assertWithAI: "Shopping cart has 3 items"` |
+| `assertNoDefectsWithAI` | Check for UI defects | `- assertNoDefectsWithAI`                     |
+| `extractTextWithAI`     | Extract text with AI | `- extractTextWithAI: { query: "price" }`     |
+
+## Media
+
+| Command        | Description            | Example                             |
+| -------------- | ---------------------- | ----------------------------------- |
+| `addMedia`     | Add media to device    | `- addMedia: { path: "photo.jpg" }` |
+| `setClipboard` | Set clipboard content  | `- setClipboard: "Copied text"`     |
+| `copyTextFrom` | Copy text from element | `- copyTextFrom: { id: "label" }`   |

--- a/.agents/skills/maestro-e2e/rules/debugging.md
+++ b/.agents/skills/maestro-e2e/rules/debugging.md
@@ -1,0 +1,181 @@
+---
+name: debugging
+description: Maestro Studio, hierarchy inspection, troubleshooting
+metadata:
+  tags: debug, studio, hierarchy, troubleshooting
+---
+
+## Maestro Studio
+
+Interactive visual debugging tool:
+
+```bash
+# Mobile (iOS/Android)
+maestro studio
+
+# Web
+maestro -p web studio
+```
+
+### Features
+
+- Live UI hierarchy view
+- Click elements to generate selectors
+- Record interactions as YAML
+- Real-time flow editing
+
+## UI Hierarchy Inspection
+
+View all visible elements and their properties:
+
+```bash
+maestro hierarchy
+```
+
+Output shows:
+
+- Element types
+- Text content
+- IDs / accessibilityIdentifiers
+- Bounds (position/size)
+- Enabled/selected state
+
+### Filter Hierarchy
+
+```bash
+maestro hierarchy | grep "login"
+```
+
+## Common Issues
+
+### Element Not Found
+
+**Symptoms:** `Could not find element`
+
+**Solutions:**
+
+1. Run `maestro hierarchy` to check actual identifiers
+2. Verify element is on screen (not below fold)
+3. Check for loading states blocking UI
+4. Add wait before interaction:
+   ```yaml
+   - extendedWaitUntil:
+       visible: "Element"
+       timeout: 10000
+   ```
+
+### Keyboard Blocking Elements
+
+**Symptoms:** `tapOn` fails after inputText
+
+**Solution:**
+
+```yaml
+- inputText: "password"
+- hideKeyboard
+- tapOn:
+    id: "submit_button"
+```
+
+### Element Below Fold
+
+**Symptoms:** Element exists but can't be tapped
+
+**Solution:**
+
+```yaml
+- scroll
+- tapOn:
+    id: "hidden_button"
+
+# Or
+- scrollUntilVisible:
+    element:
+      id: "hidden_button"
+```
+
+### Timing Issues
+
+**Symptoms:** Intermittent failures
+
+**Solutions:**
+
+```yaml
+# Wait for animations
+- waitForAnimationToEnd
+
+# Extended wait
+- extendedWaitUntil:
+    visible: "Element"
+    timeout: 10000
+
+# Retry flaky actions
+- retry:
+    maxRetries: 3
+    commands:
+      - tapOn: "Button"
+```
+
+### iOS Permission Dialog Not Dismissed
+
+**Symptoms:** Dialog stays on screen
+
+**Solutions:**
+
+1. Ensure simulator language is **English**
+2. Use `permissions:` in launchApp:
+   ```yaml
+   - launchApp:
+       permissions:
+         camera: allow
+   ```
+
+### Android Dialog Not Responding
+
+**Symptoms:** Permission dialog not tapped
+
+**Solution:**
+
+```yaml
+- tapOn: "While using the app"
+# Try exact text from dialog
+```
+
+## Debugging Flow
+
+```yaml
+# Add screenshots at key points
+- takeScreenshot: "step_1"
+- tapOn: "Button"
+- takeScreenshot: "step_2"
+```
+
+## Verbose Mode
+
+Run with debug output:
+
+```bash
+maestro test --debug flow.yaml
+```
+
+## Check Device Connection
+
+```bash
+# Android
+adb devices
+
+# iOS
+xcrun simctl list devices booted
+```
+
+## Re-install App
+
+```bash
+# Android
+adb uninstall com.example.app
+adb install app.apk
+
+# iOS
+xcrun simctl uninstall booted com.example.app
+xcrun simctl install booted App.app
+```

--- a/.agents/skills/maestro-e2e/rules/installation.md
+++ b/.agents/skills/maestro-e2e/rules/installation.md
@@ -1,0 +1,59 @@
+---
+name: installation
+description: Installing Maestro on macOS, Linux, and Windows
+metadata:
+  tags: install, setup, brew, curl, cli
+---
+
+## macOS (Homebrew)
+
+```bash
+brew tap mobile-dev-inc/tap
+brew install mobile-dev-inc/tap/maestro
+```
+
+## Linux / Windows (WSL)
+
+```bash
+curl -Ls "https://get.maestro.mobile.dev" | bash
+```
+
+After installation, add to PATH:
+
+```bash
+export PATH="$PATH:$HOME/.maestro/bin"
+```
+
+## Verify Installation
+
+```bash
+maestro --version
+```
+
+## Upgrade
+
+```bash
+# macOS
+brew upgrade maestro
+
+# Linux
+curl -Ls "https://get.maestro.mobile.dev" | bash
+```
+
+## Prerequisites
+
+| Platform | Requirement                                 |
+| -------- | ------------------------------------------- |
+| iOS      | Xcode + iOS Simulator (macOS only)          |
+| Android  | Android SDK + Emulator or device with ADB   |
+| Web      | No prerequisites (Chromium auto-downloaded) |
+
+## Troubleshooting
+
+If `maestro` command not found after installation:
+
+```bash
+# Add to ~/.zshrc or ~/.bashrc
+echo 'export PATH="$PATH:$HOME/.maestro/bin"' >> ~/.zshrc
+source ~/.zshrc
+```

--- a/.agents/skills/maestro-e2e/rules/interactions.md
+++ b/.agents/skills/maestro-e2e/rules/interactions.md
@@ -1,0 +1,167 @@
+---
+name: interactions
+description: tapOn, inputText, scroll, swipe, and gesture commands
+metadata:
+  tags: tap, input, scroll, swipe, gestures, keyboard
+---
+
+## Tap Interactions
+
+### tapOn
+
+```yaml
+# By text
+- tapOn: "Login"
+
+# By ID
+- tapOn:
+    id: "submit_button"
+
+# With retry
+- tapOn:
+    text: "Next"
+    retryTapIfNoChange: true
+```
+
+### doubleTapOn
+
+```yaml
+- doubleTapOn: "Image to zoom"
+- doubleTapOn:
+    id: "zoomable_view"
+```
+
+### longPressOn
+
+```yaml
+- longPressOn: "Item to delete"
+- longPressOn:
+    id: "context_menu_trigger"
+```
+
+## Text Input
+
+### inputText
+
+```yaml
+# Simple text
+- inputText: "john@example.com"
+
+# With variable
+- inputText: ${USERNAME}
+
+# Focus field first
+- tapOn:
+    id: "email_field"
+- inputText: "test@example.com"
+```
+
+### eraseText
+
+```yaml
+# Erase specific count
+- eraseText:
+    charactersToErase: 10
+
+# Erase all (large number)
+- eraseText:
+    charactersToErase: 100
+```
+
+### hideKeyboard
+
+MUST be called before tapping elements obscured by keyboard:
+
+```yaml
+- tapOn:
+    id: "password_field"
+- inputText: "secret123"
+- hideKeyboard
+- tapOn:
+    id: "submit_button"
+```
+
+## Scrolling
+
+### scroll
+
+```yaml
+# Default scroll down
+- scroll
+
+# Scroll in direction
+- scroll:
+    direction: UP
+
+# Scroll on specific element
+- scroll:
+    element:
+      id: "scrollable_list"
+```
+
+### scrollUntilVisible
+
+```yaml
+- scrollUntilVisible:
+    element: "Footer"
+
+- scrollUntilVisible:
+    element:
+      id: "load_more_button"
+    direction: DOWN
+    speed: 40
+```
+
+## Swipe Gestures
+
+```yaml
+# Swipe left (like dismissing)
+- swipe:
+    direction: LEFT
+
+# Swipe with start point
+- swipe:
+    direction: RIGHT
+    start: "90%,50%"
+    end: "10%,50%"
+
+# Swipe on element
+- swipe:
+    direction: LEFT
+    element:
+      id: "swipeable_card"
+```
+
+## Common Patterns
+
+### Form Filling
+
+```yaml
+- tapOn:
+    id: "name_field"
+- inputText: "John Doe"
+
+- tapOn:
+    id: "email_field"
+- inputText: "john@example.com"
+
+- tapOn:
+    id: "password_field"
+- inputText: "SecurePass123"
+
+- hideKeyboard
+- scroll
+- tapOn:
+    id: "submit_button"
+```
+
+### Carousel Navigation
+
+```yaml
+- repeat:
+    times: 3
+    commands:
+      - swipe:
+          direction: LEFT
+      - takeScreenshot: "slide_${i}"
+```

--- a/.agents/skills/maestro-e2e/rules/permissions.md
+++ b/.agents/skills/maestro-e2e/rules/permissions.md
@@ -1,0 +1,120 @@
+---
+name: permissions
+description: iOS vs Android permission configuration and dialog handling
+metadata:
+  tags: permissions, camera, location, dialogs, ios, android
+---
+
+## Permission Configuration at Launch
+
+By default, all permissions are set to `allow`. Override with `launchApp`:
+
+```yaml
+- launchApp:
+    clearState: true
+    permissions:
+      all: deny # Deny all first
+      camera: allow # Then allow specific
+      location: allow
+      notifications: deny
+```
+
+## Setting Permissions Mid-Flow
+
+Use `setPermissions` outside of launch (e.g., before deep links):
+
+```yaml
+- setPermissions:
+    permissions:
+      camera: allow
+      microphone: allow
+```
+
+## Available Permissions
+
+| Permission      | iOS | Android |
+| --------------- | --- | ------- |
+| `camera`        | ✅  | ✅      |
+| `location`      | ✅  | ✅      |
+| `microphone`    | ✅  | ✅      |
+| `photos`        | ✅  | ❌      |
+| `notifications` | ✅  | ✅      |
+| `contacts`      | ✅  | ✅      |
+| `calendar`      | ✅  | ✅      |
+| `medialibrary`  | ✅  | ✅      |
+| `bluetooth`     | ❌  | ✅      |
+| `storage`       | ❌  | ✅      |
+| `phone`         | ❌  | ✅      |
+| `sms`           | ❌  | ✅      |
+
+Use `all` to reference all app permissions.
+
+## Permission Values
+
+| Value   | iOS          | Android                 |
+| ------- | ------------ | ----------------------- |
+| `allow` | Granted      | Granted                 |
+| `deny`  | Denied       | Prompt shown at runtime |
+| `unset` | Prompt shown | Prompt shown            |
+
+## iOS-Specific Values
+
+### Location
+
+```yaml
+permissions:
+  location: always   # Same as allow
+  location: inuse    # Only while using app
+  location: never    # Same as deny
+```
+
+### Photos
+
+```yaml
+permissions:
+  photos: limited # Limited access
+```
+
+## Platform Differences
+
+### iOS
+
+- Permission dialogs are **auto-dismissed** by Maestro
+- Only works on **English** language simulators
+- Cannot manually tap dialog buttons
+- Use `permissions:` in `launchApp` to pre-configure
+
+### Android
+
+- Can **interact** with permission dialogs via `tapOn`
+- Dialog text varies by Android version:
+  - `"Allow"` / `"Deny"`
+  - `"While using the app"`
+  - `"Only this time"`
+  - `"Don't allow"`
+
+### Android Dialog Example
+
+```yaml
+- launchApp:
+    permissions:
+      camera: deny # Start denied
+
+- tapOn:
+    id: "request_camera_button"
+
+# Android only - tap system dialog
+- tapOn: "While using the app"
+
+- assertVisible: "Camera ready"
+```
+
+## Custom Android Permissions
+
+Use full permission ID for non-standard permissions:
+
+```yaml
+permissions:
+  android.permission.ADD_VOICEMAIL: allow
+  my.custom.permission: allow
+```

--- a/.agents/skills/maestro-e2e/rules/platforms/android.md
+++ b/.agents/skills/maestro-e2e/rules/platforms/android.md
@@ -1,0 +1,120 @@
+---
+name: android
+description: Android-specific features, ADB, permission dialogs, emulators
+metadata:
+  tags: android, adb, emulator, dialogs, permissions
+---
+
+## What is ADB?
+
+ADB (Android Debug Bridge) is a command-line tool that enables communication between your computer and Android devices/emulators.
+
+Maestro uses ADB internally to:
+
+- Interact with system dialogs (permissions, alerts)
+- Install/launch applications
+- Simulate input events (taps, swipes, text)
+- Inspect UI hierarchy
+
+## Bundle ID Format
+
+Android uses lowercase with underscores:
+
+```yaml
+appId: com.example.my_app
+```
+
+Find your app's package name:
+
+```bash
+adb shell pm list packages | grep yourapp
+```
+
+## Permission Dialogs
+
+Maestro can **tap** Android permission dialogs:
+
+```yaml
+- launchApp:
+    permissions:
+      camera: deny # Start denied to trigger dialog
+
+- tapOn:
+    id: "request_permission_button"
+
+# Tap the system dialog
+- tapOn: "While using the app"
+```
+
+### Common Dialog Texts
+
+| Android Version | Allow Options                                          |
+| --------------- | ------------------------------------------------------ |
+| Android 10      | "Allow", "Deny"                                        |
+| Android 11+     | "While using the app", "Only this time", "Don't allow" |
+
+## Emulator Setup
+
+Start emulator via command line:
+
+```bash
+emulator -avd Pixel_4_API_31
+```
+
+List available devices:
+
+```bash
+adb devices
+```
+
+## UI Hierarchy Inspection
+
+```bash
+maestro hierarchy
+```
+
+Returns XML tree of all visible elements with their properties, useful for finding correct selectors.
+
+## Android-Specific Commands
+
+### Back Button
+
+```yaml
+- back
+```
+
+### Airplane Mode
+
+```yaml
+- setAirplaneMode:
+    enabled: true
+```
+
+### Location Mocking
+
+```yaml
+- setLocation:
+    latitude: 37.7749
+    longitude: -122.4194
+```
+
+## Troubleshooting
+
+### App Not Found
+
+```bash
+# Check if app is installed
+adb shell pm list packages | grep com.example
+
+# Reinstall APK
+adb install -r app.apk
+```
+
+### Permission Dialog Not Appearing
+
+Ensure app is started with `clearState: true` to reset permissions:
+
+```yaml
+- launchApp:
+    clearState: true
+```

--- a/.agents/skills/maestro-e2e/rules/platforms/flutter.md
+++ b/.agents/skills/maestro-e2e/rules/platforms/flutter.md
@@ -1,0 +1,205 @@
+---
+name: flutter
+description: Flutter integration using Semantics and identifier
+metadata:
+  tags: flutter, semantics, identifier, dart, widget
+---
+
+## Requirement
+
+Flutter 3.19+ is required for `Semantics.identifier` support.
+
+Check your version:
+
+```bash
+flutter --version
+```
+
+Upgrade if needed:
+
+```bash
+flutter upgrade
+```
+
+## Semantics Identifier (Recommended)
+
+Use `Semantics` widget with `identifier` property:
+
+```dart
+Semantics(
+  identifier: 'login_button',
+  child: ElevatedButton(
+    onPressed: () => login(),
+    child: const Text('Login'),
+  ),
+)
+```
+
+In Maestro:
+
+```yaml
+- tapOn:
+    id: "login_button"
+```
+
+## Semantics Label (Alternative)
+
+For older Flutter versions, use `semanticsLabel`:
+
+```dart
+Text(
+  'Welcome',
+  semanticsLabel: 'welcome_text',
+)
+
+TextField(
+  decoration: const InputDecoration(
+    hintText: 'Email',
+    semanticLabel: 'email_field',
+  ),
+)
+```
+
+## Why Not Flutter Keys?
+
+Flutter `Key` is NOT accessible by Maestro. Keys exist only in the widget tree, not in the accessibility/semantics tree that Maestro inspects.
+
+```dart
+// ❌ NOT accessible by Maestro
+ElevatedButton(
+  key: const Key('login_button'),
+  child: const Text('Login'),
+)
+
+// ✅ Accessible by Maestro
+Semantics(
+  identifier: 'login_button',
+  child: ElevatedButton(
+    child: const Text('Login'),
+  ),
+)
+```
+
+## Naming Convention
+
+Use snake_case for identifiers:
+
+```dart
+// Pattern: {screen}_{element}_{type}
+identifier: 'login_email_field'
+identifier: 'login_password_field'
+identifier: 'login_submit_button'
+identifier: 'dashboard_profile_card'
+```
+
+## Common Widgets
+
+### Buttons
+
+```dart
+Semantics(
+  identifier: 'submit_button',
+  child: ElevatedButton(
+    onPressed: onSubmit,
+    child: const Text('Submit'),
+  ),
+)
+```
+
+### Text Fields
+
+```dart
+Semantics(
+  identifier: 'email_field',
+  child: TextField(
+    controller: emailController,
+    decoration: const InputDecoration(
+      labelText: 'Email',
+    ),
+  ),
+)
+```
+
+### Cards / Containers
+
+```dart
+Semantics(
+  identifier: 'user_profile_card',
+  child: Card(
+    child: ListTile(
+      title: Text(user.name),
+    ),
+  ),
+)
+```
+
+### Status Text
+
+```dart
+Semantics(
+  identifier: 'permission_status',
+  child: Text(
+    permissionGranted ? 'Granted' : 'Denied',
+  ),
+)
+```
+
+## Full Example
+
+```dart
+class LoginPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Column(
+        children: [
+          Semantics(
+            identifier: 'login_email_field',
+            child: TextField(
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+          ),
+          Semantics(
+            identifier: 'login_password_field',
+            child: TextField(
+              obscureText: true,
+              decoration: const InputDecoration(labelText: 'Password'),
+            ),
+          ),
+          Semantics(
+            identifier: 'login_submit_button',
+            child: ElevatedButton(
+              onPressed: () => login(),
+              child: const Text('Login'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+## Maestro Test
+
+```yaml
+appId: com.example.myApp
+---
+- launchApp:
+    clearState: true
+
+- tapOn:
+    id: "login_email_field"
+- inputText: "test@example.com"
+
+- tapOn:
+    id: "login_password_field"
+- inputText: "password123"
+
+- hideKeyboard
+- tapOn:
+    id: "login_submit_button"
+
+- assertVisible: "Dashboard"
+```

--- a/.agents/skills/maestro-e2e/rules/platforms/ios.md
+++ b/.agents/skills/maestro-e2e/rules/platforms/ios.md
@@ -1,0 +1,148 @@
+---
+name: ios
+description: iOS-specific features, auto-dismiss dialogs, simulators, limitations
+metadata:
+  tags: ios, simulator, dialogs, permissions, auto-dismiss
+---
+
+## Bundle ID Format
+
+iOS uses camelCase:
+
+```yaml
+appId: com.example.myApp
+```
+
+Find your app's bundle ID in Xcode project settings or:
+
+```bash
+xcrun simctl listapps booted | grep CFBundleIdentifier
+```
+
+## Permission Dialogs - Auto Dismiss
+
+Maestro **automatically dismisses** permission dialogs on iOS by selecting "Allow".
+
+**Important Limitations:**
+
+- Only works on **English** language simulators
+- Cannot manually tap dialog buttons
+- Cannot select "Don't Allow" or custom options
+
+### Example
+
+```yaml
+- launchApp:
+    permissions:
+      camera: deny # Will prompt and auto-allow
+
+- tapOn:
+    id: "open_camera_button"
+
+# Dialog auto-dismissed, no tapOn needed
+- assertVisible: "Camera Ready"
+```
+
+## Simulator Setup
+
+List available simulators:
+
+```bash
+xcrun simctl list devices
+```
+
+Boot a simulator:
+
+```bash
+xcrun simctl boot "iPhone 15 Pro"
+```
+
+Open Simulator app:
+
+```bash
+open -a Simulator
+```
+
+## Language Requirement
+
+For auto-dismiss to work, set simulator to English:
+
+1. Settings → General → Language & Region
+2. Select English
+3. Restart simulator
+
+Or via command line:
+
+```bash
+xcrun simctl shutdown all
+defaults write com.apple.iphonesimulator AppleLocale "en_US"
+xcrun simctl boot "iPhone 15 Pro"
+```
+
+## Push Notifications Behavior
+
+`notifications: allow` on iOS:
+
+- Does NOT grant permission automatically
+- Shows OS prompt
+- Maestro auto-dismisses with "Allow"
+
+On Android, `notifications: allow` grants immediately.
+
+## iOS-Specific Permissions
+
+### Location Options
+
+```yaml
+permissions:
+  location: always   # Always allow
+  location: inuse    # Only while using
+  location: never    # Deny
+```
+
+### Photos Options
+
+```yaml
+permissions:
+  photos: allow     # Full access
+  photos: limited   # Limited access
+```
+
+## Keychain
+
+Clear iOS keychain (stored credentials):
+
+```yaml
+- launchApp:
+    clearKeychain: true
+```
+
+Or as separate command:
+
+```yaml
+- clearKeychain
+```
+
+## Known Limitations
+
+| Feature                    | Status           |
+| -------------------------- | ---------------- |
+| Permission dialog text tap | ❌ Not supported |
+| Physical device testing    | ❌ Not supported |
+| Non-English dialogs        | ❌ Not supported |
+| Face ID / Touch ID         | ❌ Not supported |
+| Apple Pay sheets           | ❌ Not supported |
+
+## Workaround for Non-English
+
+If testing in non-English, pre-grant permissions:
+
+```yaml
+- launchApp:
+    permissions:
+      camera: allow
+      location: allow
+      notifications: allow
+```
+
+This bypasses dialogs entirely.

--- a/.agents/skills/maestro-e2e/rules/platforms/react-native.md
+++ b/.agents/skills/maestro-e2e/rules/platforms/react-native.md
@@ -1,0 +1,190 @@
+---
+name: react-native
+description: React Native with testID and accessibilityLabel
+metadata:
+  tags: react-native, testID, accessibilityLabel, expo
+---
+
+## Element Identification
+
+React Native uses two main approaches for testability:
+
+### testID (Recommended)
+
+```jsx
+<TouchableOpacity testID="login_button" onPress={handleLogin}>
+  <Text>Login</Text>
+</TouchableOpacity>
+```
+
+In Maestro:
+
+```yaml
+- tapOn:
+    id: "login_button"
+```
+
+### accessibilityLabel
+
+```jsx
+<Text accessibilityLabel="welcome_message">Welcome to the app</Text>
+```
+
+In Maestro:
+
+```yaml
+- assertVisible:
+    id: "welcome_message"
+```
+
+## Common Components
+
+### Text Input
+
+```jsx
+<TextInput
+  testID="email_input"
+  placeholder="Enter email"
+  value={email}
+  onChangeText={setEmail}
+/>
+```
+
+### Buttons
+
+```jsx
+<Pressable testID="submit_button" onPress={onSubmit}>
+  <Text>Submit</Text>
+</Pressable>
+```
+
+### ScrollView
+
+```jsx
+<ScrollView testID="main_scroll">{/* content */}</ScrollView>
+```
+
+### FlatList Items
+
+```jsx
+<FlatList
+  testID="items_list"
+  data={items}
+  renderItem={({ item, index }) => (
+    <View testID={`item_${index}`}>
+      <Text>{item.name}</Text>
+    </View>
+  )}
+/>
+```
+
+## Naming Convention
+
+Use snake_case with descriptive names:
+
+```jsx
+// Pattern: {screen}_{element}_{type}
+testID = "login_email_input";
+testID = "login_password_input";
+testID = "login_submit_button";
+testID = "home_profile_card";
+testID = "settings_logout_button";
+```
+
+## Expo Projects
+
+Expo projects work identically:
+
+```jsx
+import { Pressable, Text } from "react-native";
+
+export default function App() {
+  return (
+    <Pressable testID="hello_button">
+      <Text>Hello</Text>
+    </Pressable>
+  );
+}
+```
+
+## Full Example
+
+```jsx
+// LoginScreen.js
+import React, { useState } from "react";
+import { View, TextInput, Pressable, Text, StyleSheet } from "react-native";
+
+export const LoginScreen = ({ onLogin }) => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        testID="login_email_input"
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        style={styles.input}
+      />
+      <TextInput
+        testID="login_password_input"
+        placeholder="Password"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+        style={styles.input}
+      />
+      <Pressable
+        testID="login_submit_button"
+        onPress={() => onLogin(email, password)}
+        style={styles.button}
+      >
+        <Text>Login</Text>
+      </Pressable>
+    </View>
+  );
+};
+```
+
+## Maestro Test
+
+```yaml
+appId: com.example.myreactnativeapp
+---
+- launchApp:
+    clearState: true
+
+- tapOn:
+    id: "login_email_input"
+- inputText: "test@example.com"
+
+- tapOn:
+    id: "login_password_input"
+- inputText: "password123"
+
+- hideKeyboard
+- tapOn:
+    id: "login_submit_button"
+
+- assertVisible: "Dashboard"
+```
+
+## Troubleshooting
+
+### testID Not Found
+
+1. Check element is rendered on screen
+2. Run `maestro hierarchy` to inspect visible elements
+3. Ensure testID is on correct component (not wrapper)
+
+### Platform-Specific testID
+
+```jsx
+<View
+  testID={Platform.select({
+    ios: 'profile_card_ios',
+    android: 'profile_card_android',
+  })}
+>
+```

--- a/.agents/skills/maestro-e2e/rules/platforms/web.md
+++ b/.agents/skills/maestro-e2e/rules/platforms/web.md
@@ -1,0 +1,166 @@
+---
+name: web
+description: Desktop browser testing with Chromium
+metadata:
+  tags: web, browser, chromium, desktop, url
+---
+
+## Web Testing Overview
+
+Maestro supports testing web applications in a desktop Chromium browser.
+
+## Test Structure
+
+Use `url` instead of `appId`:
+
+```yaml
+url: https://example.com
+---
+- launchApp
+- tapOn: "Sign In"
+- assertVisible: "Dashboard"
+```
+
+## Running Web Tests
+
+```bash
+maestro test web_flow.yaml
+```
+
+On first run, Chromium is automatically downloaded.
+
+## Maestro Studio for Web
+
+```bash
+maestro -p web studio
+```
+
+## Element Selectors
+
+### By Text
+
+```yaml
+- tapOn: "Login"
+- assertVisible: "Welcome"
+```
+
+### By ID (data-testid)
+
+```yaml
+- tapOn:
+    id: "login-button"
+```
+
+Add `data-testid` to HTML elements:
+
+```html
+<button data-testid="login-button">Login</button>
+<input data-testid="email-input" type="email" />
+```
+
+### By Standard ID
+
+```yaml
+- tapOn:
+    id: "submit"
+```
+
+```html
+<button id="submit">Submit</button>
+```
+
+## Form Interactions
+
+```yaml
+url: https://example.com/login
+---
+- launchApp
+
+- tapOn:
+    id: "email-input"
+- inputText: "user@example.com"
+
+- tapOn:
+    id: "password-input"
+- inputText: "secret123"
+
+- tapOn:
+    id: "login-button"
+
+- assertVisible: "Welcome back"
+```
+
+## Navigation
+
+### Page Navigation
+
+```yaml
+- openLink: "https://example.com/dashboard"
+```
+
+### Back Button
+
+```yaml
+- back
+```
+
+## Screenshots
+
+```yaml
+- takeScreenshot: "homepage"
+```
+
+## Known Limitations
+
+| Feature            | Status                |
+| ------------------ | --------------------- |
+| Different browsers | ❌ Chromium only      |
+| Different locales  | ❌ en-US only         |
+| Screen size config | ❌ Not configurable   |
+| Flutter Web        | ⚠️ Requires Semantics |
+| Mobile viewport    | ❌ Desktop only       |
+
+## Flutter Web
+
+Flutter Web requires Semantics for element identification:
+
+```dart
+Semantics(
+  identifier: 'login_button',
+  child: ElevatedButton(...),
+)
+```
+
+See [Flutter rules](./flutter.md) for details.
+
+## Full Example
+
+```yaml
+url: https://demo.example.com
+env:
+  EMAIL: test@example.com
+  PASSWORD: demo123
+---
+- launchApp
+- takeScreenshot: "landing_page"
+
+# Navigate to login
+- tapOn: "Sign In"
+
+# Fill form
+- tapOn:
+    id: "email-field"
+- inputText: ${EMAIL}
+
+- tapOn:
+    id: "password-field"
+- inputText: ${PASSWORD}
+
+# Submit
+- tapOn:
+    id: "submit-button"
+
+# Verify success
+- assertVisible: "Dashboard"
+- takeScreenshot: "logged_in"
+```

--- a/.agents/skills/maestro-e2e/rules/rnw-community.md
+++ b/.agents/skills/maestro-e2e/rules/rnw-community.md
@@ -1,0 +1,80 @@
+---
+name: rnw-community
+description: Package under test, run scripts, fleet labels, and artifact locations for this repo
+metadata:
+  tags: rnw-community, react-native-payments, ci, fleet
+---
+
+## Package under test
+
+`packages/react-native-payments-example` is ONE private package proving
+`@rnw-community/react-native-payments` on two app targets that share a single `src/` screen layer:
+
+- `apps/bare` — React Native CLI target, package `@rnw-community/react-native-payments-example-bare`
+- `apps/expo` — Expo target, package `@rnw-community/react-native-payments-example-expo`
+
+Both targets are nested Yarn workspaces excluded from Lerna publishing (see the package's `AGENTS.md`).
+
+## App identifiers (`appId` header)
+
+| Target      | Platform | appId                                                    |
+| ----------- | -------- | --------------------------------------------------------- |
+| `apps/bare` | iOS      | `org.reactjs.native.example.ReactNativePaymentsExample`   |
+| `apps/bare` | Android  | `com.reactnativepaymentsexample`                           |
+| `apps/expo` | iOS      | `com.reactnativepaymentsexpoexample`                       |
+| `apps/expo` | Android  | `com.reactnativepaymentsexpoexample`                       |
+
+## Flow layout
+
+Flows live at `packages/react-native-payments-example/e2e/`, written as shared YAML parameterized
+per target/platform (an `${APP_ID}` env var rather than four near-duplicate files) — see #393 for
+the concrete suite: app launch, `canMakePayments` true, sheet opens on `show()`, dismiss →
+abort/reject state visible in the event log, shipping-change round-trip where observable, async
+`updateWith` completion, and JS state transitions after each step. Demo-screen testIDs are
+documented against that suite by #392; until then, follow the `snake_case`
+`{screen}_{element}_{type}` convention in [../best-practices.md](../best-practices.md) and
+[../platforms/react-native.md](../platforms/react-native.md).
+
+Android flows assert graceful no-support/stub behavior where Google Pay is unavailable on the
+emulator — do not assert a real Google Pay sheet on Android.
+
+## Local run scripts
+
+Issue #393 adds package-level scripts on `packages/react-native-payments-example/package.json`
+following the existing `<action>:<target>` naming already used for `ios:bare` / `android:bare` /
+`ios:expo` / `android:expo` (see the package's `AGENTS.md`):
+
+```bash
+yarn workspace @rnw-community/react-native-payments-example e2e:ios:bare
+yarn workspace @rnw-community/react-native-payments-example e2e:ios:expo
+yarn workspace @rnw-community/react-native-payments-example e2e:android:bare
+yarn workspace @rnw-community/react-native-payments-example e2e:android:expo
+```
+
+These scripts do not exist yet on this branch — treat the names above as the documented interface
+to implement, not a confirmed present-day command. Until #393 lands, drive Maestro directly against
+a running simulator/emulator instead:
+
+```bash
+maestro test -e APP_ID=<appId> packages/react-native-payments-example/e2e/
+```
+
+## Fleet labels (CI, issue #395)
+
+- iOS workflow (`ios-maestro.yml`): `runs-on: [self-hosted, macOS, ARM64, macos-maestro]`
+- Android workflow (`android-maestro.yml`): `runs-on: [self-hosted, linux-tiered, linux-xl]`
+
+Both workflows are planned to build the example app across the bare/expo matrix with derived-data
+and Gradle/pod caching keyed on lockfiles + native dirs (mirroring the `ios-native-cache.yml`
+pattern), triggered on paths touching `packages/react-native-payments`,
+`packages/react-native-payments-example/**`, or the workflow files themselves, plus a nightly
+schedule. Neither workflow exists on this branch yet, and issue #396 must register this repository
+in the runner fleet before these labels can pick up any job.
+
+## Artifacts on failure (issue #395)
+
+On failure, upload screenshots, videos, and Maestro logs as CI artifacts — the `maestro_output/`
+directory produced locally per [../screenshots.md](../screenshots.md) and
+[../debugging.md](../debugging.md). On success, no artifacts are retained. This is the evidence bar
+behind #395's "cold vs warm build time documented in the PR" requirement; until #395 lands there is
+no CI artifact upload configured for this repository.

--- a/.agents/skills/maestro-e2e/rules/screenshots.md
+++ b/.agents/skills/maestro-e2e/rules/screenshots.md
@@ -1,0 +1,131 @@
+---
+name: screenshots
+description: Screenshots, video recording, and visual evidence
+metadata:
+  tags: screenshot, recording, video, visual
+---
+
+## takeScreenshot
+
+Capture current screen state:
+
+```yaml
+- takeScreenshot: "login_page"
+```
+
+Screenshots saved to test output directory.
+
+### At Key Points
+
+```yaml
+- launchApp
+- takeScreenshot: "01_home"
+
+- tapOn: "Login"
+- takeScreenshot: "02_login_form"
+
+- inputText: "user@example.com"
+- takeScreenshot: "03_email_entered"
+
+- tapOn: "Submit"
+- takeScreenshot: "04_result"
+```
+
+### With Variables
+
+```yaml
+- repeat:
+    times: 3
+    commands:
+      - takeScreenshot: "slide_${maestro.repeating.index}"
+      - swipe:
+          direction: LEFT
+```
+
+## Video Recording
+
+### Start/Stop Recording
+
+```yaml
+- startRecording: "login_flow"
+
+- launchApp
+- tapOn: "Login"
+- inputText: ${USERNAME}
+- tapOn: "Submit"
+
+- stopRecording
+```
+
+Video saved as `login_flow.mp4`.
+
+### Full Flow Recording
+
+```yaml
+- startRecording: "complete_test"
+
+# All test steps...
+
+- stopRecording
+```
+
+## Output Location
+
+Screenshots and recordings are saved relative to test execution:
+
+```
+maestro_output/
+├── screenshots/
+│   ├── login_page.png
+│   └── dashboard.png
+└── recordings/
+    └── login_flow.mp4
+```
+
+## CI Artifacts
+
+### GitHub Actions
+
+```yaml
+- name: Run E2E Tests
+  run: maestro test e2e/
+
+- name: Upload Screenshots
+  if: always()
+  uses: actions/upload-artifact@v4
+  with:
+    name: maestro-screenshots
+    path: maestro_output/
+```
+
+## Best Practices
+
+1. **Name meaningfully** - Use descriptive names like `checkout_complete`
+2. **Number sequences** - Prefix with numbers for order: `01_home`, `02_login`
+3. **Screenshot on failure** - Helps debug issues
+4. **Record critical flows** - Video for complex interactions
+5. **Include in PR** - Share visual evidence in reviews
+
+## Debugging Pattern
+
+```yaml
+- tapOn: "Problem Button"
+- takeScreenshot: "after_tap"
+```
+
+If test fails, screenshot shows actual UI state.
+
+## Screenshot All Steps
+
+```yaml
+- takeScreenshot: "step_01_launch"
+- launchApp
+
+- takeScreenshot: "step_02_before_tap"
+- tapOn: "Login"
+
+- takeScreenshot: "step_03_after_tap"
+- assertVisible: "Dashboard"
+
+- takeScreenshot: "step_04_final"
+```

--- a/.agents/skills/maestro-e2e/rules/selectors.md
+++ b/.agents/skills/maestro-e2e/rules/selectors.md
@@ -1,0 +1,109 @@
+---
+name: selectors
+description: Element targeting with id, text, index, and matchers
+metadata:
+  tags: selectors, id, text, index, matchers
+---
+
+## Basic Selectors
+
+### By Text (Default)
+
+```yaml
+- tapOn: "Login"
+- assertVisible: "Welcome to Dashboard"
+```
+
+### By ID (Recommended)
+
+```yaml
+- tapOn:
+    id: "login_button"
+
+- assertVisible:
+    id: "dashboard_header"
+```
+
+### By Index
+
+When multiple elements match:
+
+```yaml
+- tapOn:
+    text: "Item"
+    index: 0 # First match (0-indexed)
+```
+
+## Combined Selectors
+
+Combine multiple matchers (AND logic):
+
+```yaml
+- tapOn:
+    id: "button"
+    text: "Submit"
+    enabled: true
+```
+
+## Selector Properties
+
+| Property       | Description                             | Example               |
+| -------------- | --------------------------------------- | --------------------- |
+| `id`           | Accessibility ID / Semantics identifier | `id: "login_btn"`     |
+| `text`         | Exact text match                        | `text: "Login"`       |
+| `textContains` | Partial text match                      | `textContains: "Log"` |
+| `index`        | Element index (0-based)                 | `index: 2`            |
+| `enabled`      | Element enabled state                   | `enabled: true`       |
+| `selected`     | Element selected state                  | `selected: true`      |
+| `checked`      | Checkbox/toggle state                   | `checked: true`       |
+| `focused`      | Element focus state                     | `focused: true`       |
+
+## Hierarchy Selectors
+
+Select relative to another element:
+
+```yaml
+# Child of element
+- tapOn:
+    below: "Username"
+    id: "input_field"
+
+# Element above another
+- tapOn:
+    above: "Submit"
+    text: "Terms"
+
+# Left/right of element
+- tapOn:
+    leftOf: "Cancel"
+    text: "OK"
+```
+
+## Optional Selector
+
+Don't fail if not found:
+
+```yaml
+- tapOn:
+    optional: true
+    text: "Skip"
+```
+
+## Point Selector
+
+Tap exact coordinates:
+
+```yaml
+- tapOn:
+    point: "50%,50%" # Center of screen
+```
+
+## Platform-Specific IDs
+
+| Platform       | ID Source                                  |
+| -------------- | ------------------------------------------ |
+| Flutter        | `Semantics.identifier` or `semanticsLabel` |
+| React Native   | `testID` or `accessibilityLabel`           |
+| iOS Native     | `accessibilityIdentifier`                  |
+| Android Native | `resource-id` or `content-desc`            |
+| Web            | `data-testid` or `id` attribute            |

--- a/.agents/skills/maestro-e2e/rules/test-structure.md
+++ b/.agents/skills/maestro-e2e/rules/test-structure.md
@@ -1,0 +1,80 @@
+---
+name: test-structure
+description: YAML test structure, appId, env variables, and flow definition
+metadata:
+  tags: yaml, structure, appId, env, flow
+---
+
+## Basic Structure
+
+Every Maestro test is a YAML file with two sections separated by `---`:
+
+```yaml
+# Header section (metadata)
+appId: com.example.myApp
+env:
+  USERNAME: test@example.com
+  PASSWORD: secret123
+---
+# Flow section (test steps)
+- launchApp
+- tapOn: "Login"
+- assertVisible: "Dashboard"
+```
+
+## Header Properties
+
+| Property | Description           | Example               |
+| -------- | --------------------- | --------------------- |
+| `appId`  | Bundle ID (mobile)    | `com.example.myApp`   |
+| `url`    | Web URL (desktop)     | `https://example.com` |
+| `name`   | Flow name (optional)  | `"Login Flow"`        |
+| `env`    | Environment variables | See below             |
+
+## Environment Variables
+
+Define constants in the header:
+
+```yaml
+appId: com.example.myApp
+env:
+  API_URL: https://api.example.com
+  USERNAME: ${USERNAME || 'default@example.com'}
+  PASSWORD: ${PASSWORD || 'password123'}
+---
+- inputText: ${USERNAME}
+```
+
+Variables support JavaScript expressions for defaults.
+
+## External Parameters
+
+Pass values from command line:
+
+```bash
+maestro test -e USERNAME=john@example.com -e PASSWORD=secret flow.yaml
+```
+
+Access with `${VARIABLE_NAME}` syntax in the flow.
+
+## Multiple Flows in Directory
+
+Run all flows in a directory:
+
+```bash
+maestro test e2e/
+```
+
+Maestro executes all `.yaml` files.
+
+## Flow Naming Convention
+
+```
+{feature}_{action}.yaml
+
+Examples:
+- login_success.yaml
+- login_invalid_credentials.yaml
+- register_new_user.yaml
+- dashboard_navigation.yaml
+```

--- a/.claude/skills/maestro-e2e
+++ b/.claude/skills/maestro-e2e
@@ -1,0 +1,1 @@
+../../.agents/skills/maestro-e2e


### PR DESCRIPTION
## Summary

Ports the Maestro E2E agent skill used elsewhere in the owner's repos into this repo, so future work on the react-native-payments unified example package (epic #372) has consistent Maestro guidance available to agents.

- Vendors the generic Maestro E2E skill (installation, YAML structure, selectors, assertions, interactions, permissions, platform guides for Android/iOS/Flutter/React Native/Web, advanced patterns, debugging, screenshots, CI integration, best practices — 3.3k lines across 25 files) into `.agents/skills/maestro-e2e`, mirrored at `.claude/skills/maestro-e2e` via the symlink convention already used for every other skill in this repo.
- Adds `rules/rnw-community.md`, a new project-specific overlay documenting:
  - The unified example package layout (`packages/react-native-payments-example` with `apps/bare` and `apps/expo` targets sharing one `src/`), read from branch `feat/rnp-391-unified-example` since it is not yet on `master`.
  - Real `appId` values for both targets/platforms.
  - The planned flow layout (`packages/react-native-payments-example/e2e/`) and local run scripts (`yarn e2e:ios:bare` and siblings), explicitly marked as arriving with #393 and not yet present on this branch.
  - Self-hosted fleet labels (`[self-hosted, macOS, ARM64, macos-maestro]` for iOS, `[self-hosted, linux-tiered, linux-xl]` for Android) and artifact policy (screenshots/videos/logs on failure), explicitly marked as arriving with #395/#396.
- Adds a short cross-reference note at the top of `rules/ci-integration.md` clarifying that its GitHub-hosted `runs-on` examples are generic reference material, not this repository's configuration.
- Retains the vendored skill's MIT license/attribution as-is; `README.md` documents provenance and the added overlay file.

## Test plan

- [x] `yarn ts` — passes (skill files are docs, no TypeScript touched)
- [x] `yarn lint` — passes (no lintable files touched)
- [x] `yarn test` — passes
- [x] Verified `.claude/skills/maestro-e2e` resolves through the symlink to `.agents/skills/maestro-e2e/SKILL.md`
- [ ] End-to-end local verification against the unified example app's Maestro suites is deferred until #393 (flows) and the unified example layout (#391) land, as noted in `rules/rnw-community.md`

Closes #397

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Maestro E2E agent skill for react-native-payments
> - Adds a self-contained Maestro E2E skill under [`.agents/skills/maestro-e2e`](https://github.com/rnw-community/rnw-community/pull/427/files#diff-d254d7596a92380c9828efcd63cf64bc7e1610890b2f353685fe4c30a457cff1) with ~25 rule documents covering test structure, selectors, interactions, assertions, CI integration, and platform-specific guides (React Native, iOS, Android, Flutter, Web).
> - Includes repository-specific guidance in [`rules/rnw-community.md`](https://github.com/rnw-community/rnw-community/pull/427/files#diff-cd125a1ef3a51c0735cbaa8dde4b34364beb51d339e35a22e5fe6eabde36b5f7) with app identifiers for bare/Expo targets, local run scripts, and CI fleet labels for the react-native-payments example app.
> - Exposes the skill to Claude via a symlink at [`.claude/skills/maestro-e2e`](https://github.com/rnw-community/rnw-community/pull/427/files#diff-9c3da12f03d0be319ebfc6f47cac5c2841709ac342cf1c390656e5bea8f796a8).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a84410.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->