### PR TITLE
fix(react-native-payments): bridgeless-safe TurboModule and emitter resolution

### DIFF
--- a/packages/react-native-payments/src/class/native-payments/native-payments.spec.ts
+++ b/packages/react-native-payments/src/class/native-payments/native-payments.spec.ts
@@ -46,19 +46,19 @@ describe('NativePayments', () => {
         delete globalWithTurboModuleProxy.__turboModuleProxy;
     });
 
-    it('should expose the TurboModule when the new architecture is enabled', () => {
+    it('should expose the TurboModule when the turbo module proxy is installed', () => {
         expect.hasAssertions();
 
+        // eslint-disable-next-line no-underscore-dangle
+        globalWithTurboModuleProxy.__turboModuleProxy = () => null;
         mockTurboModule.current = { show: showMock };
 
         expect(loadNativePayments().show).toBe(showMock);
     });
 
-    it('should expose the legacy native module when the new architecture is disabled', () => {
+    it('should expose the legacy native module when the turbo module proxy is not installed', () => {
         expect.hasAssertions();
 
-        // eslint-disable-next-line no-underscore-dangle
-        globalWithTurboModuleProxy.__turboModuleProxy = null;
         nativeModules.Payments = { show: showMock };
 
         expect(loadNativePayments().show).toBe(showMock);

--- a/packages/react-native-payments/src/class/native-payments/native-payments.ts
+++ b/packages/react-native-payments/src/class/native-payments/native-payments.ts
@@ -21,7 +21,7 @@ const changeEventMethodNames = new Set<PropertyKey>([
 
 // @ts-expect-error Temporary hack
 // eslint-disable-next-line no-underscore-dangle
-const isTurboModuleEnabled = global.__turboModuleProxy !== null;
+const isTurboModuleEnabled = isDefined(global.__turboModuleProxy);
 
 const PaymentsModule = isTurboModuleEnabled
     ? // eslint-disable-next-line @typescript-eslint/no-require-imports,n/no-missing-require,@typescript-eslint/no-unsafe-member-access


### PR DESCRIPTION
## Summary

`getNativePaymentsEventEmitter` already builds `NativeEventEmitter` from the resolved `NativePayments` reference, never from `NativeModules.Payments` directly, and `Payments.mm` already implements the change-event contract as an `RCTEventEmitter` retrieved through the same TurboModule handle used for method calls — this is the single mechanism that has to hold across old architecture, new architecture and bridgeless (RN's module-level codegen `EventEmitter` type is new-architecture only, so it cannot be "the one mechanism" for a package that still ships an old-architecture Android/iOS path).

What this PR fixes is the one place that decides *which* handle `NativePayments` (and therefore the emitter) resolves to: `isTurboModuleEnabled = global.__turboModuleProxy !== null`. On old architecture the proxy is `undefined`, never a literal `null`, so the strict `!==` check always picked the TurboModule branch. `TurboModuleRegistry.get()` happens to fall back to `NativeModules` internally on the pinned RN (0.76.9), which is why this stayed invisible, but that fallback is not guaranteed on the older RN versions this package's peer range (`>=0.64`) still advertises, and it obscures the real detection this bridgeless-safety work depends on. Replaced the check with `isDefined(global.__turboModuleProxy)` so only a genuinely installed proxy selects the TurboModule path.

## RN version / mechanism decision

- Pinned RN: `^0.76.1` devDependency, resolved `0.76.9`; the unified example (`feat/rnp-391-unified-example`) also pins `^0.76.1`.
- RN 0.76 does support codegen `EventEmitter<T>` (confirmed via `@react-native/codegen`'s `GenerateModuleObjCpp/serializeEventEmitter.js`), but that generator only emits into the new-architecture `Spec` protocol — there is no old-architecture equivalent. Since old architecture must keep working (`android/src/oldarch`, `ios/Payments.h`'s non-`RCT_NEW_ARCH_ENABLED` branch), a single mechanism valid on old arch, new arch and bridgeless can only be the fallback: `RCTEventEmitter` retrieved via the TurboModule handle obtained through `TurboModuleRegistry`, never `NativeModules`. That is what this package already implements; this PR closes the one gap in how that handle is selected.

## TDD evidence

- RED: rewrote `native-payments.spec.ts`'s architecture-selection tests to represent real proxy states (installed function vs. not installed at all, instead of "deleted = enabled" / "explicit null = disabled"). Against the unfixed `!== null` check, "turbo proxy not installed" incorrectly took the TurboModule branch, got `null` back, and `NativePayments.show` threw the linking error instead of resolving to the legacy module — 1 failing test.
- GREEN: swapped the check for `isDefined(global.__turboModuleProxy)`; all 4 tests in the file pass, and the full package suite (148 tests, 10 suites) stays green.

## Spec-surface consistency

| Surface | addListener / removeListeners / setActiveEvents / updatePaymentDetails |
| --- | --- |
| TS `NativePayments.ts` Spec | present (unchanged) |
| iOS `Payments.h` / `Payments.mm` | present, `RCTEventEmitter` subclass on both arch branches (unchanged) |
| Android new-arch `PaymentsSpec.java` | present via generated `NativePaymentsSpec` (unchanged) |
| Android old-arch `PaymentsSpec.java` | present as abstract methods (unchanged) |

No spec-surface changes were needed — this PR only fixes the JS-side handle-resolution check.

## Test plan

- [x] `yarn ts && yarn lint && yarn test` green from the worktree root
- [x] `yarn workspace @rnw-community/react-native-payments test:coverage` — 100% statements/functions/lines, 92.77% branches (above the package's 92% custom threshold)
- [x] `git grep -n 'NativeModules' packages/react-native-payments/src` shows no emitter-constructing use
- [ ] Runtime verification on real devices/simulators (old-arch iOS, bridgeless iOS) is deferred to the e2e issue (#393)

Closes #378

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `isTurboModuleEnabled` check to use existence check instead of null inequality
> Changes the TurboModule enablement check in [native-payments.ts](https://github.com/rnw-community/rnw-community/pull/428/files#diff-8b44ff2856f9bd1eec1e34cd69178e8a7a4970452e0cca8930c2dc82224c7131) from `global.__turboModuleProxy !== null` to `isDefined(global.__turboModuleProxy)`. In bridgeless mode, `__turboModuleProxy` may be `undefined` rather than `null`, causing the old check to incorrectly select the TurboModule path. Tests are updated to explicitly install or omit the proxy rather than setting it to `null`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ead43d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->