### PR TITLE
ci: gate maestro e2e on turborepo affected graph and run it on pull requests

### DIFF
--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -54,7 +54,7 @@ jobs:
                     echo "Non-PR event: payments pipeline always runs."
                     exit 0
                   fi
-                  affected=$(npx -y turbo@2 ls --affected --output=json | node -e '
+                  affected=$(npx -y turbo@2.10.8 ls --affected --output=json | node -e '
                     let raw = "";
                     process.stdin.on("data", chunk => (raw += chunk));
                     process.stdin.on("end", () => {
@@ -178,6 +178,10 @@ jobs:
         steps:
             - name: Report
               run: |
+                  if [ "${{ needs.detect.result }}" != "success" ]; then
+                    echo "Detection job did not succeed."
+                    exit 1
+                  fi
                   if [ "${{ needs.detect.outputs.payments_affected }}" != "true" ]; then
                     echo "Skipped: payments dependency tree untouched."
                     exit 0

--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -6,6 +6,7 @@ name: Android Maestro E2E
 # schedule keep this safe to land ahead of the fleet.
 on:
     workflow_dispatch:
+    pull_request:
     push:
         branches: [master]
         paths:
@@ -30,8 +31,49 @@ env:
     EXAMPLE_DIR: packages/react-native-payments-example
 
 jobs:
+    detect:
+        name: Detect affected packages
+        runs-on: ubuntu-latest
+        outputs:
+            payments_affected: ${{ steps.affected.outputs.payments_affected }}
+        steps:
+            - uses: actions/checkout@v5
+              with:
+                  fetch-depth: 0
+                  persist-credentials: false
+            - uses: actions/setup-node@v5
+              with:
+                  node-version: 22.x
+            - name: Compute affected packages
+              id: affected
+              env:
+                  TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+              run: |
+                  if [ "${{ github.event_name }}" != "pull_request" ]; then
+                    echo "payments_affected=true" >> "$GITHUB_OUTPUT"
+                    echo "Non-PR event: payments pipeline always runs."
+                    exit 0
+                  fi
+                  affected=$(npx -y turbo@2 ls --affected --output=json | node -e '
+                    let raw = "";
+                    process.stdin.on("data", chunk => (raw += chunk));
+                    process.stdin.on("end", () => {
+                      const names = (JSON.parse(raw).packages?.items ?? []).map(item => item.name);
+                      const targets = [
+                        "@rnw-community/react-native-payments",
+                        "@rnw-community/react-native-payments-example",
+                        "@rnw-community/react-native-payments-example-bare",
+                        "@rnw-community/react-native-payments-example-expo",
+                      ];
+                      process.stdout.write(String(names.some(name => targets.includes(name))));
+                    });
+                  ')
+                  echo "payments_affected=${affected}" >> "$GITHUB_OUTPUT"
+                  echo "payments_affected=${affected}"
     maestro:
         name: Maestro (${{ matrix.target }})
+        needs: detect
+        if: needs.detect.outputs.payments_affected == 'true'
         runs-on: [self-hosted, linux-tiered, linux-xl]
         timeout-minutes: 75
         strategy:
@@ -127,3 +169,21 @@ jobs:
                     path: ${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}/**
                     if-no-files-found: warn
                     retention-days: 7
+
+    status:
+        name: Android Maestro E2E result
+        needs: [detect, maestro]
+        if: always()
+        runs-on: ubuntu-latest
+        steps:
+            - name: Report
+              run: |
+                  if [ "${{ needs.detect.outputs.payments_affected }}" != "true" ]; then
+                    echo "Skipped: payments dependency tree untouched."
+                    exit 0
+                  fi
+                  if [ "${{ needs.maestro.result }}" != "success" ]; then
+                    echo "Maestro suite failed."
+                    exit 1
+                  fi
+                  echo "Maestro suite passed."

--- a/.github/workflows/ios-maestro.yml
+++ b/.github/workflows/ios-maestro.yml
@@ -54,7 +54,7 @@ jobs:
                     echo "Non-PR event: payments pipeline always runs."
                     exit 0
                   fi
-                  affected=$(npx -y turbo@2 ls --affected --output=json | node -e '
+                  affected=$(npx -y turbo@2.10.8 ls --affected --output=json | node -e '
                     let raw = "";
                     process.stdin.on("data", chunk => (raw += chunk));
                     process.stdin.on("end", () => {
@@ -229,6 +229,10 @@ jobs:
         steps:
             - name: Report
               run: |
+                  if [ "${{ needs.detect.result }}" != "success" ]; then
+                    echo "Detection job did not succeed."
+                    exit 1
+                  fi
                   if [ "${{ needs.detect.outputs.payments_affected }}" != "true" ]; then
                     echo "Skipped: payments dependency tree untouched."
                     exit 0

--- a/.github/workflows/ios-maestro.yml
+++ b/.github/workflows/ios-maestro.yml
@@ -6,6 +6,7 @@ name: iOS Maestro E2E
 # schedule keep this safe to land ahead of the fleet.
 on:
     workflow_dispatch:
+    pull_request:
     push:
         branches: [master]
         paths:
@@ -30,8 +31,49 @@ env:
     EXAMPLE_DIR: packages/react-native-payments-example
 
 jobs:
+    detect:
+        name: Detect affected packages
+        runs-on: ubuntu-latest
+        outputs:
+            payments_affected: ${{ steps.affected.outputs.payments_affected }}
+        steps:
+            - uses: actions/checkout@v5
+              with:
+                  fetch-depth: 0
+                  persist-credentials: false
+            - uses: actions/setup-node@v5
+              with:
+                  node-version: 22.x
+            - name: Compute affected packages
+              id: affected
+              env:
+                  TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+              run: |
+                  if [ "${{ github.event_name }}" != "pull_request" ]; then
+                    echo "payments_affected=true" >> "$GITHUB_OUTPUT"
+                    echo "Non-PR event: payments pipeline always runs."
+                    exit 0
+                  fi
+                  affected=$(npx -y turbo@2 ls --affected --output=json | node -e '
+                    let raw = "";
+                    process.stdin.on("data", chunk => (raw += chunk));
+                    process.stdin.on("end", () => {
+                      const names = (JSON.parse(raw).packages?.items ?? []).map(item => item.name);
+                      const targets = [
+                        "@rnw-community/react-native-payments",
+                        "@rnw-community/react-native-payments-example",
+                        "@rnw-community/react-native-payments-example-bare",
+                        "@rnw-community/react-native-payments-example-expo",
+                      ];
+                      process.stdout.write(String(names.some(name => targets.includes(name))));
+                    });
+                  ')
+                  echo "payments_affected=${affected}" >> "$GITHUB_OUTPUT"
+                  echo "payments_affected=${affected}"
     maestro:
         name: Maestro (${{ matrix.target }})
+        needs: detect
+        if: needs.detect.outputs.payments_affected == 'true'
         runs-on: [self-hosted, macOS, ARM64, macos-maestro]
         timeout-minutes: 60
         strategy:
@@ -178,3 +220,21 @@ jobs:
                     path: ${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}/**
                     if-no-files-found: warn
                     retention-days: 7
+
+    status:
+        name: iOS Maestro E2E result
+        needs: [detect, maestro]
+        if: always()
+        runs-on: ubuntu-latest
+        steps:
+            - name: Report
+              run: |
+                  if [ "${{ needs.detect.outputs.payments_affected }}" != "true" ]; then
+                    echo "Skipped: payments dependency tree untouched."
+                    exit 0
+                  fi
+                  if [ "${{ needs.maestro.result }}" != "success" ]; then
+                    echo "Maestro suite failed."
+                    exit 1
+                  fi
+                  echo "Maestro suite passed."


### PR DESCRIPTION
Implements #451: both Maestro workflows gain a pull_request trigger and a seconds-fast detect job that computes the Turborepo affected graph against the PR base (TURBO_SCM_BASE + turbo ls --affected) and only runs the heavy build+Maestro jobs when the react-native-payments dependency tree is affected — transitive deps included (a packages/shared change triggers e2e; unrelated packages skip in seconds). A status summary job always reports, so the check never dangles. Non-PR events (push to master, nightly, dispatch) keep the previous always-run behavior.

Report-only for now per the #451 rollout: the check is not required until #447's repack cache makes warm PR runs cheap.

**This PR self-tests the fast path:** it touches only .github/workflows, so the detect job must conclude payments_affected=false and both heavy jobs must skip.

Closes #451

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate Maestro E2E workflows on Turborepo affected graph and run on pull requests
> - Adds `pull_request` as a trigger to both the [Android](https://github.com/rnw-community/rnw-community/pull/456/files#diff-55335efdf44cf2f549475f95db0a3c18a4cd462466e0062fb3597da7bfbf87e7) and [iOS](https://github.com/rnw-community/rnw-community/pull/456/files#diff-6b7af4e54f96b22cfae304bd9b25e10eda4ca19dc9126df35ce3a59cda688c86) Maestro E2E workflows.
> - Adds a `detect` job that runs `npx turbo ls --affected` on PRs to check whether any payments-related packages are in the affected set; non-PR runs always set `payments_affected=true`.
> - The `maestro` job now depends on `detect` and is skipped when `payments_affected` is false, avoiding unnecessary E2E runs on unrelated changes.
> - Adds a `status` job that always runs, reports the overall result, and fails the workflow if detection failed or Maestro failed when it executed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c933fa1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated Android and iOS Maestro checks for pull requests affecting payment functionality.
  * Unrelated pull requests now skip unnecessary mobile test runs, improving validation efficiency.
  * Added clear workflow status reporting for skipped, successful, and failed checks.
  * Failures in mobile validation are now correctly surfaced in the overall workflow result.
  * Mobile checks continue to run for other supported workflow events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->