### PR TITLE
test(react-native-payments): 100% coverage, thresholds to 100

### DIFF
--- a/packages/react-native-payments/jest.config.js
+++ b/packages/react-native-payments/jest.config.js
@@ -2,10 +2,10 @@ module.exports = {
     ...require('../../get-jest.config.js')('react-native-payments'),
     coverageThreshold: {
         global: {
-            branches: 92,
-            lines: 99.9,
-            statements: 99.9,
-            functions: 99.9,
+            branches: 100,
+            lines: 100,
+            statements: 100,
+            functions: 100,
         },
     },
 };

--- a/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
@@ -3,6 +3,9 @@ import { Platform } from 'react-native';
 
 import { emptyFn } from '@rnw-community/shared';
 
+import { AndroidPaymentMethodTokenizationType } from '../../@standard/android/enum/android-payment-method-tokenization-type.enum';
+import { IOSPKContactField } from '../../@standard/ios/enum/ios-pk-contact-field.enum';
+import { IosPKMerchantCapability } from '../../@standard/ios/enum/ios-pk-merchant-capability.enum';
 import { IosPKPaymentMethodType } from '../../@standard/ios/enum/ios-pk-payment-method-type.enum';
 import { changeEventTimeoutMs } from '../../constant/change-event-timeout-ms';
 import { EnvironmentEnum } from '../../enum/environment.enum';
@@ -230,6 +233,40 @@ describe('PaymentRequest', () => {
                         `Failed to construct 'PaymentRequest':  '10.00.' is not a valid amount format for total`
                     )
                 );
+            });
+
+            it('should throw when total.amount.value is a negative number', () => {
+                expect.assertions(1);
+
+                const invalidPaymentDetails = {
+                    total: {
+                        label: 'Total',
+                        amount: {
+                            currency: 'USD',
+                            value: -10,
+                        },
+                    },
+                } as unknown as PaymentDetailsInit;
+
+                expect(() => new PaymentRequest([methodData], invalidPaymentDetails)).toThrow(
+                    new PaymentsError(`Failed to construct 'PaymentRequest':  Total amount value should be non-negative`)
+                );
+            });
+
+            it('should NOT throw when total.amount.value is a non-negative number', () => {
+                expect.assertions(1);
+
+                const validPaymentDetails = {
+                    total: {
+                        label: 'Total',
+                        amount: {
+                            currency: 'USD',
+                            value: 10,
+                        },
+                    },
+                } as unknown as PaymentDetailsInit;
+
+                expect(() => new PaymentRequest([methodData], validPaymentDetails)).not.toThrow();
             });
         });
 
@@ -649,6 +686,99 @@ describe('PaymentRequest', () => {
                 );
             });
         });
+
+        describe('platform method data serialization', () => {
+            const getSerializedAndroidMethodData = async (
+                requestMethodData: AndroidPaymentMethodDataInterface
+            ): Promise<AndroidPaymentDataRequest> => {
+                jest.mocked(NativePayments.canMakePayments).mockResolvedValue(true);
+
+                await new PaymentRequest([requestMethodData], paymentDetails).canMakePayment();
+
+                const [[serializedMethodData]] = jest.mocked(NativePayments.canMakePayments).mock.calls;
+
+                return JSON.parse(serializedMethodData) as AndroidPaymentDataRequest;
+            };
+
+            it('should require a full billing address when requestBillingAddress is set', async () => {
+                expect.hasAssertions();
+
+                const methodDataRequest = await getSerializedAndroidMethodData({
+                    ...androidMethodData,
+                    data: { ...androidMethodData.data, requestBillingAddress: true, requestPayerPhone: true },
+                });
+
+                expect(methodDataRequest.allowedPaymentMethods[0].parameters).toMatchObject({
+                    billingAddressRequired: true,
+                    billingAddressParameters: { format: 'FULL', phoneNumberRequired: true },
+                });
+            });
+
+            it('should require a minimal billing address when only the payer name is requested', async () => {
+                expect.hasAssertions();
+
+                const methodDataRequest = await getSerializedAndroidMethodData({
+                    ...androidMethodData,
+                    data: { ...androidMethodData.data, requestPayerName: true },
+                });
+
+                expect(methodDataRequest.allowedPaymentMethods[0].parameters).toMatchObject({
+                    billingAddressRequired: true,
+                    billingAddressParameters: { format: 'MIN', phoneNumberRequired: false },
+                });
+            });
+
+            it('should not require a billing address when no payer field is requested', async () => {
+                expect.hasAssertions();
+
+                const methodDataRequest = await getSerializedAndroidMethodData(androidMethodData);
+
+                expect(methodDataRequest.allowedPaymentMethods[0].parameters).not.toHaveProperty('billingAddressRequired');
+            });
+
+            it('should serialize a direct tokenization specification', async () => {
+                expect.hasAssertions();
+
+                const methodDataRequest = await getSerializedAndroidMethodData({
+                    supportedMethods: PaymentMethodNameEnum.AndroidPay,
+                    data: {
+                        currencyCode: 'USD',
+                        countryCode: 'US',
+                        supportedNetworks: [SupportedNetworkEnum.Visa],
+                        environment: EnvironmentEnum.TEST,
+                        directConfig: { protocolVersion: 'ECv2', publicKey: 'testPublicKey' },
+                    },
+                });
+
+                expect(methodDataRequest.allowedPaymentMethods[0].tokenizationSpecification).toStrictEqual({
+                    parameters: { protocolVersion: 'ECv2', publicKey: 'testPublicKey' },
+                    type: AndroidPaymentMethodTokenizationType.DIRECT,
+                });
+            });
+
+            it('should require the payer email when requestPayerEmail is set', async () => {
+                expect.hasAssertions();
+
+                const methodDataRequest = await getSerializedAndroidMethodData({
+                    ...androidMethodData,
+                    data: { ...androidMethodData.data, requestPayerEmail: true },
+                });
+
+                expect(methodDataRequest.emailRequired).toBe(true);
+            });
+
+            it('should require the shipping address when requestShipping is set', async () => {
+                expect.hasAssertions();
+
+                const methodDataRequest = await getSerializedAndroidMethodData({
+                    ...androidMethodData,
+                    data: { ...androidMethodData.data, requestShipping: true, requestPayerPhone: true },
+                });
+
+                expect(methodDataRequest.shippingAddressRequired).toBe(true);
+                expect(methodDataRequest.shippingAddressParameters).toStrictEqual({ phoneNumberRequired: true });
+            });
+        });
     });
 
     describe('PaymentRequest on iOS', () => {
@@ -665,6 +795,18 @@ describe('PaymentRequest', () => {
                 merchantIdentifier: 'merchant.com.example',
                 supportedNetworks: [SupportedNetworkEnum.Visa, SupportedNetworkEnum.Mastercard],
             },
+        };
+
+        const getSerializedIosMethodData = async (
+            requestMethodData: IosPaymentMethodDataInterface
+        ): Promise<IosPaymentDataRequest> => {
+            jest.mocked(NativePayments.canMakePayments).mockResolvedValue(true);
+
+            await new PaymentRequest([requestMethodData], paymentDetails).canMakePayment();
+
+            const [[serializedMethodData]] = jest.mocked(NativePayments.canMakePayments).mock.calls;
+
+            return JSON.parse(serializedMethodData) as IosPaymentDataRequest;
         };
 
         beforeEach(() => {
@@ -878,18 +1020,6 @@ describe('PaymentRequest', () => {
             );
         });
         describe('couponCode serialization', () => {
-            const getSerializedIosMethodData = async (
-                requestMethodData: IosPaymentMethodDataInterface
-            ): Promise<IosPaymentDataRequest> => {
-                jest.mocked(NativePayments.canMakePayments).mockResolvedValue(true);
-
-                await new PaymentRequest([requestMethodData], paymentDetails).canMakePayment();
-
-                const [[serializedMethodData]] = jest.mocked(NativePayments.canMakePayments).mock.calls;
-
-                return JSON.parse(serializedMethodData) as IosPaymentDataRequest;
-            };
-
             it('should serialize the prefilled coupon code', async () => {
                 expect.assertions(1);
 
@@ -912,6 +1042,71 @@ describe('PaymentRequest', () => {
 
                 expect(withoutCouponCode).not.toHaveProperty('couponCode');
                 expect(withEmptyCouponCode).not.toHaveProperty('couponCode');
+            });
+        });
+
+        describe('platform method data serialization', () => {
+            it('should serialize the provided merchant capabilities instead of the defaults', async () => {
+                expect.hasAssertions();
+
+                const methodDataRequest = await getSerializedIosMethodData({
+                    ...iosMethodData,
+                    data: {
+                        ...iosMethodData.data,
+                        merchantCapabilities: [IosPKMerchantCapability.PKMerchantCapabilityEMV],
+                    },
+                });
+
+                expect(methodDataRequest.merchantCapabilities).toStrictEqual([
+                    IosPKMerchantCapability.PKMerchantCapabilityEMV,
+                ]);
+            });
+
+            it('should serialize the default merchant capabilities when none are provided', async () => {
+                expect.hasAssertions();
+
+                const methodDataRequest = await getSerializedIosMethodData(iosMethodData);
+
+                expect(methodDataRequest.merchantCapabilities).toStrictEqual([
+                    IosPKMerchantCapability.PKMerchantCapability3DS,
+                    IosPKMerchantCapability.PKMerchantCapabilityDebit,
+                    IosPKMerchantCapability.PKMerchantCapabilityCredit,
+                ]);
+            });
+
+            it('should serialize the provided application data', async () => {
+                expect.hasAssertions();
+
+                const methodDataRequest = await getSerializedIosMethodData({
+                    ...iosMethodData,
+                    data: { ...iosMethodData.data, applicationData: 'dGVzdA==' },
+                });
+
+                expect(methodDataRequest.applicationData).toBe('dGVzdA==');
+            });
+
+            it('should not serialize a missing application data', async () => {
+                expect.hasAssertions();
+
+                const methodDataRequest = await getSerializedIosMethodData(iosMethodData);
+
+                expect(methodDataRequest).not.toHaveProperty('applicationData');
+            });
+
+            it('should exclude the postal address from the required shipping fields when shipping is not requested', async () => {
+                expect.hasAssertions();
+
+                const { requestShipping, ...dataWithoutShipping } = iosMethodData.data;
+                const methodDataRequest = await getSerializedIosMethodData({
+                    ...iosMethodData,
+                    data: dataWithoutShipping,
+                });
+
+                expect(methodDataRequest.requiredShippingContactFields).toStrictEqual([
+                    IOSPKContactField.PKContactFieldEmailAddress,
+                    IOSPKContactField.PKContactFieldName,
+                    IOSPKContactField.PKContactFieldPhoneNumber,
+                ]);
             });
         });
 

--- a/packages/react-native-payments/src/class/payment-request/payment-request.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.ts
@@ -91,10 +91,10 @@ export class PaymentRequest {
         validateTotal(details.total, ConstructorError);
 
         // 6. If the displayItems member of details is present, then for each item in details.displayItems:
-        validateDisplayItems(details.displayItems, ConstructorError);
+        validateDisplayItems(ConstructorError, details.displayItems);
 
         // 7. If the shippingOptions member of details is present, then for each option in details.shippingOptions:
-        validateShippingOptions(details.shippingOptions, ConstructorError);
+        validateShippingOptions(ConstructorError, details.shippingOptions);
 
         // 17. Set request.[[serializedMethodData]] to serializedMethodData.         */
         this.platformMethodData = this.findPlatformPaymentMethodData();
@@ -544,21 +544,12 @@ export class PaymentRequest {
                 ? methodData.merchantCapabilities
                 : defaultMerchantCapabilities,
             ...(methodData.requestBillingAddress === true && {
-                requiredBillingContactFields: this.getRequestedBillingFields(methodData),
+                requiredBillingContactFields: [IOSPKContactField.PKContactFieldPostalAddress],
             }),
             ...(isShippingRequested && { requiredShippingContactFields: requestedShippingFields }),
             ...(isDefined(methodData.applicationData) && { applicationData: methodData.applicationData }),
             ...(isNotEmptyString(methodData.couponCode) && { couponCode: methodData.couponCode }),
         };
-    }
-
-    private getRequestedBillingFields(methodData: IosPaymentMethodDataDataInterface): IOSPKContactField[] {
-        const requiredBillingFields: IOSPKContactField[] = [];
-        if (methodData.requestBillingAddress ?? false) {
-            requiredBillingFields.push(IOSPKContactField.PKContactFieldPostalAddress);
-        }
-
-        return requiredBillingFields;
     }
 
     private getRequestedShippingFields(methodData: IosPaymentMethodDataDataInterface): IOSPKContactField[] {

--- a/packages/react-native-payments/src/class/payment-response/android-payment-response.spec.ts
+++ b/packages/react-native-payments/src/class/payment-response/android-payment-response.spec.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, jest } from '@jest/globals';
 
 import { AndroidPaymentMethodTokenizationType } from '../../@standard/android/enum/android-payment-method-tokenization-type.enum';
+import { emptyAndroidIntermediateSigningKey } from '../../@standard/android/response/android-intermediate-signing-key';
 import { PaymentMethodNameEnum } from '../../enum/payment-method-name.enum';
 
 import { AndroidPaymentResponse } from './android-payment-response';
 
+import type { AndroidFullAddress } from '../../@standard/android/response/android-full-address';
 import type { AndroidPaymentData } from '../../@standard/android/response/android-payment-data';
 
 jest.mock('../native-payments/native-payments', () => ({
@@ -34,6 +36,32 @@ describe('AndroidPaymentResponse', () => {
         },
     });
 
+    const billingAddress: AndroidFullAddress = {
+        address1: '1 Infinite Loop',
+        address2: 'Suite 1',
+        address3: 'Building B',
+        administrativeArea: 'CA',
+        countryCode: 'US',
+        locality: 'Cupertino',
+        name: 'John Appleseed',
+        phoneNumber: '+1-555-555-5555',
+        postalCode: '95014',
+        sortingCode: '123',
+    };
+
+    const shippingAddress: AndroidFullAddress = {
+        address1: 'Invalidenstrasse 1',
+        address2: 'Apt 2',
+        address3: '',
+        administrativeArea: 'BE',
+        countryCode: 'DE',
+        locality: 'Berlin',
+        name: 'Jane Appleseed',
+        phoneNumber: '+49-30-000000',
+        postalCode: '10115',
+        sortingCode: '',
+    };
+
     const authorizedPayment: AndroidPaymentData = {
         apiVersion: 2,
         apiVersionMinor: 0,
@@ -45,33 +73,11 @@ describe('AndroidPaymentResponse', () => {
                 assuranceDetails: { accountVerified: true, cardHolderAuthenticated: true },
                 cardDetails: '1234',
                 cardNetwork: 'VISA',
-                billingAddress: {
-                    address1: '1 Infinite Loop',
-                    address2: 'Suite 1',
-                    address3: 'Building B',
-                    administrativeArea: 'CA',
-                    countryCode: 'US',
-                    locality: 'Cupertino',
-                    name: 'John Appleseed',
-                    phoneNumber: '+1-555-555-5555',
-                    postalCode: '95014',
-                    sortingCode: '123',
-                },
+                billingAddress,
             },
             tokenizationData: { type: AndroidPaymentMethodTokenizationType.PAYMENT_GATEWAY, token: paymentToken },
         },
-        shippingAddress: {
-            address1: 'Invalidenstrasse 1',
-            address2: 'Apt 2',
-            address3: '',
-            administrativeArea: 'BE',
-            countryCode: 'DE',
-            locality: 'Berlin',
-            name: 'Jane Appleseed',
-            phoneNumber: '+49-30-000000',
-            postalCode: '10115',
-            sortingCode: '',
-        },
+        shippingAddress,
     };
 
     const createResponse = (payment: AndroidPaymentData): AndroidPaymentResponse =>
@@ -142,5 +148,78 @@ describe('AndroidPaymentResponse', () => {
         expect(androidPayToken.protocolVersion).toBe('ECv2');
         expect(androidPayToken.signedMessage.tag).toBe('testTag');
         expect(androidPayToken.cardInfo.cardNetwork).toBe('VISA');
+    });
+
+    it('should default the shipping address payer phone to an empty string when omitted', () => {
+        expect.assertions(1);
+
+        const { info } = authorizedPayment.paymentMethodData;
+        const { phoneNumber, ...shippingAddressWithoutPhone } = shippingAddress;
+        const { details } = createResponse({
+            ...authorizedPayment,
+            paymentMethodData: {
+                ...authorizedPayment.paymentMethodData,
+                info: { assuranceDetails: info.assuranceDetails, cardDetails: info.cardDetails, cardNetwork: 'VISA' },
+            },
+            shippingAddress: shippingAddressWithoutPhone,
+        });
+
+        expect(details.payerPhone).toBe('');
+    });
+
+    it('should default the billing address payer phone to an empty string when omitted', () => {
+        expect.assertions(1);
+
+        const { phoneNumber, ...billingAddressWithoutPhone } = billingAddress;
+        const { details } = createResponse({
+            ...authorizedPayment,
+            paymentMethodData: {
+                ...authorizedPayment.paymentMethodData,
+                info: { ...authorizedPayment.paymentMethodData.info, billingAddress: billingAddressWithoutPhone },
+            },
+        });
+
+        expect(details.payerPhone).toBe('');
+    });
+
+    it('should throw when the tokenization data is missing a token', () => {
+        expect.assertions(1);
+
+        const paymentWithoutToken: AndroidPaymentData = {
+            ...authorizedPayment,
+            paymentMethodData: {
+                ...authorizedPayment.paymentMethodData,
+                tokenizationData: { type: AndroidPaymentMethodTokenizationType.PAYMENT_GATEWAY },
+            },
+        };
+
+        expect(() => createResponse(paymentWithoutToken)).toThrow(SyntaxError);
+    });
+
+    it('should default the intermediate signing key when the token does not carry one', () => {
+        expect.assertions(1);
+
+        const tokenWithoutIntermediateSigningKey = JSON.stringify({
+            protocolVersion: 'ECv2',
+            signature: 'testSignature',
+            signedMessage: JSON.stringify({
+                encryptedMessage: 'testEncryptedMessage',
+                ephemeralPublicKey: 'testEphemeralPublicKey',
+                tag: 'testTag',
+            }),
+        });
+
+        const { details } = createResponse({
+            ...authorizedPayment,
+            paymentMethodData: {
+                ...authorizedPayment.paymentMethodData,
+                tokenizationData: {
+                    type: AndroidPaymentMethodTokenizationType.PAYMENT_GATEWAY,
+                    token: tokenWithoutIntermediateSigningKey,
+                },
+            },
+        });
+
+        expect(details.androidPayToken.intermediateSigningKey).toStrictEqual(emptyAndroidIntermediateSigningKey);
     });
 });

--- a/packages/react-native-payments/src/util/validate-details-update.util.ts
+++ b/packages/react-native-payments/src/util/validate-details-update.util.ts
@@ -13,6 +13,6 @@ export const validateDetailsUpdate = (detailsUpdate: PaymentDetailsUpdate): void
         validateTotal(detailsUpdate.total, PaymentsError);
     }
 
-    validateDisplayItems(detailsUpdate.displayItems, PaymentsError);
-    validateShippingOptions(detailsUpdate.shippingOptions, PaymentsError);
+    validateDisplayItems(PaymentsError, detailsUpdate.displayItems);
+    validateShippingOptions(PaymentsError, detailsUpdate.shippingOptions);
 };

--- a/packages/react-native-payments/src/util/validate-display-items.util.ts
+++ b/packages/react-native-payments/src/util/validate-display-items.util.ts
@@ -5,10 +5,7 @@ import { isValidDecimalMonetaryValue } from './is-valid-decimal-monetary-value.u
 import type { PaymentItem } from '../@standard/w3c/payment-item';
 import type { PaymentsError } from '../error/payments.error';
 
-export const validateDisplayItems = (
-    displayItems: PaymentItem[] = [],
-    ErrorType: ClassType<PaymentsError> = Error
-): void => {
+export const validateDisplayItems = (ErrorType: ClassType<PaymentsError>, displayItems: PaymentItem[] = []): void => {
     // Check that the value of each display item is a valid decimal monetary value
     displayItems.forEach(item => {
         // TODO: Can we improve this checks?

--- a/packages/react-native-payments/src/util/validate-shipping-options.util.ts
+++ b/packages/react-native-payments/src/util/validate-shipping-options.util.ts
@@ -6,8 +6,8 @@ import type { PaymentShippingOption } from '../@standard/w3c/payment-shipping-op
 import type { PaymentsError } from '../error/payments.error';
 
 export const validateShippingOptions = (
-    shippingOptions: PaymentShippingOption[] = [],
-    ErrorType: ClassType<PaymentsError> = Error
+    ErrorType: ClassType<PaymentsError>,
+    shippingOptions: PaymentShippingOption[] = []
 ): void => {
     shippingOptions.forEach(shippingOption => {
         if (!isDefined(shippingOption) || !isNotEmptyString(shippingOption.id) || !isNotEmptyString(shippingOption.label)) {

--- a/packages/react-native-payments/src/util/validate-total.util.ts
+++ b/packages/react-native-payments/src/util/validate-total.util.ts
@@ -9,7 +9,7 @@ import type { AmountValue } from '../type/amount-value.type';
 const isNegative = (amountValue: AmountValue): boolean =>
     isNumber(amountValue) ? amountValue < 0 : amountValue.startsWith('-');
 
-export const validateTotal = (total: PaymentItem, ErrorType: ClassType<PaymentsError> = Error): void => {
+export const validateTotal = (total: PaymentItem, ErrorType: ClassType<PaymentsError>): void => {
     // Should Validator take an errorType to pre populate "Failed to construct 'PaymentRequest'"
 
     if (!isDefined(total)) {


### PR DESCRIPTION
## Summary
- Closed every remaining branch-coverage gap in `react-native-payments` (Android/iOS platform method data mapping, Android response nullish fallbacks, total-amount numeric branch) with tests that assert serialized values, not just execution.
- Removed two structurally dead branches instead of ignoring them: `PaymentRequest.getRequestedBillingFields`'s internal guard was unreachable (caller already gated on the same condition), and the three `validate*.util.ts` validators' `ErrorType` default was never used by any call site in the package.
- Raised `packages/react-native-payments/jest.config.js` coverage thresholds to 100/100/100/100 and removed the local branch-threshold override (was 92%).

## Test plan
- [x] `yarn test:coverage` in `packages/react-native-payments` → 100% statements/branches/functions/lines, 165/165 tests passing
- [x] `yarn ts` at repo root
- [x] `yarn lint` at repo root
- [x] `yarn test` at repo root

Closes #389

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Achieve 100% test coverage in react-native-payments and raise coverage thresholds
> - Adds tests for `PaymentRequest` covering negative total validation, Android billing address serialization, and iOS `merchantCapabilities` and `applicationData` serialization.
> - Adds tests for `AndroidPaymentResponse` covering missing `payerPhone` defaults, `SyntaxError` on missing token, and default `intermediateSigningKey` values.
> - Refactors `validateDisplayItems`, `validateShippingOptions`, and `validateTotal` to require `ErrorType` as the first positional argument (no default), updating all call sites in [`payment-request.ts`](https://github.com/rnw-community/rnw-community/pull/429/files#diff-fd94f54cea4d1c0f6b854bea4a7d185dbf3506b01fcec3799dc70bb604dfe81e) and [`validate-details-update.util.ts`](https://github.com/rnw-community/rnw-community/pull/429/files#diff-56393d64986dbcddc1fb58dabe847ab81f62bff45965217d031c8ffd01a3b9b6).
> - Removes the private `getRequestedBillingFields` method from `PaymentRequest`, inlining the `PKContactFieldPostalAddress` logic.
> - Raises all coverage thresholds in [`jest.config.js`](https://github.com/rnw-community/rnw-community/pull/429/files#diff-4c8374dd59cb970f62afe5205cddfa75f8de345f6ac9f767e16b6d7ae0b705a7) to 100%.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f221760.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->