### PR TITLE
ci: add CodeRabbit review configuration tuned to repo conventions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,38 @@
+language: en-US
+reviews:
+    profile: assertive
+    request_changes_workflow: false
+    high_level_summary: true
+    poem: false
+    review_status: true
+    auto_review:
+        enabled: true
+        drafts: false
+    path_filters:
+        - '!**/dist/**'
+        - '!.yarn/**'
+        - '!**/CHANGELOG.md'
+        - '!**/*.pbxproj'
+        - '!**/Podfile.lock'
+        - '!**/gradle/wrapper/**'
+        - '!**/yarn.lock'
+    path_instructions:
+        - path: 'packages/**/src/**/*.ts'
+          instructions: >-
+              Enforce this repo's hard rules from AGENTS.md: exactly one exported entity per file; interfaces in
+              .interface.ts and type aliases in .type.ts files; no code comments except
+              eslint-disable-next-line and istanbul ignore pragmas; always use @rnw-community/shared primitives
+              (isDefined, isError, isString, getErrorMessage, emptyFn, wait, Maybe, OnEventFn) instead of inline
+              checks; never re-export types owned by another workspace package.
+        - path: 'packages/**/src/**/*.spec.ts'
+          instructions: >-
+              Every test must call expect.hasAssertions() and import from @jest/globals. Test-only fixtures must
+              be inlined in the spec file, never in separate src files. Flag tests that execute code without
+              asserting behavior (values, error identities, call arguments).
+        - path: '.github/workflows/**'
+          instructions: >-
+              Builds must produce self-contained apps (embedded JS bundle, no Metro dependency at runtime);
+              self-hosted runner labels must match the fleet profiles; prefer explicit xcodebuild/gradlew/simctl/adb
+              over dev-CLI launchers; caches must be keyed on toolchain version + lockfiles.
+chat:
+    auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,14 +17,14 @@ reviews:
         - '!**/gradle/wrapper/**'
         - '!**/yarn.lock'
     path_instructions:
-        - path: 'packages/**/src/**/*.ts'
+        - path: 'packages/**/src/**/*.{ts,tsx}'
           instructions: >-
               Enforce this repo's hard rules from AGENTS.md: exactly one exported entity per file; interfaces in
               .interface.ts and type aliases in .type.ts files; no code comments except
               eslint-disable-next-line and istanbul ignore pragmas; always use @rnw-community/shared primitives
               (isDefined, isError, isString, getErrorMessage, emptyFn, wait, Maybe, OnEventFn) instead of inline
               checks; never re-export types owned by another workspace package.
-        - path: 'packages/**/src/**/*.spec.ts'
+        - path: 'packages/**/src/**/*.spec.{ts,tsx}'
           instructions: >-
               Every test must call expect.hasAssertions() and import from @jest/globals. Test-only fixtures must
               be inlined in the spec file, never in separate src files. Flag tests that execute code without

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,7 +259,7 @@ The monorepo uses dual ESM + CJS output. Key decisions:
 
 ## PR Review & Merge Policy
 
-**Before merging any PR, read every bot review comment on it** (Macroscope, Codecov, claude-review, DeepScan). Treat
+**Before merging any PR, read every bot review comment on it** (Macroscope, CodeRabbit, Codecov, claude-review, DeepScan). Treat
 unresolved bot findings as merge blockers: **never merge a PR carrying an open bot finding without explicit maintainer
 approval** — resolve the finding, refute it in a reply on the thread, or get the maintainer's sign-off first. Findings
 marked resolved/outdated by the bot itself are cleared. This applies to agents and humans alike, and to admin merges

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,11 +259,14 @@ The monorepo uses dual ESM + CJS output. Key decisions:
 
 ## PR Review & Merge Policy
 
-**Before merging any PR, read every bot review comment on it** (Macroscope, CodeRabbit, Codecov, claude-review, DeepScan). Treat
-unresolved bot findings as merge blockers: **never merge a PR carrying an open bot finding without explicit maintainer
-approval** — resolve the finding, refute it in a reply on the thread, or get the maintainer's sign-off first. Findings
-marked resolved/outdated by the bot itself are cleared. This applies to agents and humans alike, and to admin merges
-especially.
+**Before merging any PR, read every bot review comment on it** (Macroscope, CodeRabbit, Codecov, claude-review, DeepScan)
+and run this loop for each finding — it is mandatory for agents, not optional:
+
+1. **Validate** the finding against the actual code — never accept or dismiss it on wording alone.
+2. **Valid** → fix it in the same PR (root cause, not suppression) and reply on the thread naming the fixing commit.
+3. **Invalid** → reply on the thread with the concrete refutation (evidence: file/line, spec reference, or reproduction).
+4. A finding that is neither fixed nor answered on its thread **blocks the merge** — no exceptions without explicit
+   maintainer approval, and admin merges are not a bypass. Findings the bot itself marks resolved/outdated are cleared.
 
 ## Pre-commit Checks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,8 +259,8 @@ The monorepo uses dual ESM + CJS output. Key decisions:
 
 ## PR Review & Merge Policy
 
-**Before merging any PR, read every bot review comment on it** (Macroscope, CodeRabbit, Codecov, claude-review, DeepScan)
-and run this loop for each finding — it is mandatory for agents, not optional:
+**Before merging any PR, read every automated review comment on it** (every finding posted by any bot account,
+whatever the current review tooling is) and run this loop for each — it is mandatory for agents, not optional:
 
 1. **Validate** the finding against the actual code — never accept or dismiss it on wording alone.
 2. **Valid** → fix it in the same PR (root cause, not suppression) and reply on the thread naming the fixing commit.


### PR DESCRIPTION
Implements the PR-able half of #452: .coderabbit.yaml with an assertive, comment-only profile (the AGENTS.md bot-findings policy governs merges, not bot approvals), path instructions encoding the repo's hard conventions for the reviewer, and noise filters for generated/lock files. AGENTS.md's merge-policy bot list now includes CodeRabbit.

Remaining (maintainer action, tracked in #452): install the CodeRabbit GitHub App on the repo via app.coderabbit.ai — config activates on the first reviewed PR.

Refs #452

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CodeRabbit review configuration and enforce bot-finding workflow in contributor docs
> - Adds [.coderabbit.yaml](https://github.com/rnw-community/rnw-community/pull/453/files#diff-c0f93b6ec1bb8a9771fe87219aa22843985ba0cd27a23689b7be274bfb7baf57) configuring CodeRabbit with a review profile, auto-review, path exclusions for generated/lock files, and path-specific instructions for TypeScript sources, tests, and GitHub workflows.
> - Rewrites the PR review policy in [AGENTS.md](https://github.com/rnw-community/rnw-community/pull/453/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) with an explicit 4-step workflow: validate findings, fix with a reply naming the commit, refute with evidence, or block merge until resolved or answered with maintainer approval.
> - Clarifies that automated findings from any bot account are in scope and that admin merges do not bypass the policy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 94c935b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated review workflows for more consistent pull request feedback.
  * Added tailored review guidance for source code, tests, and workflow changes.
  * Updated contribution guidance to include findings from all automated review tools.
  * Required review findings to be validated, addressed, or answered with supporting evidence.
  * Configured review automation to provide summaries, status updates, and responses.
  * Excluded generated and project-maintenance files from automated review coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->