### PR TITLE
docs(react-native-payments): web platform type fidelity and docs

### DIFF
--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -553,6 +553,52 @@ consumer who never calls `addEventListener` sees the same sheet as before (aside
 > `addEventListener` becomes a no-op and every further `show()` rejects with `InvalidStateError`. Construct a new
 > `PaymentRequest` per payment attempt instead of reusing one across retries.
 
+## Web platform
+
+`payment-request.web.ts` / `payment-response.web.ts` are one-line passthroughs — `PaymentRequest` and `PaymentResponse`
+resolve to `window.PaymentRequest` / `window.PaymentResponse` (or `null` when `window` is not defined, e.g. during SSR),
+typed as `WebPaymentRequestConstructor` / `WebPaymentResponseConstructor` — aliases for the browser's own
+`typeof window.PaymentRequest` / `typeof window.PaymentResponse` from `lib.dom`. On web there is no TurboModule, no
+native class and none of this package's own logic in the loop: you get the browser's implementation of the W3C Payment
+Request API, unmodified.
+
+> **Type visibility caveat:** a bundler that platform-resolves `.web.ts` files (Metro building for the web target,
+> `react-native-web` webpack configs) swaps in this passthrough at *runtime* regardless of what TypeScript shows you.
+> `src/index.ts` re-exports the platform-agnostic `PaymentRequest` / `PaymentResponse` specifiers without a build-time
+> branch, so a plain `tsc`/IDE setup resolves `import { PaymentRequest } from '@rnw-community/react-native-payments'`
+> to the native class documented above on every platform, web included. Add
+> `"moduleSuffixes": [".web", ".native", ""]` (or an order matching your own bundler's platform resolution) to your
+> app's `tsconfig.json` if you need the IDE/`tsc` to show the true DOM types for a web build.
+
+Apple Pay through this browser passthrough is **not** the native iOS integration documented under
+[ApplePay setup](#applepay-setup) — calling `show()` in Safari drives Safari's own Apple Pay JS flow, which fires a
+`merchantvalidation` event that your own server must answer by completing Apple's merchant validation session
+round-trip (TLS, your merchant certificate, Apple's validation URL) before the sheet can display line items. There is
+no `merchantIdentifier` Expo plugin config, no PassKit entitlement and no `merchantCapabilities` on this path — see
+[Apple Pay on the Web](https://developer.apple.com/documentation/apple_pay_on_the_web).
+
+Browser support is inconsistent: Chrome, Edge and Safari (with the merchant-validation caveat above) implement the
+Payment Request API; Firefox removed its implementation. Check [caniuse](https://caniuse.com/payment-request) before
+shipping a web checkout on top of it, and always guard for `PaymentRequest`/`PaymentResponse` being `null` — the
+passthrough returns `null` outside a `window` (SSR), and an unsupported browser simply has no `window.PaymentRequest`
+at all.
+
+None of the native-only behavior documented above for the `PaymentRequest` class applies to the browser's own
+implementation:
+
+- **`couponCode`** — populated only by the iOS 15+ PassKit `couponcodechange` flow; the browser's `PaymentRequest` has
+  no `couponCode` property.
+- **Normalized `AbortError`** — dismissing the sheet on web throws the browser's own native `DOMException`, not this
+  package's [`PaymentsErrorEnum`](#paymentserrorenum)-driven `DOMException`; `isNativeUserCancellation` never runs on
+  web.
+- **Single-use request semantics** — the native class tracks `state: 'created' | 'interactive' | 'closed'` itself and
+  rejects a reused, settled request with its own `InvalidStateError`. The browser enforces single-use per the W3C spec
+  independently, through its own internal slots, not this package's state machine.
+- **Listener auto-cleanup** — the request-scoped subscription bookkeeping and automatic teardown on `show()`/`abort()`
+  described in [Payment change events](#payment-change-events) is this package's `NativeEventEmitter` plumbing over the
+  TurboModule. The browser's `PaymentRequest` follows plain DOM `addEventListener`/`removeEventListener` semantics with
+  no auto-cleanup — remove your own listeners when you are done with them.
+
 ## Type & class reference
 
 Most public exports already appear in the usage examples above. The remaining exports are referenced here for

--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -571,7 +571,7 @@ Request API, unmodified.
 > app's `tsconfig.json` if you need the IDE/`tsc` to show the true DOM types for a web build.
 
 Apple Pay through this browser passthrough is **not** the native iOS integration documented under
-[ApplePay setup](#applepay-setup) — calling `show()` in Safari drives Safari's own Apple Pay JS flow, which fires a
+[Apple Pay setup](#applepay-setup) — calling `show()` in Safari drives Safari's own Apple Pay JS flow, which fires a
 `merchantvalidation` event that your own server must answer by completing Apple's merchant validation session
 round-trip (TLS, your merchant certificate, Apple's validation URL) before the sheet can display line items. There is
 no `merchantIdentifier` Expo plugin config, no PassKit entitlement and no `merchantCapabilities` on this path — see

--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -579,9 +579,9 @@ no `merchantIdentifier` Expo plugin config, no PassKit entitlement and no `merch
 
 Browser support is inconsistent: Chrome, Edge and Safari (with the merchant-validation caveat above) implement the
 Payment Request API; Firefox removed its implementation. Check [caniuse](https://caniuse.com/payment-request) before
-shipping a web checkout on top of it, and always guard for `PaymentRequest`/`PaymentResponse` being `null` — the
-passthrough returns `null` outside a `window` (SSR), and an unsupported browser simply has no `window.PaymentRequest`
-at all.
+shipping a web checkout on top of it, and always guard for `PaymentRequest`/`PaymentResponse` being **nullish** (a
+truthiness or `== null` check, never `=== null`) — the passthrough returns `null` outside a `window` (SSR), while an
+unsupported browser has no `window.PaymentRequest` at all, so the export resolves to `undefined` there.
 
 None of the native-only behavior documented above for the `PaymentRequest` class applies to the browser's own
 implementation:

--- a/packages/react-native-payments/src/class/payment-request/payment-request.web.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.web.ts
@@ -1,1 +1,4 @@
-export const { PaymentRequest } = typeof window === 'undefined' ? { PaymentRequest: null } : window;
+import type { WebPaymentRequestConstructor } from '../../type/web-payment-request-constructor.type';
+
+export const { PaymentRequest }: { PaymentRequest: WebPaymentRequestConstructor | null } =
+    typeof window === 'undefined' ? { PaymentRequest: null } : window;

--- a/packages/react-native-payments/src/class/payment-request/payment-request.web.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.web.ts
@@ -1,4 +1,6 @@
 import type { WebPaymentRequestConstructor } from '../../type/web-payment-request-constructor.type';
+import type { Maybe } from '@rnw-community/shared';
 
-export const { PaymentRequest }: { PaymentRequest: WebPaymentRequestConstructor | null } =
+
+export const { PaymentRequest }: { PaymentRequest: Maybe<WebPaymentRequestConstructor> | undefined } =
     typeof window === 'undefined' ? { PaymentRequest: null } : window;

--- a/packages/react-native-payments/src/class/payment-response/payment-response.web.ts
+++ b/packages/react-native-payments/src/class/payment-response/payment-response.web.ts
@@ -1,4 +1,6 @@
 import type { WebPaymentResponseConstructor } from '../../type/web-payment-response-constructor.type';
+import type { Maybe } from '@rnw-community/shared';
 
-export const { PaymentResponse }: { PaymentResponse: WebPaymentResponseConstructor | null } =
+
+export const { PaymentResponse }: { PaymentResponse: Maybe<WebPaymentResponseConstructor> | undefined } =
     typeof window === 'undefined' ? { PaymentResponse: null } : window;

--- a/packages/react-native-payments/src/class/payment-response/payment-response.web.ts
+++ b/packages/react-native-payments/src/class/payment-response/payment-response.web.ts
@@ -1,1 +1,4 @@
-export const { PaymentResponse } = typeof window === 'undefined' ? { PaymentResponse: null } : window;
+import type { WebPaymentResponseConstructor } from '../../type/web-payment-response-constructor.type';
+
+export const { PaymentResponse }: { PaymentResponse: WebPaymentResponseConstructor | null } =
+    typeof window === 'undefined' ? { PaymentResponse: null } : window;

--- a/packages/react-native-payments/src/type/web-payment-request-constructor.type.ts
+++ b/packages/react-native-payments/src/type/web-payment-request-constructor.type.ts
@@ -1,0 +1,1 @@
+export type WebPaymentRequestConstructor = typeof globalThis.PaymentRequest;

--- a/packages/react-native-payments/src/type/web-payment-response-constructor.type.ts
+++ b/packages/react-native-payments/src/type/web-payment-response-constructor.type.ts
@@ -1,0 +1,1 @@
+export type WebPaymentResponseConstructor = typeof globalThis.PaymentResponse;


### PR DESCRIPTION
## Summary

- Audits the web passthrough (`payment-request.web.ts` / `payment-response.web.ts`): the destructured `window.PaymentRequest`/`window.PaymentResponse` already type-checks as the browser's own `lib.dom` constructor type (not this package's native class) — TypeScript infers that structurally from `window`. The gap wasn't a wrong type on the passthrough itself, it's that `src/index.ts` re-exports a single, non-platform-branching specifier, so a plain `tsc`/IDE consumer (no `moduleSuffixes`) always resolves `PaymentRequest`/`PaymentResponse` to the native class `.d.ts`, on every platform including web — the runtime value on a web build (Metro/`react-native-web` platform-extension resolution) is the passthrough, but the types shown by default are the native class's. That mismatch is now called out explicitly in the readme, since it can't be fixed from inside this package (it depends on the consumer's bundler + `moduleSuffixes` matching).
- Names the passthrough constructor types explicitly (`WebPaymentRequestConstructor`, `WebPaymentResponseConstructor` — aliases of `typeof globalThis.PaymentRequest` / `typeof globalThis.PaymentResponse`) instead of leaving them as implicit structural inference, and applies them as explicit annotations on the `.web.ts` exports. No runtime behavior change — same destructuring, same `window`/SSR fallback, just an explicit, self-documenting, drift-resistant type.
- Adds a new readme "Web platform" section: the passthrough contract, the type-visibility caveat above (with the `moduleSuffixes` workaround), Apple Pay on web requiring its own merchant-validation server flow (unrelated to native PassKit setup), browser support reality, and which native-only documented behaviors do not apply on web (`couponCode`, normalized `AbortError`, single-use state machine, listener auto-cleanup). Placed as its own section; the existing `Sheet errors` / `PaymentsErrorEnum` sections are untouched (owned by a concurrent PR).
- wdio smoke: **won't-build**. This repo's `wdio` package is a page-object/command library consumed by *other* apps' own wdio suites — there is no `wdio.conf`, browser driver wiring or CI job for a browser E2E run anywhere in this repo. The passthrough has zero logic of ours (a two-line destructure), and E2E coverage for this package is already tracked through Maestro on-device suites (#393, #395, #397). Standing up a full wdio browser harness (config, driver provisioning, a web build of the example app, a CI job) just to assert a literal `window.PaymentRequest` passthrough resolves is disproportionate infrastructure for the value it returns.

## Test plan

- [x] `yarn build && yarn ts && yarn lint && yarn test && yarn deadcode` all pass at the repo root
- [x] `packages/react-native-payments` coverage stays 100/100/100/100 (`.web.ts` files remain untested by design — no branches were added)
- [x] Verified the emitted `dist/esm/class/payment-request/payment-request.web.d.ts` / `payment-response.web.d.ts` still show the true DOM constructor type after the explicit annotation

Closes #454

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add type annotations and Web platform docs to react-native-payments
> - Adds `WebPaymentRequestConstructor` and `WebPaymentResponseConstructor` type aliases (typed as `typeof globalThis.PaymentRequest/PaymentResponse`) in new files under `src/type/`.
> - Annotates the exports in [`payment-request.web.ts`](https://github.com/rnw-community/rnw-community/pull/460/files#diff-af29246060bc2b1f08324836e469664f76c7f07b8a9edcb94af7654bc2ac33e8) and [`payment-response.web.ts`](https://github.com/rnw-community/rnw-community/pull/460/files#diff-c177b856c3646f553e34b3191fdd818c67084dd586ec197a08c1be0277ab5e39) with these types; runtime behavior is unchanged.
> - Adds a Web platform section to the [readme](https://github.com/rnw-community/rnw-community/pull/460/files#diff-6190e5c40ba924df626fcc867585c216eb1de7d6d5d2d5ecdf36a25525783239) covering passthrough semantics, bundler/TypeScript caveats, Apple Pay on the Web differences, browser support, and native-only behavior differences (`couponCode`, `AbortError` normalization, listener cleanup).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23ee2e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance on web platform behavior, including server-side rendering, browser support, Apple Pay differences, and native implementation variations.

- **Bug Fixes**
  - Improved web payment API compatibility across supported browsers.
  - Added explicit typing for web payment request and response constructors.
  - Preserved safe handling when payment APIs are unavailable or accessed during server-side rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->