### PR TITLE
feat(react-native-payments): implement PaymentDetailsModifier support

### DIFF
--- a/packages/react-native-payments/AGENTS.md
+++ b/packages/react-native-payments/AGENTS.md
@@ -51,6 +51,12 @@ src/
 - `PaymentRequest` constructor validates per W3C spec, then serializes platform-specific JSON for native bridge; the
   total, the display items and the shipping options run through the same validators on the change-event path, so an
   update that fails them is answered like a failing listener and never reaches the sheet
+- `details.modifiers` is resolved against the platform's active payment method (`PaymentMethodNameEnum.ApplePay` on
+  iOS, `AndroidPay` on Android) in `resolvePaymentDetailsModifier`: a matching modifier's `total` overrides the
+  effective total and its `additionalDisplayItems` are appended to `displayItems` before either reaches native (Android
+  `transactionInfo` at construction, iOS PassKit summary items at `show()`); a modifier for the other platform's method
+  is left untouched. The same resolution re-runs on every `updateWith()` so a listener can ship new modifiers with the
+  rest of the update; `this.details` always keeps the raw, unresolved values it was given
 - iOS builds `PKShippingMethod` and `PKPaymentSummaryItem` with one converter each for the initial `show()` details and
   for `updatePaymentDetails`, so an option or an item renders the same in both flows: label, amount, identifier and the
   optional detail for a shipping method, `PKPaymentSummaryItemTypePending` for a `pending` item

--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -270,6 +270,29 @@ const paymentDetails = {
 };
 ```
 
+#### 2.4 Payment details modifiers
+
+`details.modifiers` accepts an array of [`PaymentDetailsModifier`](https://www.w3.org/TR/payment-request/#dom-paymentdetailsmodifier),
+one entry per `supportedMethods`. The library picks the entry whose `supportedMethods` matches the platform's active
+payment method (`PaymentMethodNameEnum.ApplePay` on iOS, `PaymentMethodNameEnum.AndroidPay` on Android) and applies it
+before serializing details to native: `modifier.total` overrides the top-level `total` and `modifier.additionalDisplayItems`
+is appended to `displayItems`. A modifier for the other platform's method is ignored. The same resolution runs again on
+every `updateWith()` call, so a listener can ship an updated `modifiers` array together with the rest of the update.
+`modifier.data` is validated for shape but not forwarded to native — the bridge has no per-method extension point for it.
+
+```ts
+const paymentDetails = {
+    total: { label: 'Total', amount: { currency: 'USD', value: '10.00' } },
+    modifiers: [
+        {
+            supportedMethods: PaymentMethodNameEnum.ApplePay,
+            total: { label: 'Total with Apple Pay discount', amount: { currency: 'USD', value: '9.00' } },
+            additionalDisplayItems: [{ label: 'Apple Pay discount', amount: { currency: 'USD', value: '-1.00' } }],
+        },
+    ],
+};
+```
+
 ### 3. Checking Payment Capability
 
 Before displaying the payment sheet to the user, you can check if the current device supports the payment methods specified:
@@ -844,7 +867,8 @@ You can find working example in the `App` component of the [react-native-payment
       verification is tracked in [#393](https://github.com/rnw-community/rnw-community/issues/393)
 - [x] [PaymentMethodChangeEvent](https://www.w3.org/TR/payment-request/#dom-paymentmethodchangeevent) — same
       implementation and verification status as `PaymentRequestUpdateEvent`
-- [ ] Implement [PaymentDetailsModifier](https://www.w3.org/TR/payment-request/#dom-paymentdetailsmodifier)
+- [x] Implement [PaymentDetailsModifier](https://www.w3.org/TR/payment-request/#dom-paymentdetailsmodifier) — see
+      [Payment details modifiers](#24-payment-details-modifiers)
 - [x] Improve and unify errors according to the spec — see [Error Handling](#error-handling)
 - [ ] Implement `PaymentResponse` `retry()` method
 - [ ] Implement `PaymentResponse` `toJSON()` method

--- a/packages/react-native-payments/src/@standard/w3c/payment-details-modifier.ts
+++ b/packages/react-native-payments/src/@standard/w3c/payment-details-modifier.ts
@@ -1,10 +1,10 @@
 import type { PaymentItem } from './payment-item';
-import type { SupportedNetworkEnum } from '../../enum/supported-networks.enum';
+import type { PaymentMethodNameEnum } from '../../enum/payment-method-name.enum';
 
 // https://www.w3.org/TR/payment-request/#paymentdetailsmodifier-dictionary
 export interface PaymentDetailsModifier {
-    additionalDisplayItems: PaymentItem[];
-    // TODO: Add type
-    data: Record<string, string>;
-    supportedMethods: SupportedNetworkEnum;
+    additionalDisplayItems?: PaymentItem[];
+    data?: Record<string, unknown>;
+    supportedMethods: PaymentMethodNameEnum;
+    total?: PaymentItem;
 }

--- a/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
@@ -31,6 +31,7 @@ import type { AndroidTransactionInfo } from '../../@standard/android/request/and
 import type { IosPaymentMethodDataInterface } from '../../@standard/ios/mapping/ios-payment-method-data.interface';
 import type { IosPaymentDataRequest } from '../../@standard/ios/request/ios-payment-data-request';
 import type { PaymentDetailsInit } from '../../@standard/w3c/payment-details-init';
+import type { PaymentDetailsModifier } from '../../@standard/w3c/payment-details-modifier';
 import type { PaymentDetailsUpdate } from '../../@standard/w3c/payment-details-update';
 import type { PaymentItem } from '../../@standard/w3c/payment-item';
 import type { PaymentMethodData } from '../../@standard/w3c/payment-method-data';
@@ -408,6 +409,63 @@ describe('PaymentRequest', () => {
             });
         });
 
+        describe(`payment details modifiers`, () => {
+            const paymentDetailsWithTotal: PaymentDetailsInit = {
+                total: { label: 'Total', amount: { currency: 'USD', value: '10.00' } },
+            };
+
+            const constructWithModifiers = (modifiers: unknown[]): PaymentRequest =>
+                new PaymentRequest([methodData], {
+                    ...paymentDetailsWithTotal,
+                    modifiers: modifiers as PaymentDetailsModifier[],
+                });
+
+            it('should NOT throw when modifiers is not defined or empty', () => {
+                expect.hasAssertions();
+
+                expect(() => new PaymentRequest([methodData], paymentDetailsWithTotal)).not.toThrow();
+                expect(() => constructWithModifiers([])).not.toThrow();
+                expect(() =>
+                    constructWithModifiers([{ supportedMethods: PaymentMethodNameEnum.AndroidPay }])
+                ).not.toThrow();
+            });
+
+            it('should throw when a modifier has no supportedMethods', () => {
+                expect.hasAssertions();
+
+                const expectedError = new ConstructorError(`required member supportedMethods is undefined.`);
+
+                expect(() => constructWithModifiers([undefined])).toThrow(expectedError);
+                expect(() => constructWithModifiers([{}])).toThrow(expectedError);
+            });
+
+            it('should throw when a modifier total is negative', () => {
+                expect.hasAssertions();
+
+                expect(() =>
+                    constructWithModifiers([
+                        {
+                            supportedMethods: PaymentMethodNameEnum.AndroidPay,
+                            total: { label: 'Discounted', amount: { currency: 'USD', value: '-1.00' } },
+                        },
+                    ])
+                ).toThrow(new ConstructorError(`Total amount value should be non-negative`));
+            });
+
+            it('should throw when a modifier additionalDisplayItems entry is invalid', () => {
+                expect.hasAssertions();
+
+                expect(() =>
+                    constructWithModifiers([
+                        {
+                            supportedMethods: PaymentMethodNameEnum.AndroidPay,
+                            additionalDisplayItems: [{ amount: { currency: 'USD', value: true } }],
+                        },
+                    ])
+                ).toThrow(new ConstructorError(`'true' is not a valid amount format for display items`));
+            });
+        });
+
         describe('spec-conformant error identity', () => {
             const expectConstructionTypeError = (construct: () => PaymentRequest): void => {
                 expect(construct).toThrow(TypeError);
@@ -708,6 +766,39 @@ describe('PaymentRequest', () => {
                 expect(transactionInfo.totalPriceStatus).toBe('NOT_CURRENTLY_KNOWN');
                 expect(transactionInfo.transactionId).toBe('txn-1');
                 expect(transactionInfo.totalPrice).toBe('0.00');
+            });
+
+            it('should replace the total with a matching modifier before serializing transactionInfo', async () => {
+                expect.assertions(2);
+
+                const transactionInfo = await getSerializedTransactionInfo(androidMethodData, {
+                    total: { label: 'Total', amount: { currency: 'USD', value: '10.00' } },
+                    modifiers: [
+                        {
+                            supportedMethods: PaymentMethodNameEnum.AndroidPay,
+                            total: { label: 'Discounted total', amount: { currency: 'USD', value: '8.00' } },
+                        },
+                    ],
+                });
+
+                expect(transactionInfo.totalPrice).toBe('8.00');
+                expect(transactionInfo.totalPriceLabel).toBe('Discounted total');
+            });
+
+            it('should ignore a modifier for a non-matching platform payment method', async () => {
+                expect.assertions(1);
+
+                const transactionInfo = await getSerializedTransactionInfo(androidMethodData, {
+                    total: { label: 'Total', amount: { currency: 'USD', value: '10.00' } },
+                    modifiers: [
+                        {
+                            supportedMethods: PaymentMethodNameEnum.ApplePay,
+                            total: { label: 'Discounted total', amount: { currency: 'USD', value: '8.00' } },
+                        },
+                    ],
+                });
+
+                expect(transactionInfo.totalPrice).toBe('10.00');
             });
 
             it('should serialize checkoutOption with default FINAL totalPriceStatus', async () => {
@@ -2453,6 +2544,121 @@ describe('PaymentRequest', () => {
 
             expect((shownDetails as PaymentDetailsInit).shippingOptions).toStrictEqual([detailedOption]);
             expect(updatedShippingOptions).toStrictEqual([detailedOption]);
+        });
+
+        describe('payment details modifiers', () => {
+            const modifierTotal: PaymentItem = { label: 'Discounted total', amount: { currency: 'USD', value: '7.50' } };
+            const modifierItem: PaymentItem = { label: 'Loyalty discount', amount: { currency: 'USD', value: '-2.50' } };
+
+            it('should replace the total and append additionalDisplayItems from a matching modifier before show()', async () => {
+                expect.hasAssertions();
+
+                let finishShow: (details: string) => void = emptyFn;
+                jest.mocked(NativePayments.show).mockImplementation(
+                    async () =>
+                        new Promise<string>(resolve => {
+                            finishShow = resolve;
+                        })
+                );
+
+                const request = new PaymentRequest([eventsMethodData], {
+                    total: initialTotal,
+                    displayItems: [displayItem],
+                    modifiers: [
+                        {
+                            supportedMethods: PaymentMethodNameEnum.ApplePay,
+                            total: modifierTotal,
+                            additionalDisplayItems: [modifierItem],
+                        },
+                    ],
+                });
+
+                const response = request.show();
+                finishShow(acceptedPayment);
+                await response;
+
+                const [[, , shownDetails]] = jest.mocked(NativePayments.show).mock.calls;
+
+                expect((shownDetails as PaymentDetailsInit).total).toStrictEqual(modifierTotal);
+                expect((shownDetails as PaymentDetailsInit).displayItems).toStrictEqual([displayItem, modifierItem]);
+            });
+
+            it('should ignore a modifier for a non-matching payment method on show()', async () => {
+                expect.hasAssertions();
+
+                let finishShow: (details: string) => void = emptyFn;
+                jest.mocked(NativePayments.show).mockImplementation(
+                    async () =>
+                        new Promise<string>(resolve => {
+                            finishShow = resolve;
+                        })
+                );
+
+                const request = new PaymentRequest([eventsMethodData], {
+                    total: initialTotal,
+                    modifiers: [{ supportedMethods: PaymentMethodNameEnum.AndroidPay, total: modifierTotal }],
+                });
+
+                const response = request.show();
+                finishShow(acceptedPayment);
+                await response;
+
+                const [[, , shownDetails]] = jest.mocked(NativePayments.show).mock.calls;
+
+                expect((shownDetails as PaymentDetailsInit).total).toStrictEqual(initialTotal);
+            });
+
+            it('should apply a matching modifier carried by updateWith before answering native', async () => {
+                expect.hasAssertions();
+
+                const request = createInteractiveRequest();
+
+                request.addEventListener('shippingaddresschange', event => {
+                    event.updateWith({
+                        total: updatedTotal,
+                        modifiers: [
+                            {
+                                supportedMethods: PaymentMethodNameEnum.ApplePay,
+                                total: modifierTotal,
+                                additionalDisplayItems: [modifierItem],
+                            },
+                        ],
+                    });
+                });
+
+                emitNativeEvent('shippingaddresschange', { requestId: request.id, shippingAddress: address });
+                await nativeUpdate;
+                await flushEventLoop();
+
+                expect(request.details.total).toStrictEqual(updatedTotal);
+                expect(updatePaymentDetailsMock).toHaveBeenCalledWith(
+                    { error: '', eventName: 'shippingaddresschange', requestId: request.id, total: modifierTotal },
+                    [modifierItem],
+                    []
+                );
+            });
+
+            it('should ignore a modifier for a non-matching payment method carried by updateWith', async () => {
+                expect.hasAssertions();
+
+                const request = createInteractiveRequest();
+
+                request.addEventListener('shippingaddresschange', event => {
+                    event.updateWith({
+                        total: updatedTotal,
+                        modifiers: [{ supportedMethods: PaymentMethodNameEnum.AndroidPay, total: modifierTotal }],
+                    });
+                });
+
+                emitNativeEvent('shippingaddresschange', { requestId: request.id, shippingAddress: address });
+                await nativeUpdate;
+
+                expect(updatePaymentDetailsMock).toHaveBeenCalledWith(
+                    { error: '', eventName: 'shippingaddresschange', requestId: request.id, total: updatedTotal },
+                    [],
+                    []
+                );
+            });
         });
 
         it('should remove a listener registered while the native module could not deliver change events', () => {

--- a/packages/react-native-payments/src/class/payment-request/payment-request.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.ts
@@ -19,9 +19,11 @@ import { DOMException } from '../../error/dom.exception';
 import { PaymentsError } from '../../error/payments.error';
 import { getNativePaymentsEventEmitter } from '../../util/get-native-payments-event-emitter/get-native-payments-event-emitter.util';
 import { isNativeUserCancellation } from '../../util/is-native-user-cancellation.util';
+import { resolvePaymentDetailsModifier } from '../../util/resolve-payment-details-modifier.util';
 import { validateAndroidTransactionInfo } from '../../util/validate-android-transaction-info.util';
 import { validateDetailsUpdate } from '../../util/validate-details-update.util';
 import { validateDisplayItems } from '../../util/validate-display-items.util';
+import { validateModifiers } from '../../util/validate-modifiers.util';
 import { validatePaymentMethods } from '../../util/validate-payment-methods.util';
 import { validateShippingOptions } from '../../util/validate-shipping-options.util';
 import { validateTotal } from '../../util/validate-total.util';
@@ -38,11 +40,13 @@ import type { IosPaymentMethodDataDataInterface } from '../../@standard/ios/mapp
 import type { IosPaymentDataRequest } from '../../@standard/ios/request/ios-payment-data-request';
 import type { PaymentDetailsInit } from '../../@standard/w3c/payment-details-init';
 import type { PaymentDetailsUpdate } from '../../@standard/w3c/payment-details-update';
+import type { PaymentItem } from '../../@standard/w3c/payment-item';
 import type { PaymentMethodData } from '../../@standard/w3c/payment-method-data';
 import type { NativePaymentDetailsUpdateInterface } from '../../interface/native-payment-details-update.interface';
 import type { PaymentRequestEventPayloadInterface } from '../../interface/payment-request-event-payload.interface';
 import type { PaymentRequestEventRegistrationInterface } from '../../interface/payment-request-event-registration.interface';
 import type { PaymentResponseAddressInterface } from '../../interface/payment-response-address.interface';
+import type { ResolvedPaymentDetailsInterface } from '../../interface/resolved-payment-details.interface';
 import type { PaymentMethodChangeEventListener } from '../../type/payment-method-change-event-listener.type';
 import type { PaymentRequestEventListener } from '../../type/payment-request-event-listener.type';
 import type { PaymentRequestEventType } from '../../type/payment-request-event.type';
@@ -95,13 +99,17 @@ export class PaymentRequest {
         validateDisplayItems(ConstructorError, details.displayItems);
 
         validateShippingOptions(ConstructorError, details.shippingOptions);
+        validateModifiers(ConstructorError, details.modifiers);
 
         // 17. Set request.[[serializedMethodData]] to serializedMethodData.         */
         this.platformMethodData = this.findPlatformPaymentMethodData();
 
         const nativePlatformMethodData =
             Platform.OS === 'android'
-                ? this.getAndroidPaymentMethodData(this.platformMethodData as AndroidPaymentMethodDataDataInterface, details)
+                ? this.getAndroidPaymentMethodData(
+                      this.platformMethodData as AndroidPaymentMethodDataDataInterface,
+                      this.resolveEffectiveDetails(details).total
+                  )
                 : this.getIosPaymentMethodData(this.platformMethodData as IosPaymentMethodDataDataInterface);
 
         this.serializedMethodData = JSON.stringify(nativePlatformMethodData);
@@ -125,14 +133,17 @@ export class PaymentRequest {
         this.state = 'interactive';
         this.syncActiveEvents();
 
+        const resolvedDetails = this.resolveEffectiveDetails(this.details);
+
         // HINT: We need to pass Android environment configuration to native module via details
         const details =
             Platform.OS === 'android'
                 ? {
                       ...this.details,
                       environment: (this.platformMethodData as AndroidPaymentMethodDataDataInterface).environment,
+                      ...resolvedDetails,
                   }
-                : this.details;
+                : { ...this.details, ...resolvedDetails };
 
         return new Promise<AndroidPaymentResponse | IosPaymentResponse>((resolve, reject) => {
             this.acceptPromiseRejecter = reject;
@@ -394,15 +405,16 @@ export class PaymentRequest {
         }
 
         const updatedDetails = this.getUpdatedDetails(detailsUpdate);
+        const resolvedDetails = this.resolveEffectiveDetails(updatedDetails);
         const update: NativePaymentDetailsUpdateInterface = {
             error: detailsUpdate?.error ?? '',
             eventName: type,
             requestId: this.id,
-            total: updatedDetails.total,
+            total: resolvedDetails.total,
             ...(isDefined(eventId) && { eventId }),
         };
 
-        await updatePaymentDetails(update, updatedDetails.displayItems ?? [], updatedDetails.shippingOptions ?? []);
+        await updatePaymentDetails(update, resolvedDetails.displayItems, updatedDetails.shippingOptions ?? []);
 
         this.details = updatedDetails;
     }
@@ -417,12 +429,25 @@ export class PaymentRequest {
             ...(isDefined(detailsUpdate.total) && { total: detailsUpdate.total }),
             ...(isDefined(detailsUpdate.displayItems) && { displayItems: detailsUpdate.displayItems }),
             ...(isDefined(detailsUpdate.shippingOptions) && { shippingOptions: detailsUpdate.shippingOptions }),
+            ...(isDefined(detailsUpdate.modifiers) && { modifiers: detailsUpdate.modifiers }),
         };
     }
 
+    private resolveEffectiveDetails(details: PaymentDetailsInit): ResolvedPaymentDetailsInterface {
+        return resolvePaymentDetailsModifier(
+            this.getPlatformSupportedMethod(),
+            details.total,
+            details.displayItems,
+            details.modifiers
+        );
+    }
+
+    private getPlatformSupportedMethod(): PaymentMethodNameEnum {
+        return Platform.OS === 'ios' ? PaymentMethodNameEnum.ApplePay : PaymentMethodNameEnum.AndroidPay;
+    }
+
     private findPlatformPaymentMethodData(): AndroidPaymentMethodDataDataInterface | IosPaymentMethodDataDataInterface {
-        const platformSupportedMethod =
-            Platform.OS === 'ios' ? PaymentMethodNameEnum.ApplePay : PaymentMethodNameEnum.AndroidPay;
+        const platformSupportedMethod = this.getPlatformSupportedMethod();
 
         const platformMethod = this.methodData.find(
             paymentMethodData => paymentMethodData.supportedMethods === platformSupportedMethod
@@ -437,7 +462,7 @@ export class PaymentRequest {
 
     private getAndroidPaymentMethodData(
         methodData: AndroidPaymentMethodDataDataInterface,
-        details: PaymentDetailsInit
+        total: PaymentItem
     ): AndroidPaymentDataRequest {
         const isBillingRequired =
             methodData.requestBillingAddress === true ||
@@ -449,13 +474,13 @@ export class PaymentRequest {
         return {
             ...defaultAndroidPaymentDataRequest,
             merchantInfo: {
-                merchantName: details.total.label,
+                merchantName: total.label,
             },
             transactionInfo: {
                 ...defaultAndroidTransactionInfo,
                 currencyCode: methodData.currencyCode,
-                totalPrice: details.total.amount.value,
-                totalPriceLabel: details.total.label,
+                totalPrice: total.amount.value,
+                totalPriceLabel: total.label,
                 countryCode: methodData.countryCode,
                 totalPriceStatus,
                 ...(isDefined(methodData.checkoutOption) && { checkoutOption: methodData.checkoutOption }),

--- a/packages/react-native-payments/src/index.ts
+++ b/packages/react-native-payments/src/index.ts
@@ -11,6 +11,7 @@ export { DOMException } from './error/dom.exception';
 export { PaymentsError } from './error/payments.error';
 export type { PaymentDetailsUpdateError } from './type/payment-details-update-error.type';
 export type { PaymentDetailsInit } from './@standard/w3c/payment-details-init';
+export type { PaymentDetailsModifier } from './@standard/w3c/payment-details-modifier';
 export type { PaymentDetailsUpdate } from './@standard/w3c/payment-details-update';
 export type { PaymentItem } from './@standard/w3c/payment-item';
 export type { PaymentShippingOption } from './@standard/w3c/payment-shipping-option';

--- a/packages/react-native-payments/src/interface/resolved-payment-details.interface.ts
+++ b/packages/react-native-payments/src/interface/resolved-payment-details.interface.ts
@@ -1,0 +1,6 @@
+import type { PaymentItem } from '../@standard/w3c/payment-item';
+
+export interface ResolvedPaymentDetailsInterface {
+    displayItems: PaymentItem[];
+    total: PaymentItem;
+}

--- a/packages/react-native-payments/src/util/resolve-payment-details-modifier.util.ts
+++ b/packages/react-native-payments/src/util/resolve-payment-details-modifier.util.ts
@@ -1,0 +1,25 @@
+import { isDefined } from '@rnw-community/shared';
+
+import type { PaymentDetailsModifier } from '../@standard/w3c/payment-details-modifier';
+import type { PaymentItem } from '../@standard/w3c/payment-item';
+import type { PaymentMethodNameEnum } from '../enum/payment-method-name.enum';
+import type { ResolvedPaymentDetailsInterface } from '../interface/resolved-payment-details.interface';
+
+// https://www.w3.org/TR/payment-request/#dom-paymentdetailsmodifier
+export const resolvePaymentDetailsModifier = (
+    platformSupportedMethod: PaymentMethodNameEnum,
+    total: PaymentItem,
+    displayItems: PaymentItem[] = [],
+    modifiers: PaymentDetailsModifier[] = []
+): ResolvedPaymentDetailsInterface => {
+    const modifier = modifiers.find(candidate => candidate.supportedMethods === platformSupportedMethod);
+
+    if (!isDefined(modifier)) {
+        return { displayItems, total };
+    }
+
+    return {
+        displayItems: [...displayItems, ...(modifier.additionalDisplayItems ?? [])],
+        total: modifier.total ?? total,
+    };
+};

--- a/packages/react-native-payments/src/util/validate-details-update.util.ts
+++ b/packages/react-native-payments/src/util/validate-details-update.util.ts
@@ -3,6 +3,7 @@ import { isDefined } from '@rnw-community/shared';
 import { PaymentsError } from '../error/payments.error';
 
 import { validateDisplayItems } from './validate-display-items.util';
+import { validateModifiers } from './validate-modifiers.util';
 import { validateShippingOptions } from './validate-shipping-options.util';
 import { validateTotal } from './validate-total.util';
 
@@ -15,4 +16,5 @@ export const validateDetailsUpdate = (detailsUpdate: PaymentDetailsUpdate): void
 
     validateDisplayItems(PaymentsError, detailsUpdate.displayItems);
     validateShippingOptions(PaymentsError, detailsUpdate.shippingOptions);
+    validateModifiers(PaymentsError, detailsUpdate.modifiers);
 };

--- a/packages/react-native-payments/src/util/validate-modifiers.util.ts
+++ b/packages/react-native-payments/src/util/validate-modifiers.util.ts
@@ -1,0 +1,21 @@
+import { isDefined } from '@rnw-community/shared';
+
+import { validateDisplayItems } from './validate-display-items.util';
+import { validateTotal } from './validate-total.util';
+
+import type { PaymentDetailsModifier } from '../@standard/w3c/payment-details-modifier';
+import type { ClassType } from '@rnw-community/shared';
+
+export const validateModifiers = (ErrorType: ClassType<Error>, modifiers: PaymentDetailsModifier[] = []): void => {
+    modifiers.forEach(modifier => {
+        if (!isDefined(modifier) || !isDefined(modifier.supportedMethods)) {
+            throw new ErrorType(`required member supportedMethods is undefined.`);
+        }
+
+        if (isDefined(modifier.total)) {
+            validateTotal(modifier.total, ErrorType);
+        }
+
+        validateDisplayItems(ErrorType, modifier.additionalDisplayItems);
+    });
+};


### PR DESCRIPTION
## Summary
- Resolve a `PaymentDetailsModifier` matching the active platform's payment method (`PaymentMethodNameEnum.ApplePay` / `AndroidPay`) before serializing details to native: Android `transactionInfo` at construction, iOS PassKit total/display items at `show()`.
- Accept `modifiers` on the `updateWith()` path too, re-resolving the matching modifier before answering native; a modifier for the other platform's method is ignored per spec.
- Validate each modifier with the same monetary rules already used for `total` and `displayItems` (`validateModifiers`), wired into both the constructor and `validateDetailsUpdate`.
- Fix `PaymentDetailsModifier.supportedMethods` typing (it was incorrectly `SupportedNetworkEnum`, a card-network enum) to `PaymentMethodNameEnum`, matching `PaymentMethodData.supportedMethods`; make `total`/`additionalDisplayItems`/`data` optional per spec and export the type from the package's public API.
- readme: new "Payment details modifiers" section with one example; ticked the `PaymentDetailsModifier` row of the W3C compliance checklist.

## Test plan
- [x] `yarn build && yarn ts && yarn lint && yarn test && yarn deadcode`
- [x] `yarn test:coverage` for `react-native-payments` — 100% statements/branches/functions/lines
- [x] New unit tests cover: constructor validation of modifiers, Android `transactionInfo` total replaced by a matching modifier and unaffected by a non-matching one, iOS `show()` total/displayItems replaced/appended by a matching modifier, and the same resolution applied on the `updateWith()` change-event path

Closes #435

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `PaymentDetailsModifier` support in `PaymentRequest`
> - Adds a new `resolvePaymentDetailsModifier` utility that selects a modifier matching the platform's supported payment method and applies its `total` override and `additionalDisplayItems` to base details.
> - Applies modifier resolution in the `PaymentRequest` constructor (for Android's `transactionInfo`), in `show()`, and in `updateWith()` so both iOS and Android render the resolved total and display items.
> - Adds a new `validateModifiers` utility called during construction and on `updateWith` to reject invalid modifiers (missing `supportedMethods`, negative totals, invalid display items).
> - Refactors `getAndroidPaymentMethodData` to accept a resolved `PaymentItem` instead of raw details, so Android merchant name and transaction total derive from the modifier-resolved total.
> - Behavioral Change: `updateWith` calls that include `modifiers` now update the stored modifier state on the request.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a89d20.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->