### PR TITLE
ci: add self-hosted maestro e2e workflows

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+    labels:
+        - macOS
+        - ARM64
+        - macos-maestro
+        - linux-tiered
+        - linux-xl

--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -1,0 +1,118 @@
+name: Android Maestro E2E
+
+# Draft workflow for issue #395 (react-native-payments revival, epic #372). The
+# self-hosted Linux fleet is not registered yet (blocked on #396), so runs
+# simply queue until that lands. workflow_dispatch + path filters + a nightly
+# schedule keep this safe to land ahead of the fleet.
+on:
+    workflow_dispatch:
+    push:
+        branches: [master]
+        paths:
+            - packages/react-native-payments/**
+            - packages/react-native-payments-example/**
+            - .github/workflows/android-maestro.yml
+    schedule:
+        - cron: '47 3 * * *'
+
+concurrency:
+    group: android-maestro-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+env:
+    MAESTRO_VERSION: '2.8.0'
+    MAESTRO_CLI_NO_ANALYTICS: true
+    MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED: true
+    YARN_ENABLE_IMMUTABLE_INSTALLS: true
+    EXAMPLE_DIR: packages/react-native-payments-example
+
+jobs:
+    maestro:
+        name: Maestro (${{ matrix.target }})
+        runs-on: [self-hosted, linux-tiered, linux-xl]
+        timeout-minutes: 75
+        strategy:
+            fail-fast: false
+            matrix:
+                target: [bare, expo]
+        env:
+            APP_DIR: packages/react-native-payments-example/apps/${{ matrix.target }}
+            MAESTRO_DEBUG_OUTPUT_DIRECTORY: ${{ github.workspace }}/packages/react-native-payments-example/artifacts/maestro-android-${{ matrix.target }}
+
+        steps:
+            -   name: Checkout repository
+                uses: actions/checkout@v5
+
+            -   name: Setup Node
+                uses: actions/setup-node@v5
+                with:
+                    node-version: 22.x
+                    cache: yarn
+
+            -   name: Enable corepack
+                run: corepack enable
+
+            -   name: Install dependencies
+                run: yarn install --immutable
+
+            -   name: Generate native project (expo)
+                if: matrix.target == 'expo'
+                working-directory: ${{ env.EXAMPLE_DIR }}
+                run: yarn prebuild:expo
+
+            -   name: Restore Gradle cache
+                uses: actions/cache@v4
+                with:
+                    path: |
+                        ~/.gradle/caches
+                        ~/.gradle/wrapper
+                    key: gradle-${{ matrix.target }}-${{ runner.os }}-${{ hashFiles(format('{0}/android/gradle/wrapper/gradle-wrapper.properties', env.APP_DIR), format('{0}/android/**/*.gradle*', env.APP_DIR), format('{0}/package.json', env.APP_DIR), format('{0}/app.json', env.APP_DIR), 'yarn.lock') }}
+                    restore-keys: |
+                        gradle-${{ matrix.target }}-${{ runner.os }}-
+
+            -   name: Install Maestro
+                run: |
+                    maestro_bin="$HOME/.maestro/bin/maestro"
+                    if [ ! -x "$maestro_bin" ] || [ "$("$maestro_bin" --version 2>/dev/null | tail -n 1 | tr -d '\r' || true)" != "$MAESTRO_VERSION" ]; then
+                      curl -fsSL https://get.maestro.mobile.dev | env MAESTRO_VERSION="$MAESTRO_VERSION" bash
+                    fi
+                    echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+            -   name: Run emulator, build, and test
+                uses: reactivecircus/android-emulator-runner@v2.34.0
+                with:
+                    api-level: 34
+                    target: google_apis
+                    arch: x86_64
+                    profile: pixel_6
+                    disable-animations: true
+                    disable-spellchecker: true
+                    force-avd-creation: false
+                    emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+                    script: |
+                        set -euo pipefail
+                        cd "${{ env.EXAMPLE_DIR }}"
+                        yarn android:${{ matrix.target }}
+                        yarn e2e:android:${{ matrix.target }}
+
+            -   name: Capture final device state
+                if: failure()
+                shell: bash
+                run: |
+                    out="${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}"
+                    mkdir -p "$out"
+                    adb exec-out screencap -p > "$out/final-screen.png" || true
+                    adb logcat -d > "$out/logcat-full.txt" 2>&1 || true
+                    adb logcat -d -b crash > "$out/logcat-crash.txt" 2>&1 || true
+
+            -   name: Upload Maestro artifacts
+                if: failure()
+                uses: actions/upload-artifact@v4
+                with:
+                    name: maestro-android-${{ matrix.target }}
+                    path: ${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}/**
+                    if-no-files-found: warn
+                    retention-days: 7

--- a/.github/workflows/ios-maestro.yml
+++ b/.github/workflows/ios-maestro.yml
@@ -1,0 +1,141 @@
+name: iOS Maestro E2E
+
+# Draft workflow for issue #395 (react-native-payments revival, epic #372). The
+# self-hosted macOS fleet is not registered yet (blocked on #396), so runs
+# simply queue until that lands. workflow_dispatch + path filters + a nightly
+# schedule keep this safe to land ahead of the fleet.
+on:
+    workflow_dispatch:
+    push:
+        branches: [master]
+        paths:
+            - packages/react-native-payments/**
+            - packages/react-native-payments-example/**
+            - .github/workflows/ios-maestro.yml
+    schedule:
+        - cron: '17 3 * * *'
+
+concurrency:
+    group: ios-maestro-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+env:
+    MAESTRO_VERSION: '2.8.0'
+    MAESTRO_CLI_NO_ANALYTICS: true
+    MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED: true
+    YARN_ENABLE_IMMUTABLE_INSTALLS: true
+    EXAMPLE_DIR: packages/react-native-payments-example
+
+jobs:
+    maestro:
+        name: Maestro (${{ matrix.target }})
+        runs-on: [self-hosted, macOS, ARM64, macos-maestro]
+        timeout-minutes: 60
+        strategy:
+            fail-fast: false
+            matrix:
+                target: [bare, expo]
+        env:
+            APP_DIR: packages/react-native-payments-example/apps/${{ matrix.target }}
+            MAESTRO_DEBUG_OUTPUT_DIRECTORY: ${{ github.workspace }}/packages/react-native-payments-example/artifacts/maestro-ios-${{ matrix.target }}
+
+        steps:
+            -   name: Checkout repository
+                uses: actions/checkout@v5
+
+            -   name: Setup Node
+                uses: actions/setup-node@v5
+                with:
+                    node-version: 22.x
+                    cache: yarn
+
+            -   name: Enable corepack
+                run: corepack enable
+
+            -   name: Install dependencies
+                run: yarn install --immutable
+
+            -   name: Verify Xcode toolchain
+                run: xcodebuild -version
+
+            -   name: Restore CocoaPods global cache
+                uses: actions/cache@v4
+                with:
+                    path: |
+                        ~/Library/Caches/CocoaPods
+                        ~/.cocoapods
+                    key: pods-global-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+                    restore-keys: |
+                        pods-global-${{ runner.os }}-
+
+            -   name: Restore project Pods and DerivedData cache
+                uses: actions/cache@v4
+                with:
+                    path: |
+                        ${{ env.APP_DIR }}/ios/Pods
+                        ~/Library/Developer/Xcode/DerivedData/ReactNativePaymentsExample*
+                    key: pods-project-ios-${{ matrix.target }}-${{ runner.os }}-${{ hashFiles(format('{0}/ios/Podfile.lock', env.APP_DIR), format('{0}/package.json', env.APP_DIR), format('{0}/app.json', env.APP_DIR), 'yarn.lock') }}
+                    restore-keys: |
+                        pods-project-ios-${{ matrix.target }}-${{ runner.os }}-
+
+            -   name: Generate native project (expo)
+                if: matrix.target == 'expo'
+                working-directory: ${{ env.EXAMPLE_DIR }}
+                run: yarn prebuild:expo
+
+            -   name: Install CocoaPods dependencies (bare)
+                if: matrix.target == 'bare'
+                working-directory: ${{ env.APP_DIR }}/ios
+                run: pod install --repo-update
+
+            -   name: Boot iOS Simulator
+                shell: bash
+                run: |
+                    set -euo pipefail
+                    device_line=$(xcrun simctl list devices available | grep -E '^\s+iPhone.*\(' | tail -1)
+                    test -n "$device_line"
+                    device_udid=$(grep -oE '[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}' <<< "$device_line")
+                    test -n "$device_udid"
+                    echo "Booting simulator: $device_line"
+                    xcrun simctl boot "$device_udid" || true
+                    xcrun simctl bootstatus "$device_udid" -b
+                    echo "SIMULATOR_UDID=$device_udid" >> "$GITHUB_ENV"
+
+            -   name: Build and launch app
+                working-directory: ${{ env.EXAMPLE_DIR }}
+                run: yarn ios:${{ matrix.target }}
+
+            -   name: Install Maestro
+                run: |
+                    maestro_bin="$HOME/.maestro/bin/maestro"
+                    if [ ! -x "$maestro_bin" ] || [ "$("$maestro_bin" --version 2>/dev/null | tail -n 1 | tr -d '\r' || true)" != "$MAESTRO_VERSION" ]; then
+                      curl -fsSL https://get.maestro.mobile.dev | env MAESTRO_VERSION="$MAESTRO_VERSION" bash
+                    fi
+                    echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+            -   name: Run Maestro suite
+                working-directory: ${{ env.EXAMPLE_DIR }}
+                run: yarn e2e:ios:${{ matrix.target }}
+
+            -   name: Capture final simulator state
+                if: failure()
+                shell: bash
+                run: |
+                    mkdir -p "${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}"
+                    xcrun simctl io "$SIMULATOR_UDID" screenshot "${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}/final-screen.png" || true
+
+            -   name: Shutdown simulator
+                if: always()
+                run: xcrun simctl shutdown "$SIMULATOR_UDID" || true
+
+            -   name: Upload Maestro artifacts
+                if: failure()
+                uses: actions/upload-artifact@v4
+                with:
+                    name: maestro-ios-${{ matrix.target }}
+                    path: ${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}/**
+                    if-no-files-found: warn
+                    retention-days: 7


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ios-maestro.yml` (`runs-on: [self-hosted, macOS, ARM64, macos-maestro]`) and `.github/workflows/android-maestro.yml` (`runs-on: [self-hosted, linux-tiered, linux-xl]`), each matrixed over the `bare`/`expo` targets of `packages/react-native-payments-example`.
- Both workflows build the example app and run its Maestro suite via the package's own scripts (`ios:<target>`/`android:<target>` for build+launch, `e2e:ios:<target>`/`e2e:android:<target>` for the Maestro run), with an explicit `expo prebuild` step ahead of the native build for the Expo target.
- CocoaPods/DerivedData (iOS) and Gradle (Android) caching keyed on `yarn.lock` plus the native lockfiles/dirs where they exist (falling back to `package.json`/`app.json` pre-generation for the Expo target, since its native dirs don't exist until `expo prebuild` runs).
- Failure-only artifact upload (Maestro debug output, final screen capture, device logs); no artifacts retained on success.
- Triggers: `workflow_dispatch`, a path-filtered `push` to `master` (`packages/react-native-payments/**`, `packages/react-native-payments-example/**`, the workflow files themselves), and a nightly `schedule`. No `pull_request` trigger, so this doesn't leave a perpetually-queued check on every contributor PR while the fleet is unregistered.
- Adds `.github/actionlint.yaml` declaring the custom self-hosted runner labels so `actionlint` doesn't flag them as unknown.

## Status

Draft-only, per #395: the self-hosted fleet isn't registered yet (blocked on external issue #396), so these workflows will queue/fail-closed until that lands. The "green runs for both platforms × both targets" and "cold vs warm build time documented" acceptance criteria in #395 are **not** met by this PR and remain blocked on #396 — this PR only lands the workflow definitions safely (manual dispatch + path filters + nightly schedule, no impact on PR checks).

The example app's `apps/bare`/`apps/expo` targets and Maestro suite referenced here (from #393) aren't on `master` yet either; the workflow paths/script names are written against that branch's real, documented interface per the task brief, and will resolve correctly once it merges.

Closes #395

## Test plan

- [x] `actionlint` on both new workflow files (clean; repo-wide `actionlint` run shows only one pre-existing, unrelated finding in `release.yml`)
- [x] `yarn ts && yarn lint && yarn test && yarn deadcode` at repo root (all pass, pre-existing warnings only)
- [ ] Green fleet runs for both platforms × both targets — blocked on #396

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add self-hosted Maestro E2E workflows for iOS and Android
> - Adds [android-maestro.yml](.github/workflows/android-maestro.yml) to run Maestro E2E tests on self-hosted Linux runners (`linux-tiered`, `linux-xl`) using an Android emulator (API 34, Pixel 6 profile) for both `bare` and `expo` targets.
> - Adds [ios-maestro.yml](.github/workflows/ios-maestro.yml) to run Maestro E2E tests on self-hosted macOS ARM64 runners (`macos-maestro`) using a booted iOS simulator for both `bare` and `expo` targets.
> - Both workflows trigger on `workflow_dispatch`, pushes to `master` affecting `react-native-payments` packages, and a nightly cron schedule.
> - Both workflows cache build artifacts (Gradle for Android, CocoaPods/DerivedData for iOS) and upload screenshots and logcat/simulator output as artifacts on failure.
> - Updates [actionlint.yaml](.github/actionlint.yaml) to allowlist the self-hosted runner labels used by these workflows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe354fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->