### PR TITLE
refactor(react-native-payments): conventions sweep for the new payments code

### DIFF
--- a/packages/react-native-payments/AGENTS.md
+++ b/packages/react-native-payments/AGENTS.md
@@ -104,7 +104,7 @@ src/
 
 ### Coverage
 
-Custom: branches **92%** (platform-conditional code), rest **99.9%**.
+**100%** for branches, lines, statements and functions.
 
 ### TypeScript Config
 

--- a/packages/react-native-payments/android/src/main/java/com/payments/PaymentsModule.java
+++ b/packages/react-native-payments/android/src/main/java/com/payments/PaymentsModule.java
@@ -177,8 +177,6 @@ public class PaymentsModule extends PaymentsSpec {
         promise.resolve("AndroidPay complete is not supported");
     }
 
-    // HINT: GooglePay renders its own sheet in a separate activity and never asks the app for an in-sheet update,
-    // so the whole W3C change event handshake is accepted and answered immediately.
     @ReactMethod
     public void setActiveEvents(String requestId, ReadableArray eventNames, Promise promise) {
         Log.d(NAME, "Change events are not supported by AndroidPay, ignoring " + eventNames.size() + " event(s) of " + requestId);

--- a/packages/react-native-payments/ios/Payments.mm
+++ b/packages/react-native-payments/ios/Payments.mm
@@ -993,7 +993,6 @@ RCT_EXPORT_METHOD(canMakePayments: (NSString *)methodDataString
             networks[@"PKPaymentNetworkBarcode"] = PKPaymentNetworkBarcode;
         }
 
-        // HINT: Apple delisted Mir over the sanctions, it resolves but no Mir card can be provisioned
         if (@available(iOS 14.5, *)) {
             networks[@"PKPaymentNetworkMir"] = PKPaymentNetworkMir;
         }

--- a/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { Platform } from 'react-native';
 
-import { emptyFn } from '@rnw-community/shared';
+import { emptyFn, wait } from '@rnw-community/shared';
 
 import { AndroidPaymentMethodTokenizationType } from '../../@standard/android/enum/android-payment-method-tokenization-type.enum';
 import { IOSPKContactField } from '../../@standard/ios/enum/ios-pk-contact-field.enum';
@@ -236,7 +236,7 @@ describe('PaymentRequest', () => {
             });
 
             it('should throw when total.amount.value is a negative number', () => {
-                expect.assertions(1);
+                expect.hasAssertions();
 
                 const invalidPaymentDetails = {
                     total: {
@@ -254,7 +254,7 @@ describe('PaymentRequest', () => {
             });
 
             it('should NOT throw when total.amount.value is a non-negative number', () => {
-                expect.assertions(1);
+                expect.hasAssertions();
 
                 const validPaymentDetails = {
                     total: {
@@ -343,7 +343,7 @@ describe('PaymentRequest', () => {
                 });
 
             it('should NOT throw when shippingOptions is not defined or empty', () => {
-                expect.assertions(3);
+                expect.hasAssertions();
 
                 expect(() => new PaymentRequest([methodData], paymentDetailsWithTotal)).not.toThrow();
                 expect(() => constructWithShippingOptions([])).not.toThrow();
@@ -355,7 +355,7 @@ describe('PaymentRequest', () => {
             });
 
             it('should throw when a shipping option has no id or no label', () => {
-                expect.assertions(3);
+                expect.hasAssertions();
 
                 const expectedError = new ConstructorError(`Missing required member(s): id, label.`);
                 const amount = { currency: 'USD', value: '5.00' };
@@ -366,7 +366,7 @@ describe('PaymentRequest', () => {
             });
 
             it('should throw when a shipping option has no amount value', () => {
-                expect.assertions(2);
+                expect.hasAssertions();
 
                 const expectedError = new ConstructorError(`required member value is undefined.`);
 
@@ -377,7 +377,7 @@ describe('PaymentRequest', () => {
             });
 
             it('should throw when a shipping option amount value is not monetary', () => {
-                expect.assertions(1);
+                expect.hasAssertions();
 
                 expect(() =>
                     constructWithShippingOptions([
@@ -1021,7 +1021,7 @@ describe('PaymentRequest', () => {
         });
         describe('couponCode serialization', () => {
             it('should serialize the prefilled coupon code', async () => {
-                expect.assertions(1);
+                expect.hasAssertions();
 
                 const methodDataRequest = await getSerializedIosMethodData({
                     ...iosMethodData,
@@ -1032,7 +1032,7 @@ describe('PaymentRequest', () => {
             });
 
             it('should not serialize a missing or empty coupon code', async () => {
-                expect.assertions(2);
+                expect.hasAssertions();
 
                 const withoutCouponCode = await getSerializedIosMethodData(iosMethodData);
                 const withEmptyCouponCode = await getSerializedIosMethodData({
@@ -1399,9 +1399,7 @@ describe('PaymentRequest', () => {
             request.addEventListener('shippingoptionchange', async event => {
                 updatingWhileListening = request.updating;
 
-                await new Promise<void>(resolve => {
-                    setTimeout(resolve, 10);
-                });
+                await wait(10);
 
                 event.updateWith({ total: updatedTotal });
             });
@@ -1790,9 +1788,7 @@ describe('PaymentRequest', () => {
 
             const request = createInteractiveRequest();
             const listener = jest.fn(async (event: PaymentRequestUpdateEvent) => {
-                await new Promise<void>(resolve => {
-                    setTimeout(resolve, 10);
-                });
+                await wait(10);
 
                 event.updateWith({ total: updatedTotal });
             });
@@ -1824,9 +1820,7 @@ describe('PaymentRequest', () => {
             const request = createInteractiveRequest();
 
             request.addEventListener('shippingoptionchange', async (event: PaymentRequestUpdateEvent) => {
-                await new Promise<void>(resolve => {
-                    setTimeout(resolve, 10);
-                });
+                await wait(10);
 
                 event.updateWith({ total: updatedTotal });
             });

--- a/packages/react-native-payments/src/class/payment-request/payment-request.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.ts
@@ -93,7 +93,6 @@ export class PaymentRequest {
         // 6. If the displayItems member of details is present, then for each item in details.displayItems:
         validateDisplayItems(ConstructorError, details.displayItems);
 
-        // 7. If the shippingOptions member of details is present, then for each option in details.shippingOptions:
         validateShippingOptions(ConstructorError, details.shippingOptions);
 
         // 17. Set request.[[serializedMethodData]] to serializedMethodData.         */

--- a/packages/react-native-payments/src/class/payment-response/android-payment-response.spec.ts
+++ b/packages/react-native-payments/src/class/payment-response/android-payment-response.spec.ts
@@ -84,7 +84,7 @@ describe('AndroidPaymentResponse', () => {
         new AndroidPaymentResponse('requestId', PaymentMethodNameEnum.AndroidPay, JSON.stringify(payment));
 
     it('should parse the billing address of the authorized payment', () => {
-        expect.assertions(1);
+        expect.hasAssertions();
 
         expect(createResponse(authorizedPayment).details.billingAddress).toStrictEqual({
             address1: '1 Infinite Loop',
@@ -99,7 +99,7 @@ describe('AndroidPaymentResponse', () => {
     });
 
     it('should parse the shipping address of the authorized payment', () => {
-        expect.assertions(1);
+        expect.hasAssertions();
 
         expect(createResponse(authorizedPayment).details.shippingAddress).toStrictEqual({
             address1: 'Invalidenstrasse 1',
@@ -114,7 +114,7 @@ describe('AndroidPaymentResponse', () => {
     });
 
     it('should prefer the payer name and phone of the billing address', () => {
-        expect.assertions(3);
+        expect.hasAssertions();
 
         const { details } = createResponse(authorizedPayment);
 
@@ -124,7 +124,7 @@ describe('AndroidPaymentResponse', () => {
     });
 
     it('should take the payer name and phone from the shipping address without a billing address', () => {
-        expect.assertions(3);
+        expect.hasAssertions();
 
         const { info } = authorizedPayment.paymentMethodData;
         const { details } = createResponse({
@@ -141,7 +141,7 @@ describe('AndroidPaymentResponse', () => {
     });
 
     it('should parse the google pay token of the authorized payment', () => {
-        expect.assertions(3);
+        expect.hasAssertions();
 
         const { androidPayToken } = createResponse(authorizedPayment).details;
 
@@ -151,7 +151,7 @@ describe('AndroidPaymentResponse', () => {
     });
 
     it('should default the shipping address payer phone to an empty string when omitted', () => {
-        expect.assertions(1);
+        expect.hasAssertions();
 
         const { info } = authorizedPayment.paymentMethodData;
         const { phoneNumber, ...shippingAddressWithoutPhone } = shippingAddress;
@@ -168,7 +168,7 @@ describe('AndroidPaymentResponse', () => {
     });
 
     it('should default the billing address payer phone to an empty string when omitted', () => {
-        expect.assertions(1);
+        expect.hasAssertions();
 
         const { phoneNumber, ...billingAddressWithoutPhone } = billingAddress;
         const { details } = createResponse({
@@ -183,7 +183,7 @@ describe('AndroidPaymentResponse', () => {
     });
 
     it('should throw when the tokenization data is missing a token', () => {
-        expect.assertions(1);
+        expect.hasAssertions();
 
         const paymentWithoutToken: AndroidPaymentData = {
             ...authorizedPayment,
@@ -197,7 +197,7 @@ describe('AndroidPaymentResponse', () => {
     });
 
     it('should default the intermediate signing key when the token does not carry one', () => {
-        expect.assertions(1);
+        expect.hasAssertions();
 
         const tokenWithoutIntermediateSigningKey = JSON.stringify({
             protocolVersion: 'ECv2',

--- a/packages/react-native-payments/src/class/payment-response/ios-payment-response.spec.ts
+++ b/packages/react-native-payments/src/class/payment-response/ios-payment-response.spec.ts
@@ -83,7 +83,7 @@ describe('IosPaymentResponse', () => {
         new IosPaymentResponse('requestId', PaymentMethodNameEnum.ApplePay, JSON.stringify(payment));
 
     it('should parse the billing address of the authorized payment', () => {
-        expect.assertions(1);
+        expect.hasAssertions();
 
         expect(createResponse(authorizedPayment).details.billingAddress).toStrictEqual({
             address1: '1 Infinite Loop',
@@ -98,7 +98,7 @@ describe('IosPaymentResponse', () => {
     });
 
     it('should parse the shipping address of the authorized payment', () => {
-        expect.assertions(1);
+        expect.hasAssertions();
 
         expect(createResponse(authorizedPayment).details.shippingAddress).toStrictEqual({
             address1: 'Invalidenstrasse 1',
@@ -113,7 +113,7 @@ describe('IosPaymentResponse', () => {
     });
 
     it('should parse the payer name, email and phone of the shipping contact', () => {
-        expect.assertions(3);
+        expect.hasAssertions();
 
         const { details } = createResponse(authorizedPayment);
 
@@ -123,7 +123,7 @@ describe('IosPaymentResponse', () => {
     });
 
     it('should parse the apple pay token of the authorized payment', () => {
-        expect.assertions(2);
+        expect.hasAssertions();
 
         const { applePayToken } = createResponse(authorizedPayment).details;
 
@@ -132,7 +132,7 @@ describe('IosPaymentResponse', () => {
     });
 
     it('should fall back to empty values when no contact was requested', () => {
-        expect.assertions(4);
+        expect.hasAssertions();
 
         const { details } = createResponse({ token: authorizedPayment.token });
 

--- a/packages/react-native-payments/src/enum/supported-networks.enum.ts
+++ b/packages/react-native-payments/src/enum/supported-networks.enum.ts
@@ -14,10 +14,6 @@ export enum SupportedNetworkEnum {
     Mada = 'mada',
     Maestro = 'maestro',
     Mastercard = 'masterCard',
-    /**
-     * @deprecated Apple delisted Mir over the sanctions against the issuing banks. The network still resolves on
-     * iOS 14.5+ so an existing integration keeps building, but no Mir card can be provisioned into Apple Pay.
-     */
     Mir = 'mir',
     PrivateLabel = 'privateLabel',
     Visa = 'visa',


### PR DESCRIPTION
## Audit — full package diff vs master

| # | Rule | Status | Evidence |
|---|------|--------|----------|
| 1 | One exported entity per file (event classes/interfaces own file; no extra exports from payment-request.ts) | PASS | Every new/changed file (`change-event-dispatcher.ts`, `payment-method-change-event.ts`, `payment-request-update-event.ts`, all new `interface`/`type`/`enum`/`constant` files) exports exactly one entity; `index.ts` is a re-export-only barrel; `payment-request.ts` exports only `PaymentRequest` |
| 2 | `.interface.ts`/`.type.ts` suffixes; no single-file folders | PASS | New `src/interface/*.interface.ts` and `src/type/*.type.ts` are flat (no spec/md siblings); new `class/change-event-dispatcher/`, `class/payment-method-change-event/`, `class/payment-request-update-event/`, `util/get-native-payments-event-emitter/` each group source+spec+md (3 files). `@standard/w3c/payment-shipping-option.ts` has no suffix, matching the pre-existing, unbroken no-suffix convention of every other file in `@standard/{w3c,ios,android}` (out of scope to rename the whole zone) |
| 3 | Zero comments in TS except sanctioned pragmas; check ObjC/Java for explanatory comments added by this epic | FIXED | Removed 4 net-new narrative/doc comments introduced by this train: a `@deprecated` JSDoc block on `SupportedNetworkEnum.Mir` (redundant with readme.md §2.2), a new numbered W3C-step comment in `payment-request.ts` constructor, a HINT comment in `Payments.mm` (Mir delisting) and one in `PaymentsModule.java` (GooglePay no-op rationale) — all already documented in readme.md. One net-new comment was deliberately kept: `@standard/ios/request/ios-payment-data-request.ts` gained a `couponCode` field together with its own `// https://developer.apple.com/...` doc-URL line — new, but it matches the unbroken per-field convention every other property in that file already carries (all pre-existing, unchanged since master), so stripping only the new one would leave that one field undocumented relative to its siblings; ruling: keep it, flag the whole file's convention as legacy debt for a dedicated future cleanup. All other pre-existing comments (W3C step markers, HINT/TODO lines, Apple-doc-URL references) that already existed in `origin/master` and were not touched by this train are left as-is. `/* istanbul ignore */` pragmas: zero present (`grep -rn "istanbul ignore" src` — no matches) |
| 4 | Shared primitives everywhere (isDefined/isError/isString/isNotEmptyString/isArray/isNotEmptyArray/getErrorMessage/emptyFn/wait) | FIXED | 3 new tests in `payment-request.spec.ts` used `new Promise<void>(resolve => { setTimeout(resolve, 10); })` — replaced with `wait(10)` from `@rnw-community/shared`. Swept all touched files for `!== null && !== undefined`, `typeof x === 'string'`, `instanceof Error`, raw `new Promise(...setTimeout...)`, `() => void 0`, `.catch(() => {})` noops, `Array.isArray` — no other instances found; existing code already uses `isDefined`/`isError`/`isNotEmptyString`/`isEmptyArray`/`isNotEmptyArray`/`emptyFn`/`getErrorMessage` throughout |
| 5 | index.ts exports complete; one-home-per-type (no cross-package re-exports) | PASS | `git grep "export type.*from '@rnw-community" packages/react-native-payments/src` → no matches. All new public entities (`PaymentRequestUpdateEvent`, `PaymentMethodChangeEvent`, `PaymentShippingOption`, event types/interfaces) are exported from `index.ts` consistent with what's already public vs. internal |
| 6 | `expect.hasAssertions()` in every test; `@jest/globals` imports | FIXED (new) / documented (pre-existing) | **Two fix rounds.** Round 1 converted 8 net-new `expect.assertions(N)` calls in `payment-request.spec.ts` to `expect.hasAssertions()`. Round 2 (this update) fixed a coordinator-flagged miss: **14 more** net-new `expect.assertions(N)` calls in the two entirely-new files `payment-response/android-payment-response.spec.ts` (9) and `payment-response/ios-payment-response.spec.ts` (5) — both files are 100% new vs `origin/master` (git status `A`), so every assertion call in them is a net-new violation; all 14 are now `expect.hasAssertions()`. Total net-new fixes: 22. Ruling on pre-existing usage: `payment-request.spec.ts` still has 40 pre-existing `expect.assertions(N)` calls (verified count against `origin/master`'s copy of the file, corrected from an earlier "~46" approximation) and `payment-response.spec.ts` (modified, not new) has 5 pre-existing ones — both predate this epic byte-for-byte and are left alone as out-of-scope legacy debt, not part of "the new payments code" this issue targets. Every touched `.spec.ts` file imports from `@jest/globals`; `it()` count now matches assertions-call count 1:1 in every new file |
| 7 | Test-only fixtures inlined in specs; none in src/ outside specs; none exported from index.ts | PASS | No `*.mock.ts` or fixture files added; searched touched-file list and full `src/` tree — none found |
| 8 | ESLint limits respected (85 lines/fn, 12 statements, 4 params); zero disables added to dodge them | PASS | `yarn lint` is clean (0 errors) for the package. New `eslint-disable-next-line` pragmas added by this train (`no-await-in-loop`, `no-console`) are unrelated to the three limits under audit; the pre-existing file-level `/* eslint-disable max-lines */` in `payment-request.ts` predates this epic and is a file-length rule, not one of the three limits called out |

**Result: 6 rules pass as-is, 2 fixed (comments + shared primitives), with the `expect.hasAssertions()` rule split — 22 net-new violations fixed across two rounds, pre-existing ones (40 + 5) documented as out of scope.**

## Fixes made

**Round 1:**
- `src/class/payment-request/payment-request.spec.ts`: 8× `expect.assertions(N)` → `expect.hasAssertions()` on tests added by this epic; 3× `new Promise(resolve => setTimeout(resolve, 10))` → `wait(10)` (added `wait` to the `@rnw-community/shared` import)
- `src/class/payment-request/payment-request.ts`: removed a newly-added numbered W3C-step comment (the other pre-existing numbered comments are untouched, out of scope)
- `src/enum/supported-networks.enum.ts`: removed a newly-added `@deprecated` JSDoc block (already documented in readme.md)
- `ios/Payments.mm`: removed a newly-added HINT comment about Mir delisting (already documented in readme.md)
- `android/src/main/java/com/payments/PaymentsModule.java`: removed a newly-added HINT comment about GooglePay's no-op change-event handshake (already documented in readme.md)
- `AGENTS.md`: corrected a stale coverage note ("branches 92%, rest 99.9%") to match the package's actual `jest.config.js` gate, now 100/100/100/100 after #389

**Round 2 (coordinator-flagged fix):**
- `src/class/payment-response/android-payment-response.spec.ts`: 9× `expect.assertions(N)` → `expect.hasAssertions()` (entirely new file, every call was a net-new violation)
- `src/class/payment-response/ios-payment-response.spec.ts`: 5× `expect.assertions(N)` → `expect.hasAssertions()` (entirely new file, every call was a net-new violation)

## Gates

- `yarn ts` (root, all 23 packages): pass
- `yarn lint` (root, all 23 packages): pass, 0 errors
- `yarn test` (root, all 23 packages): pass, 19/19 tasks
- `cd packages/react-native-payments && yarn test:coverage`: **100%** statements / branches / functions / lines (323/323, 270/270, 82/82, 321/321) — unchanged from #389

Closes #388


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply conventions sweep to react-native-payments test and source files
> - Replaces `expect.assertions(n)` with `expect.hasAssertions()` across payment request and response spec files for more flexible assertion counting.
> - Replaces manual `setTimeout`-based Promises in async listener tests with `wait` from `@rnw-community/shared`.
> - Removes stale comments from source files including deprecation notes, numbered step comments, and platform-conditional remarks; no logic changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 87d9ac8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->