### PR TITLE
fix(react-native-payments): resolve open bot findings and finish the release polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,14 @@ The monorepo uses dual ESM + CJS output. Key decisions:
 - `lib: ["es2021"]` matches the build target
 - Build scripts correctly reference their tsconfig files (`build:esm` → `tsconfig.build-esm.json`)
 
+## PR Review & Merge Policy
+
+**Before merging any PR, read every bot review comment on it** (Macroscope, Codecov, claude-review, DeepScan). Treat
+unresolved bot findings as merge blockers: **never merge a PR carrying an open bot finding without explicit maintainer
+approval** — resolve the finding, refute it in a reply on the thread, or get the maintainer's sign-off first. Findings
+marked resolved/outdated by the bot itself are cleared. This applies to agents and humans alike, and to admin merges
+especially.
+
 ## Pre-commit Checks
 
 **IMPORTANT: Always run all checks before committing and pushing:**

--- a/packages/react-native-payments/CHANGELOG.md
+++ b/packages/react-native-payments/CHANGELOG.md
@@ -11,6 +11,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [2.5.0](https://github.com/rnw-community/rnw-community/compare/v2.4.0...v2.5.0) (2026-08-02)
 
+The W3C change-event revival in this release builds on the original contribution by
+[@dutompson](https://github.com/dutompson) in [#343](https://github.com/rnw-community/rnw-community/pull/343).
+
 ### Bug Fixes
 
 - **react-native-payments:** align show() test fixtures with its new request id argument ([88df271](https://github.com/rnw-community/rnw-community/commit/88df2718d279cd1b08a8e5807476ce03bafa15ad))

--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -562,7 +562,8 @@ completeness — one usage example each.
 
 The message carried by every `DOMException` and rejection the library throws: `AbortError`, `InvalidStateError`,
 `NotAllowedError`, `NotSupportedError`, `SecurityError`. Every `DOMException` also carries the W3C error name in
-`error.name`, which is the stable way to branch on the failure:
+`error.name`, which is the stable way to branch on the failure. Native user cancellation (the person dismissing the
+payment sheet on either platform) is normalized to an `AbortError` `DOMException`, matching the W3C behaviour:
 
 ```ts
 paymentRequest.show().catch((error: Error) => {

--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -1,6 +1,7 @@
 # ReactNative Payments
 
-[![npm version](https://badge.fury.io/js/%40rnw-community%2Fnestjs-webpack-swc.svg)](https://badge.fury.io/js/%40rnw-community%2Freact-native-payments)
+[![npm version](https://badge.fury.io/js/%40rnw-community%2Freact-native-payments.svg)](https://badge.fury.io/js/%40rnw-community%2Freact-native-payments)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=react-native-payments&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Freact-native-payments.svg)](https://www.npmjs.com/package/%40rnw-community%2Freact-native-payments)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 
@@ -537,6 +538,10 @@ selection is still stored on the request, so these values always describe what t
 
 ## Migrating from v2
 
+> **The native module interface changed** (`show()` now carries the request id, and the change-event methods are part of
+> the TurboModule spec). Rebuild the native app when upgrading — a JavaScript-only update (e.g. CodePush/OTA) shipped on
+> top of a v2 binary will fail to open the payment sheet.
+
 The `v2.x` line shipped no change-event API: the sheet only ever showed the `PaymentDetailsInit` given to the
 constructor, and neither `addEventListener` nor `removeEventListener` existed. Adopting the event API above is purely
 additive — `PaymentRequest`, `canMakePayment()`, `show()`, `abort()` and `PaymentComplete` keep their v2 signatures, and a
@@ -556,11 +561,12 @@ completeness — one usage example each.
 ### `PaymentsErrorEnum`
 
 The message carried by every `DOMException` and rejection the library throws: `AbortError`, `InvalidStateError`,
-`NotAllowedError`, `NotSupportedError`, `SecurityError`.
+`NotAllowedError`, `NotSupportedError`, `SecurityError`. Every `DOMException` also carries the W3C error name in
+`error.name`, which is the stable way to branch on the failure:
 
 ```ts
 paymentRequest.show().catch((error: Error) => {
-    if (error.message === PaymentsErrorEnum.AbortError) {
+    if (error.name === 'AbortError') {
         // the user dismissed the sheet
     }
 });

--- a/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
@@ -2101,6 +2101,20 @@ describe('PaymentRequest', () => {
             expect(updatePaymentDetailsMock).not.toHaveBeenCalled();
         });
 
+        it.each(['E_CANCELLED_BY_USER', 'payment_error'])(
+            'should reject show() with an AbortError DOMException when native cancels with %s',
+            async code => {
+                expect.hasAssertions();
+
+                const cancellation = Object.assign(new Error('canceled'), { code });
+                jest.mocked(NativePayments.show).mockRejectedValue(cancellation);
+
+                const request = createRequest();
+
+                await expect(request.show()).rejects.toMatchObject({ name: 'AbortError' });
+            }
+        );
+
         it('should name DOMException rejections after their W3C error type', async () => {
             expect.hasAssertions();
 

--- a/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
@@ -1622,6 +1622,34 @@ describe('PaymentRequest', () => {
             );
         });
 
+        it('should keep numeric shipping option amounts away from native and answer with the unchanged details', async () => {
+            expect.hasAssertions();
+
+            const request = createInteractiveRequest();
+
+            request.addEventListener('shippingoptionchange', event => {
+                event.updateWith({
+                    total: updatedTotal,
+                    shippingOptions: [
+                        { id: 'express', label: 'Express', amount: { currency: 'USD', value: 5 as unknown as string } },
+                    ],
+                });
+            });
+
+            emitNativeEvent('shippingoptionchange', { requestId: request.id, shippingOption: 'express' });
+            await nativeUpdate;
+
+            expect(warnMock).toHaveBeenCalledWith(
+                expect.stringContaining(`'5' is not a valid amount format for shipping options`)
+            );
+            expect(request.details.shippingOptions).toBeUndefined();
+            expect(updatePaymentDetailsMock).toHaveBeenCalledWith(
+                { error: '', eventName: 'shippingoptionchange', requestId: request.id, total: initialTotal },
+                [],
+                []
+            );
+        });
+
         it('should keep invalid shipping options away from native and answer with the unchanged details', async () => {
             expect.hasAssertions();
 
@@ -2071,6 +2099,14 @@ describe('PaymentRequest', () => {
             expect(setActiveEventsMock).toHaveBeenLastCalledWith(request.id, []);
             expect(listener).not.toHaveBeenCalled();
             expect(updatePaymentDetailsMock).not.toHaveBeenCalled();
+        });
+
+        it('should name DOMException rejections after their W3C error type', async () => {
+            expect.hasAssertions();
+
+            const request = createRequest();
+
+            await expect(request.abort()).rejects.toMatchObject({ name: 'InvalidStateError' });
         });
 
         it('should remove all subscriptions when show rejects', async () => {

--- a/packages/react-native-payments/src/class/payment-request/payment-request.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.ts
@@ -18,6 +18,7 @@ import { ConstructorError } from '../../error/constructor.error';
 import { DOMException } from '../../error/dom.exception';
 import { PaymentsError } from '../../error/payments.error';
 import { getNativePaymentsEventEmitter } from '../../util/get-native-payments-event-emitter/get-native-payments-event-emitter.util';
+import { isNativeUserCancellation } from '../../util/is-native-user-cancellation.util';
 import { validateAndroidTransactionInfo } from '../../util/validate-android-transaction-info.util';
 import { validateDetailsUpdate } from '../../util/validate-details-update.util';
 import { validateDisplayItems } from '../../util/validate-display-items.util';
@@ -147,6 +148,13 @@ export class PaymentRequest {
                 })
                 .catch((error: unknown) => {
                     this.closeRequest();
+
+                    if (isNativeUserCancellation(error)) {
+                        reject(new DOMException(PaymentsErrorEnum.AbortError));
+
+                        return;
+                    }
+
                     reject(isError(error) ? error : new PaymentsError(`Failed showing PaymentRequest`));
                 });
         });

--- a/packages/react-native-payments/src/error/dom.exception.ts
+++ b/packages/react-native-payments/src/error/dom.exception.ts
@@ -13,7 +13,16 @@ export class DOMException extends PaymentsError {
         [PaymentsErrorEnum.SecurityError]: 'The operation is insecure.',
     };
 
+    private static readonly names: Record<PaymentsErrorEnum, string> = {
+        [PaymentsErrorEnum.AbortError]: 'AbortError',
+        [PaymentsErrorEnum.InvalidStateError]: 'InvalidStateError',
+        [PaymentsErrorEnum.NotAllowedError]: 'NotAllowedError',
+        [PaymentsErrorEnum.NotSupportedError]: 'NotSupportedError',
+        [PaymentsErrorEnum.SecurityError]: 'SecurityError',
+    };
+
     constructor(errorType: PaymentsErrorEnum) {
         super(`[DOMException]: ${DOMException.messages[errorType]}`);
+        this.name = DOMException.names[errorType];
     }
 }

--- a/packages/react-native-payments/src/util/is-native-user-cancellation.util.ts
+++ b/packages/react-native-payments/src/util/is-native-user-cancellation.util.ts
@@ -1,0 +1,6 @@
+import { isError } from '@rnw-community/shared';
+
+const nativeCancellationCodes: ReadonlySet<string> = new Set(['E_CANCELLED_BY_USER', 'payment_error']);
+
+export const isNativeUserCancellation = (error: unknown): boolean =>
+    isError(error) && nativeCancellationCodes.has((error as { code?: string }).code ?? '');

--- a/packages/react-native-payments/src/util/validate-shipping-options.util.ts
+++ b/packages/react-native-payments/src/util/validate-shipping-options.util.ts
@@ -1,4 +1,4 @@
-import { type ClassType, isDefined, isNotEmptyString } from '@rnw-community/shared';
+import { type ClassType, isDefined, isNotEmptyString, isString } from '@rnw-community/shared';
 
 import { isValidDecimalMonetaryValue } from './is-valid-decimal-monetary-value.util';
 
@@ -18,7 +18,7 @@ export const validateShippingOptions = (
             throw new ErrorType(`required member value is undefined.`);
         }
 
-        if (!isValidDecimalMonetaryValue(shippingOption.amount.value)) {
+        if (!isString(shippingOption.amount.value) || !isValidDecimalMonetaryValue(shippingOption.amount.value)) {
             throw new ErrorType(`'${shippingOption.amount.value}' is not a valid amount format for shipping options`);
         }
     });


### PR DESCRIPTION
Resolves the open Macroscope findings from the merged epic trains and completes #399's remaining scope.

## Bot findings fixed
- **validateShippingOptions accepted numeric amount.value** (from #412): iOS's decimal converter is string-only, so numeric amounts passed validation and were silently dropped. Now guarded with isString + regression test.
- **Readme error example could never match** (from #433): messages carry the [ReactNativePayments] prefix. DOMException now sets the W3C error.name (AbortError, InvalidStateError, ...) — first step toward #437 — and the example branches on error.name, pinned by a test.
- **v2 native-binary compatibility** (from #410): documented in Migrating from v2 — native rebuild required; never ship v2.5+ JS over a v2 binary via OTA.

## Release polish (Closes #399)
- Changelog credits @dutompson's original contribution in #343.
- npm version badge fixed (pointed at nestjs-webpack-swc) + Codecov flag coverage badge added.

## Repo policy
- AGENTS.md: bot review comments must be read before merging; unresolved bot findings block merges without explicit maintainer approval.

Stale findings verified already fixed on master (not re-fixed here): expo babel config, dispatcher timeout, applyEventPayload ordering, AGENTS setActiveEvents invariants.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `PaymentRequest` to reject with `DOMException` on user cancellation and enforce string shipping amounts
> - `PaymentRequest.show()` now maps native user-cancellation error codes (`E_CANCELLED_BY_USER`, `payment_error`) to a `DOMException` with name `AbortError` instead of propagating raw native errors, matching the W3C spec.
> - `DOMException` instances now set `this.name` to the corresponding W3C error name (e.g. `AbortError`, `InvalidStateError`) via a static enum mapping.
> - `validateShippingOptions` now rejects shipping option amounts where `value` is not a string (e.g. numeric `5`).
> - Adds a migration note in the readme warning that a JS-only update on a v2 binary will fail to open the payment sheet due to native module interface changes.
> - Behavioral Change: code catching `PaymentRequest` rejections by comparing `error.message` to `PaymentsErrorEnum` values should switch to checking `error.name` (e.g. `'AbortError'`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 263f4f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->