### PR TITLE
docs(react-native-payments): add llms.txt agent doc index

### DIFF
--- a/packages/react-native-payments/AGENTS.md
+++ b/packages/react-native-payments/AGENTS.md
@@ -2,6 +2,9 @@
 
 W3C Payment Request API implementation for React Native — Apple Pay (iOS) and Google Pay (Android). Includes Expo config plugin.
 
+See [readme.md](readme.md) for the human-facing installation and usage guide. For a curated, agent-oriented index of
+every doc in this package (API surface, change-event contract, E2E boundary), see [llms.txt](llms.txt).
+
 ## Package Commands
 
 ```bash
@@ -70,7 +73,7 @@ src/
   no-change update when its event type is not active for the current request, and is flushed on every teardown path
   (`didFinish`, `didAuthorizePayment`, `complete`, `abort`, `stopObserving`, `invalidate`) so the sheet cannot hang.
   Android answers the same contract with documented no-ops. The semantics live in
-  `src/util/get-native-payments-event-emitter/get-native-payments-event-emitter.md`
+  [get-native-payments-event-emitter.md](src/util/get-native-payments-event-emitter/get-native-payments-event-emitter.md)
 - Change events are request-scoped: `show()` passes the request `id` to native so `activeRequestId` is adopted at
   presentation time regardless of whether any listener was ever registered, `setActiveEvents(requestId, eventNames)`
   scopes the handshake per request, one native subscription per event type feeds every listener registered for it, and
@@ -82,9 +85,9 @@ src/
 - Listeners run sequentially and dispatch stops at the first one that answers with `updateWith`, mirroring the stop
   immediate propagation flag of the W3C algorithm; a listener that throws is logged and the next one still runs
 - Every delivered change event answers native exactly once through `updatePaymentDetails`, even when the listener fails,
-  never returns or leaves its update pending: `ChangeEventDispatcher` races **one** `changeEventTimeoutMs` deadline over
-  the listener bodies and their answer together, so a listener awaiting a request that never settles cannot pin a native
-  completion
+  never returns or leaves its update pending: [`ChangeEventDispatcher`](src/class/change-event-dispatcher/change-event-dispatcher.md)
+  races **one** `changeEventTimeoutMs` deadline over the listener bodies and their answer together, so a listener
+  awaiting a request that never settles cannot pin a native completion
 - Native events carry a monotonic `eventId` that JS echoes back in the update, and native resolves a completion only for
   the `eventId` it is still waiting for, so the answer of a superseded event can never be applied to the newer one
 - A dispatch is bound to an event generation bumped on every terminal path, so a response that arrives after the sheet

--- a/packages/react-native-payments/llms.txt
+++ b/packages/react-native-payments/llms.txt
@@ -1,0 +1,35 @@
+# @rnw-community/react-native-payments
+
+> W3C Payment Request API implementation for React Native — Apple Pay (iOS) and Google Pay (Android), with an Expo config plugin.
+
+TurboModule-based library (React Native New Architecture). An agent given only this package root can locate the full
+API surface, the payment change-event contract, platform deviations from the W3C spec, and the native JS<->native
+handshake without a repo-wide search.
+
+## Docs
+
+- [readme.md](readme.md): Installation (Apple Pay / Google Pay / Expo setup) and the step-by-step `PaymentRequest` usage guide.
+- [readme.md — Type & class reference](readme.md#type--class-reference): Per-export API reference — every exported class, enum, interface, and type with its own subsection.
+- [readme.md — Payment change events](readme.md#payment-change-events): `addEventListener`/`removeEventListener`, `updateWith`, sheet errors, and `PaymentMethodChangeEvent`.
+- [readme.md — Known deviations](readme.md#known-deviations): Platform differences from the W3C spec — Android no-op change events, iOS shipping preselection, single-use `PaymentRequest`, `couponcodechange`.
+- [readme.md — Migrating from v2](readme.md#migrating-from-v2): Breaking changes and upgrade steps from the v2 native interface to v3.
+- [readme.md — Web(react-native-web)](readme.md#webreact-native-web): Browser fallback behavior via the W3C `PaymentRequest` implementation.
+
+## Architecture & conventions
+
+- [AGENTS.md](AGENTS.md): Source layout, TurboModule/Expo-plugin architecture, key implementation patterns, dependencies, and coverage.
+- [Repository AGENTS.md — PR Review & Merge Policy](../../AGENTS.md#pr-review--merge-policy): Repo-wide policy for triaging automated review findings before merge; applies to this package's PRs.
+
+## Native contract
+
+- [change-event-dispatcher.md](src/class/change-event-dispatcher/change-event-dispatcher.md): `ChangeEventDispatcher` lifecycle — dispatch, per-listener answer, and the single shared timeout race.
+- [get-native-payments-event-emitter.md](src/util/get-native-payments-event-emitter/get-native-payments-event-emitter.md): The JS<->native change-event contract — event scoping, generations, and teardown semantics.
+
+## End-to-end verification
+
+- [react-native-payments-example/e2e/readme.md](../react-native-payments-example/e2e/readme.md): Maestro flow inventory and the documented iOS PassKit sheet accessibility-sandbox boundary.
+- [maestro-e2e skill](../../.agents/skills/maestro-e2e/SKILL.md): Agent skill for writing and running Maestro E2E flows against this package's example app.
+
+## Optional
+
+- [CHANGELOG.md](CHANGELOG.md): Version history.

--- a/packages/react-native-payments/package.json
+++ b/packages/react-native-payments/package.json
@@ -46,6 +46,7 @@
     "files": [
         "dist",
         "src",
+        "llms.txt",
         "android",
         "ios",
         "cpp",

--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -34,6 +34,12 @@ fantastic [react-native-payments](https://github.com/naoufal/react-native-paymen
 These enhancements ensure that the library is more efficient, maintainable, and future-proof, offering a seamless payment
 integration experience for your applications.
 
+## For AI agents
+
+Start with [llms.txt](llms.txt) for a curated, agent-oriented index of this package's docs (API surface, payment
+change events, platform deviations, migration notes, native contract, and E2E coverage) and [AGENTS.md](AGENTS.md)
+for architecture and contributor conventions.
+
 ## Features
 
 - Streamlined. Say goodbye to complicated checkout forms.


### PR DESCRIPTION
## Summary
- Adds `packages/react-native-payments/llms.txt` (per https://llmstxt.org) indexing the readme's per-export API reference, payment change events, known platform deviations, v2 migration notes, and web fallback, plus AGENTS.md, the internal change-event contract docs, the example package's e2e readme, and the maestro-e2e skill entry point.
- Adds `llms.txt` to the package's `files` whitelist so it ships with the published npm package.
- Adds direct markdown links for the two internal contract docs and a `llms.txt` pointer in AGENTS.md so every internal doc is reachable from the package's agent-facing entry point.
- Adds a short "For AI agents" pointer section in readme.md referencing llms.txt and AGENTS.md.

## Test plan
- [x] `yarn build`
- [x] `yarn ts`
- [x] `yarn lint`
- [x] `yarn test`
- [x] Verified every link target in llms.txt/AGENTS.md exists on this branch (file-existence check) and every heading anchor was computed with `github-slugger` to confirm exact GitHub slugs.

Closes #440

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `llms.txt` agent doc index to `react-native-payments`
> - Adds [llms.txt](https://github.com/rnw-community/rnw-community/pull/459/files#diff-25404be6cad8423bff357ffc2bc744672de64f8dbbdfabe1e427ae620e14e378), a curated index of project docs (API surface, architecture, native contracts, E2E resources) formatted for AI agent consumption.
> - Updates [AGENTS.md](https://github.com/rnw-community/rnw-community/pull/459/files#diff-9991ed8003499d8d12959880a0a910f5658dfb286b29e63fe4d3e95d2f6f0d55) with Markdown links and minor formatting fixes.
> - Adds a "For AI agents" section to [readme.md](https://github.com/rnw-community/rnw-community/pull/459/files#diff-6190e5c40ba924df626fcc867585c216eb1de7d6d5d2d5ecdf36a25525783239) pointing to both files.
> - Includes `llms.txt` in the `files` array of [package.json](https://github.com/rnw-community/rnw-community/pull/459/files#diff-9140d7c61cb23d744d243d1c4539521304e96a0bbd871e0045e20b82ea8d3813) so it is published with the package.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 704e69e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->