### PR TITLE
feat(react-native-payments): add hasEnrolledInstrument, event-handler attributes, shippingType

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -70,6 +70,7 @@ export default defineConfig(
             'require-await': 'off',
             'prefer-named-capture-group': 'off',
             'member-ordering': 'off',
+            'grouped-accessor-pairs': 'off',
         },
     },
     {

--- a/packages/react-native-payments/android/src/main/java/com/payments/PaymentsModule.java
+++ b/packages/react-native-payments/android/src/main/java/com/payments/PaymentsModule.java
@@ -133,7 +133,7 @@ public class PaymentsModule extends PaymentsSpec {
                 if (task.isSuccessful()) {
                     promise.resolve(task.getResult());
                 } else {
-                    rejectPromise(E_UNSUPPORTED_ANDROID_PAY, "AndroidPay is not supported");
+                    promise.reject(E_UNSUPPORTED_ANDROID_PAY, "AndroidPay is not supported");
                 }
             }
         });

--- a/packages/react-native-payments/android/src/main/java/com/payments/PaymentsModule.java
+++ b/packages/react-native-payments/android/src/main/java/com/payments/PaymentsModule.java
@@ -91,6 +91,17 @@ public class PaymentsModule extends PaymentsSpec {
     // https://developers.google.com/pay/api/android/guides/tutorial#java
     @ReactMethod
     public void canMakePayments(String paymentMethodData, final Promise promise) {
+        checkIsReadyToPay(paymentMethodData, false, promise);
+    }
+
+    // HINT: existingPaymentMethodRequired is an optimistic signal, not a guarantee a card is enrolled.
+    // https://developers.google.com/android/reference/com/google/android/gms/wallet/IsReadyToPayRequest.Builder#setExistingPaymentMethodRequired(boolean)
+    @ReactMethod
+    public void hasEnrolledInstrument(String paymentMethodData, final Promise promise) {
+        checkIsReadyToPay(paymentMethodData, true, promise);
+    }
+
+    private void checkIsReadyToPay(String paymentMethodData, boolean existingPaymentMethodRequired, final Promise promise) {
         Activity currentActivity = getCurrentActivity();
         Log.d(NAME, "Checking if AndroidPay is available " + currentActivity.toString());
 
@@ -100,7 +111,9 @@ public class PaymentsModule extends PaymentsSpec {
         validatePaymentRequestJSON(paymentMethodData);
 
         // https://developers.google.com/android/reference/com/google/android/gms/wallet/PaymentDataRequest#fromJson(java.lang.String)
-        IsReadyToPayRequest request = IsReadyToPayRequest.fromJson(paymentMethodData);
+        IsReadyToPayRequest request = existingPaymentMethodRequired
+            ? buildExistingPaymentMethodRequiredRequest(paymentMethodData)
+            : IsReadyToPayRequest.fromJson(paymentMethodData);
 
         if(request == null) {
             rejectPromise(E_UNSUPPORTED_ANDROID_PAY, "AndroidPay is not supported");
@@ -124,6 +137,17 @@ public class PaymentsModule extends PaymentsSpec {
                 }
             }
         });
+    }
+
+    private IsReadyToPayRequest buildExistingPaymentMethodRequiredRequest(String paymentMethodData) {
+        try {
+            JSONObject requestJson = new JSONObject(paymentMethodData);
+            requestJson.put("existingPaymentMethodRequired", true);
+
+            return IsReadyToPayRequest.fromJson(requestJson.toString());
+        } catch (JSONException e) {
+            return null;
+        }
     }
 
     @ReactMethod

--- a/packages/react-native-payments/android/src/oldarch/PaymentsSpec.java
+++ b/packages/react-native-payments/android/src/oldarch/PaymentsSpec.java
@@ -13,6 +13,7 @@ abstract class PaymentsSpec extends ReactContextBaseJavaModule {
 
   public abstract void show(String requestId, String paymentMethodData, ReadableMap details, Promise promise);
   public abstract void canMakePayments(String paymentMethodData, Promise promise);
+  public abstract void hasEnrolledInstrument(String paymentMethodData, Promise promise);
   public abstract void abort(Promise promise);
   public abstract void complete(String paymentComplete, Promise promise);
   public abstract void setActiveEvents(String requestId, ReadableArray eventNames, Promise promise);

--- a/packages/react-native-payments/ios/Payments.mm
+++ b/packages/react-native-payments/ios/Payments.mm
@@ -424,7 +424,7 @@ RCT_EXPORT_METHOD(hasEnrolledInstrument: (NSString *)methodDataString
     NSError *error;
     NSDictionary *methodData = [NSJSONSerialization JSONObjectWithData:jsonData options:kNilOptions error:&error];
     if (error) {
-        [self rejectPromise:@"wrong_payment_data" message:@"Invalid JSON payment methodData passed" error:nil];
+        reject(@"wrong_payment_data", @"Invalid JSON payment methodData passed", nil);
         return;
     }
 
@@ -434,7 +434,7 @@ RCT_EXPORT_METHOD(hasEnrolledInstrument: (NSString *)methodDataString
         if (paymentNetwork != PKPaymentNetworkUnknown) {
             [supportedNetworks addObject:paymentNetwork];
         } else {
-            [self rejectPromise:@"invalid_supported_network" message:[NSString stringWithFormat:@"Invalid supportedNetwork passed '%@'", supportedNetwork] error:nil];
+            reject(@"invalid_supported_network", [NSString stringWithFormat:@"Invalid supportedNetwork passed '%@'", supportedNetwork], nil);
             return;
         }
     }

--- a/packages/react-native-payments/ios/Payments.mm
+++ b/packages/react-native-payments/ios/Payments.mm
@@ -267,6 +267,12 @@ RCT_EXPORT_METHOD(show:(NSString *)requestId
         paymentRequest.requiredShippingContactFields = [NSSet setWithArray:requiredShippingContactFields];
     }
 
+    // https://developer.apple.com/documentation/passkit/pkpaymentrequest/3801273-shippingtype?language=objc
+    NSString *shippingTypeString = methodData[@"shippingType"];
+    if (shippingTypeString != nil) {
+        paymentRequest.shippingType = [self shippingTypeFromString:shippingTypeString];
+    }
+
     // https://developer.apple.com/documentation/passkit/pkpaymentauthorizationviewcontroller/1616178-initwithpaymentrequest?language=objc
     self.viewController = [[PKPaymentAuthorizationViewController alloc] initWithPaymentRequest: paymentRequest];
     self.viewController.delegate = self;
@@ -405,11 +411,36 @@ RCT_EXPORT_METHOD(canMakePayments: (NSString *)methodDataString
                                    resolve:(RCTPromiseResolveBlock)resolve
                                    reject:(RCTPromiseRejectBlock)reject)
 {
-    // TODO: We can implement https://developer.apple.com/documentation/passkit/pkpaymentauthorizationviewcontroller/1616181-canmakepaymentsusingnetworks?language=objc
-    // for this we need to extract parsing and validating methods from the show method and reuse in both places.
-
     // https://developer.apple.com/documentation/passkit/pkpaymentauthorizationviewcontroller/1616192-canmakepayments?language=objc
     resolve(@([PKPaymentAuthorizationViewController canMakePayments]));
+}
+
+RCT_EXPORT_METHOD(hasEnrolledInstrument: (NSString *)methodDataString
+                                        resolve:(RCTPromiseResolveBlock)resolve
+                                        reject:(RCTPromiseRejectBlock)reject)
+{
+    NSData *jsonData = [methodDataString dataUsingEncoding:NSUTF8StringEncoding];
+
+    NSError *error;
+    NSDictionary *methodData = [NSJSONSerialization JSONObjectWithData:jsonData options:kNilOptions error:&error];
+    if (error) {
+        [self rejectPromise:@"wrong_payment_data" message:@"Invalid JSON payment methodData passed" error:nil];
+        return;
+    }
+
+    NSMutableArray *supportedNetworks = [NSMutableArray array];
+    for (NSString *supportedNetwork in methodData[@"supportedNetworks"]) {
+        PKPaymentNetwork paymentNetwork = [self paymentNetworkFromString:supportedNetwork];
+        if (paymentNetwork != PKPaymentNetworkUnknown) {
+            [supportedNetworks addObject:paymentNetwork];
+        } else {
+            [self rejectPromise:@"invalid_supported_network" message:[NSString stringWithFormat:@"Invalid supportedNetwork passed '%@'", supportedNetwork] error:nil];
+            return;
+        }
+    }
+
+    // https://developer.apple.com/documentation/passkit/pkpaymentauthorizationviewcontroller/1616181-canmakepaymentsusingnetworks?language=objc
+    resolve(@([PKPaymentAuthorizationViewController canMakePaymentsUsingNetworks:supportedNetworks]));
 }
 
 // DELEGATES https://developer.apple.com/documentation/passkit/pkpaymentauthorizationviewcontrollerdelegate?language=objc
@@ -1009,6 +1040,20 @@ RCT_EXPORT_METHOD(canMakePayments: (NSString *)methodDataString
     });
 
     return paymentNetworks[paymentNetworkString] ?: PKPaymentNetworkUnknown;
+}
+
+// https://www.w3.org/TR/payment-request/#dom-paymentoptions-shippingtype
+// HINT: 'pickup' maps to PKShippingTypeStorePickup; PKShippingTypeServicePickup has no W3C equivalent and is not exposed.
+- (PKShippingType)shippingTypeFromString:(NSString *)shippingTypeString {
+    NSDictionary<NSString *, NSNumber *> *shippingTypes = @{
+        @"shipping": @(PKShippingTypeShipping),
+        @"delivery": @(PKShippingTypeDelivery),
+        @"pickup": @(PKShippingTypeStorePickup)
+    };
+
+    NSNumber *mappedShippingType = shippingTypes[shippingTypeString];
+
+    return mappedShippingType != nil ? (PKShippingType)mappedShippingType.unsignedIntegerValue : PKShippingTypeShipping;
 }
 
 - (PKMerchantCapability)merchantCapabilityFromString:(NSString *)capabilityString {

--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -228,10 +228,10 @@ Depending on the platform and payment method, you can provide additional data to
   include the email address of the payer.
 - `requestShipping`: An optional boolean field that, when present and set to true, indicates that the `PaymentResponse` will
   include the shipping address of the payer.
-- `shippingType`: An optional [`PaymentOptions.shippingType`](https://www.w3.org/TR/payment-request/#dom-paymentoptions-shippingtype)
-  field (`PaymentShippingTypeEnum.Shipping` / `Delivery` / `Pickup`) forwarded to `PKShippingType` on iOS — `Pickup` maps
-  to `PKShippingTypeStorePickup`, see [Known deviations](#known-deviations). No-op on Android, which has no equivalent
-  concept.
+- `shippingType`: An optional field (`PaymentShippingTypeEnum.Shipping` / `Delivery` / `Pickup`) mapping to the W3C
+  [`PaymentOptions.shippingType`](https://www.w3.org/TR/payment-request/#dom-paymentoptions-shippingtype) concept,
+  forwarded to `PKShippingType` on iOS — `Pickup` maps to `PKShippingTypeStorePickup`, see
+  [Known deviations](#known-deviations). No-op on Android, which has no equivalent concept.
 - `applicationData`: An optional string or object field for Apple Pay that allows you to store application-specific data. This data is not transmitted to Apple but is included in the payment token as a SHA-256 hash (applicationDataHash). You can use it to prevent replay attacks by associating a payment with a specific transaction.
 - `couponCode`: An optional Apple Pay field, **beyond the W3C specification**, that prefills the coupon code field of the
   payment sheet. The field itself is only rendered when a `couponcodechange` listener is registered before `show()`, so
@@ -976,8 +976,9 @@ You can find working example in the `App` component of the [react-native-payment
 - [x] Implement the event-handler attributes (`onshippingaddresschange`, `onshippingoptionchange`,
       `onpaymentmethodchange`, `oncouponcodechange`) — see
       [Event-handler attributes](#event-handler-attributes-onshippingaddresschange-onshippingoptionchange-onpaymentmethodchange-oncouponcodechange)
-- [x] Implement [`PaymentOptions.shippingType`](https://www.w3.org/TR/payment-request/#dom-paymentoptions-shippingtype) —
-      see [2.1 Additional methodData.data options](#21-additional-methoddatadata-options); no-op on Android, see Known
+- [x] Implement [`PaymentOptions.shippingType`](https://www.w3.org/TR/payment-request/#dom-paymentoptions-shippingtype) as
+      `methodData.data.shippingType` — see
+      [2.1 Additional methodData.data options](#21-additional-methoddatadata-options); no-op on Android, see Known
       deviations
 - [ ] Implement `PaymentResponse` `retry()` method
 - [ ] Implement `PaymentResponse` `toJSON()` method
@@ -1001,8 +1002,8 @@ You can find working example in the `App` component of the [react-native-payment
   `isReadyToPay` with `existingPaymentMethodRequired: true`, the closest reachable equivalent of "an instrument is
   enrolled" that the API exposes; Google documents this as best-effort and it can still resolve `true` without a fully
   usable card in some configurations.
-- **`PaymentOptions.shippingType` is a no-op on Android.** Google Pay has no `PKShippingType`-equivalent concept; the
-  value is validated but not forwarded to native.
+- **`methodData.data.shippingType` (`PaymentOptions.shippingType`) is a no-op on Android.** Google Pay has no
+  `PKShippingType`-equivalent concept; the value is validated but not forwarded to native.
 - **iOS `shippingType: 'pickup'` maps to `PKShippingTypeStorePickup`.** PassKit also has `PKShippingTypeServicePickup`,
   which has no W3C equivalent and is not exposed by this library.
 

--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -228,6 +228,10 @@ Depending on the platform and payment method, you can provide additional data to
   include the email address of the payer.
 - `requestShipping`: An optional boolean field that, when present and set to true, indicates that the `PaymentResponse` will
   include the shipping address of the payer.
+- `shippingType`: An optional [`PaymentOptions.shippingType`](https://www.w3.org/TR/payment-request/#dom-paymentoptions-shippingtype)
+  field (`PaymentShippingTypeEnum.Shipping` / `Delivery` / `Pickup`) forwarded to `PKShippingType` on iOS — `Pickup` maps
+  to `PKShippingTypeStorePickup`, see [Known deviations](#known-deviations). No-op on Android, which has no equivalent
+  concept.
 - `applicationData`: An optional string or object field for Apple Pay that allows you to store application-specific data. This data is not transmitted to Apple but is included in the payment token as a SHA-256 hash (applicationDataHash). You can use it to prevent replay attacks by associating a payment with a specific transaction.
 - `couponCode`: An optional Apple Pay field, **beyond the W3C specification**, that prefills the coupon code field of the
   payment sheet. The field itself is only rendered when a `couponcodechange` listener is registered before `show()`, so
@@ -310,6 +314,18 @@ const isPaymentPossible = await paymentRequest.canMakePayment();
 This method returns a boolean value indicating whether the device supports the specified payment methods.
 
 > The `PaymentRequest` class automatically handles platform-specific payment data based on the provided methodData.
+
+To check whether the user has a payment instrument enrolled — not just device/API support — use
+[`hasEnrolledInstrument()`](https://www.w3.org/TR/payment-request/#hasenrolledinstrument-method):
+
+```ts
+const hasCard = await paymentRequest.hasEnrolledInstrument();
+```
+
+Both methods reject with `InvalidStateError` when the request is not in the `created` state. On iOS this maps to
+PassKit's `canMakePaymentsUsingNetworks:`, restricting the capability check to the request's `supportedNetworks`. On
+Android it calls Google Pay's `isReadyToPay` with `existingPaymentMethodRequired: true` — see
+[Known deviations](#known-deviations) for the precision trade-off this implies.
 
 ### 4. Displaying the Payment Sheet
 
@@ -487,6 +503,26 @@ payment sheet is open.
 
 ```ts
 paymentRequest.removeEventListener('shippingaddresschange', onShippingAddressChange);
+```
+
+### Event-handler attributes (`onshippingaddresschange`, `onshippingoptionchange`, `onpaymentmethodchange`, `oncouponcodechange`)
+
+Thin property alternatives to `addEventListener`/`removeEventListener`, one per event type, matching the `EventTarget`
+IDL attribute semantics: assigning a function **replaces** the previously assigned attribute handler (an implicit
+`removeEventListener` of the old one followed by `addEventListener` of the new one); assigning `null` clears it without
+registering a new listener; reading the property returns the currently assigned handler, or `null` when none was set.
+The attribute handler is otherwise an ordinary listener — it coexists with every listener registered through
+`addEventListener` for the same type and runs in the order it was (re-)registered.
+
+```ts
+paymentRequest.onshippingaddresschange = event => {
+    event.updateWith({
+        total: { label: 'Total', amount: { currency: 'USD', value: '25.00' } },
+        displayItems: [{ label: 'Shipping', amount: { currency: 'USD', value: '5.00' } }],
+    });
+};
+
+paymentRequest.onshippingaddresschange = null; // clears it
 ```
 
 ### `PaymentRequestUpdateEvent.updateWith(detailsOrPromise)`
@@ -735,6 +771,18 @@ const data = {
 };
 ```
 
+### `PaymentShippingTypeEnum`
+
+Populates the optional `shippingType` of `methodData.data` documented in
+[2.1 Additional methodData.data options](#21-additional-methoddatadata-options): `Shipping`, `Delivery` or `Pickup`.
+
+```ts
+const data = {
+    merchantIdentifier: 'merchant.com.your-app.namespace',
+    shippingType: PaymentShippingTypeEnum.Delivery,
+};
+```
+
 ### `AndroidPaymentMethodDataInterface` / `AndroidPaymentMethodDataDataInterface`
 
 The typed shape of the Android entry of `methodData` shown in [Creating an Instance](#2-creating-an-instance):
@@ -922,6 +970,15 @@ You can find working example in the `App` component of the [react-native-payment
 - [x] Implement [PaymentDetailsModifier](https://www.w3.org/TR/payment-request/#dom-paymentdetailsmodifier) — see
       [Payment details modifiers](#24-payment-details-modifiers)
 - [x] Improve and unify errors according to the spec — see [Error Handling](#error-handling)
+- [x] Implement [`hasEnrolledInstrument()`](https://www.w3.org/TR/payment-request/#hasenrolledinstrument-method) — see
+      [3. Checking Payment Capability](#3-checking-payment-capability); Android answers via Google Pay's
+      `existingPaymentMethodRequired`, see Known deviations
+- [x] Implement the event-handler attributes (`onshippingaddresschange`, `onshippingoptionchange`,
+      `onpaymentmethodchange`, `oncouponcodechange`) — see
+      [Event-handler attributes](#event-handler-attributes-onshippingaddresschange-onshippingoptionchange-onpaymentmethodchange-oncouponcodechange)
+- [x] Implement [`PaymentOptions.shippingType`](https://www.w3.org/TR/payment-request/#dom-paymentoptions-shippingtype) —
+      see [2.1 Additional methodData.data options](#21-additional-methoddatadata-options); no-op on Android, see Known
+      deviations
 - [ ] Implement `PaymentResponse` `retry()` method
 - [ ] Implement `PaymentResponse` `toJSON()` method
 
@@ -940,6 +997,14 @@ You can find working example in the `App` component of the [react-native-payment
   `PaymentRequest` constructor as soon as it fails to find a platform-matching payment method, since the native bridge
   needs to know the target platform's method data up front to serialize the request. The error name matches the spec;
   only the algorithm step it fires from differs.
+- **`hasEnrolledInstrument()` on Android is an optimistic signal, not a guarantee.** It calls Google Pay's
+  `isReadyToPay` with `existingPaymentMethodRequired: true`, the closest reachable equivalent of "an instrument is
+  enrolled" that the API exposes; Google documents this as best-effort and it can still resolve `true` without a fully
+  usable card in some configurations.
+- **`PaymentOptions.shippingType` is a no-op on Android.** Google Pay has no `PKShippingType`-equivalent concept; the
+  value is validated but not forwarded to native.
+- **iOS `shippingType: 'pickup'` maps to `PKShippingTypeStorePickup`.** PassKit also has `PKShippingTypeServicePickup`,
+  which has no W3C equivalent and is not exposed by this library.
 
 ## License
 

--- a/packages/react-native-payments/src/@standard/ios/request/ios-payment-data-request.ts
+++ b/packages/react-native-payments/src/@standard/ios/request/ios-payment-data-request.ts
@@ -1,3 +1,4 @@
+import type { PaymentShippingTypeEnum } from '../../../enum/payment-shipping-type.enum';
 import type { IOSPKContactField } from '../enum/ios-pk-contact-field.enum';
 import type { IosPKMerchantCapability } from '../enum/ios-pk-merchant-capability.enum';
 import type { IosPKPaymentNetworksEnum } from '../enum/ios-pk-payment-networks.enum';
@@ -20,6 +21,8 @@ export interface IosPaymentDataRequest {
     requiredBillingContactFields?: IOSPKContactField[];
     // https://developer.apple.com/documentation/passkit/pkpaymentrequest/2865927-requiredshippingcontactfields?language=objc
     requiredShippingContactFields?: IOSPKContactField[];
+    // https://developer.apple.com/documentation/passkit/pkpaymentrequest/3801273-shippingtype?language=objc
+    shippingType?: PaymentShippingTypeEnum;
     // https://developer.apple.com/documentation/passkit/pkpaymentrequest/1619329-supportednetworks?language=objc
     supportedNetworks: IosPKPaymentNetworksEnum[];
 }

--- a/packages/react-native-payments/src/NativePayments.ts
+++ b/packages/react-native-payments/src/NativePayments.ts
@@ -12,6 +12,7 @@ export interface Spec extends TurboModule {
     addListener: (eventName: string) => void;
     canMakePayments: (methodData: string) => Promise<boolean>;
     complete: (paymentComplete: string) => Promise<void>;
+    hasEnrolledInstrument: (methodData: string) => Promise<boolean>;
     removeListeners: (count: number) => void;
     setActiveEvents: (requestId: string, eventNames: string[]) => Promise<void>;
     // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types

--- a/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
@@ -12,6 +12,7 @@ import { EnvironmentEnum } from '../../enum/environment.enum';
 import { PaymentAddressFieldEnum } from '../../enum/payment-address-field.enum';
 import { PaymentContactFieldEnum } from '../../enum/payment-contact-field.enum';
 import { PaymentMethodNameEnum } from '../../enum/payment-method-name.enum';
+import { PaymentShippingTypeEnum } from '../../enum/payment-shipping-type.enum';
 import { PaymentUpdateErrorTypeEnum } from '../../enum/payment-update-error-type.enum';
 import { PaymentsErrorEnum } from '../../enum/payments-error.enum';
 import { SupportedNetworkEnum } from '../../enum/supported-networks.enum';
@@ -46,6 +47,7 @@ import type { NativeEventEmitter } from 'react-native';
 jest.mock('../native-payments/native-payments', () => ({
     NativePayments: {
         canMakePayments: jest.fn(),
+        hasEnrolledInstrument: jest.fn(),
         show: jest.fn(),
         abort: jest.fn(),
         setActiveEvents: jest.fn(),
@@ -466,6 +468,41 @@ describe('PaymentRequest', () => {
             });
         });
 
+        describe(`methodData.data.shippingType`, () => {
+            it('should NOT throw when shippingType is not defined', () => {
+                expect.hasAssertions();
+
+                expect(() => new PaymentRequest([methodData], paymentDetails)).not.toThrow();
+            });
+
+            it('should NOT throw for every valid shippingType', () => {
+                expect.hasAssertions();
+
+                Object.values(PaymentShippingTypeEnum).forEach(shippingType => {
+                    expect(
+                        () =>
+                            new PaymentRequest(
+                                [{ ...methodData, data: { ...methodData.data, shippingType } }],
+                                paymentDetails
+                            )
+                    ).not.toThrow();
+                });
+            });
+
+            it('should throw when shippingType is invalid', () => {
+                expect.hasAssertions();
+
+                const invalidMethodData = {
+                    ...methodData,
+                    data: { ...methodData.data, shippingType: 'invalid' },
+                } as unknown as AndroidPaymentMethodDataInterface;
+
+                expect(() => new PaymentRequest([invalidMethodData], paymentDetails)).toThrow(
+                    new ConstructorError(`'invalid' is not a valid shippingType`)
+                );
+            });
+        });
+
         describe('spec-conformant error identity', () => {
             const expectConstructionTypeError = (construct: () => PaymentRequest): void => {
                 expect(construct).toThrow(TypeError);
@@ -556,6 +593,29 @@ describe('PaymentRequest', () => {
             const result = await request.canMakePayment();
 
             expect(NativePayments.canMakePayments).toHaveBeenCalledWith(expect.any(String));
+            expect(result).toBe(true);
+        });
+
+        it('should throw when `hasEnrolledInstrument` is called in invalid state', async () => {
+            expect.assertions(1);
+
+            const request = new PaymentRequest([androidMethodData], paymentDetails);
+            request.state = 'closed';
+
+            await expect(request.hasEnrolledInstrument()).rejects.toThrow(
+                new DOMException(PaymentsErrorEnum.InvalidStateError)
+            );
+        });
+
+        it('should return true from `hasEnrolledInstrument` when valid', async () => {
+            expect.assertions(2);
+
+            const request = new PaymentRequest([androidMethodData], paymentDetails);
+            jest.mocked(NativePayments.hasEnrolledInstrument).mockResolvedValue(true);
+
+            const result = await request.hasEnrolledInstrument();
+
+            expect(NativePayments.hasEnrolledInstrument).toHaveBeenCalledWith(expect.any(String));
             expect(result).toBe(true);
         });
 
@@ -987,6 +1047,29 @@ describe('PaymentRequest', () => {
             expect(result).toBe(true);
         });
 
+        it('should throw when `hasEnrolledInstrument` is called in invalid state', async () => {
+            expect.assertions(1);
+
+            const request = new PaymentRequest([iosMethodData], paymentDetails);
+            request.state = 'closed';
+
+            await expect(request.hasEnrolledInstrument()).rejects.toThrow(
+                new DOMException(PaymentsErrorEnum.InvalidStateError)
+            );
+        });
+
+        it('should return true from `hasEnrolledInstrument` when valid', async () => {
+            expect.assertions(2);
+
+            const request = new PaymentRequest([iosMethodData], paymentDetails);
+            jest.mocked(NativePayments.hasEnrolledInstrument).mockResolvedValue(true);
+
+            const result = await request.hasEnrolledInstrument();
+
+            expect(NativePayments.hasEnrolledInstrument).toHaveBeenCalledWith(expect.any(String));
+            expect(result).toBe(true);
+        });
+
         it('should throw when `show` is called in invalid state', async () => {
             expect.assertions(1);
 
@@ -1251,6 +1334,25 @@ describe('PaymentRequest', () => {
                     IOSPKContactField.PKContactFieldName,
                     IOSPKContactField.PKContactFieldPhoneNumber,
                 ]);
+            });
+
+            it('should serialize the provided shippingType', async () => {
+                expect.hasAssertions();
+
+                const methodDataRequest = await getSerializedIosMethodData({
+                    ...iosMethodData,
+                    data: { ...iosMethodData.data, shippingType: PaymentShippingTypeEnum.Pickup },
+                });
+
+                expect(methodDataRequest.shippingType).toBe(PaymentShippingTypeEnum.Pickup);
+            });
+
+            it('should not serialize a missing shippingType', async () => {
+                expect.hasAssertions();
+
+                const methodDataRequest = await getSerializedIosMethodData(iosMethodData);
+
+                expect(methodDataRequest).not.toHaveProperty('shippingType');
             });
         });
 
@@ -2671,6 +2773,105 @@ describe('PaymentRequest', () => {
             request.removeEventListener('shippingaddresschange', emptyFn);
 
             expect(setActiveEventsMock).toHaveBeenLastCalledWith(request.id, []);
+        });
+
+        describe('attribute-handler event listeners', () => {
+            it('should default every attribute handler to null', () => {
+                expect.hasAssertions();
+
+                const request = createRequest();
+
+                expect(request.onshippingaddresschange).toBeNull();
+                expect(request.onshippingoptionchange).toBeNull();
+                expect(request.onpaymentmethodchange).toBeNull();
+                expect(request.oncouponcodechange).toBeNull();
+            });
+
+            it('should register the assigned handler like an addEventListener listener', () => {
+                expect.hasAssertions();
+
+                const request = createInteractiveRequest();
+                const handler = jest.fn<(event: PaymentRequestUpdateEvent) => void>();
+
+                request.onshippingaddresschange = handler;
+
+                expect(subscriptions).toHaveLength(1);
+                expect(setActiveEventsMock).toHaveBeenCalledWith(request.id, ['shippingaddresschange']);
+                expect(request.onshippingaddresschange).toBe(handler);
+            });
+
+            it('should replace the previous attribute handler when assigned again', async () => {
+                expect.hasAssertions();
+
+                const request = createInteractiveRequest();
+                const firstHandler = jest.fn<(event: PaymentRequestUpdateEvent) => void>();
+                const secondHandler = jest.fn<(event: PaymentRequestUpdateEvent) => void>();
+
+                request.onshippingoptionchange = firstHandler;
+                request.onshippingoptionchange = secondHandler;
+
+                emitNativeEvent('shippingoptionchange', { requestId: request.id, shippingOption: 'express' });
+                await nativeUpdate;
+
+                expect(firstHandler).not.toHaveBeenCalled();
+                expect(secondHandler).toHaveBeenCalledTimes(1);
+                expect(request.onshippingoptionchange).toBe(secondHandler);
+                expect(subscriptions.filter(subscription => !subscription.removed)).toHaveLength(1);
+            });
+
+            it('should clear the attribute handler and drop the native subscription when assigned null', () => {
+                expect.hasAssertions();
+
+                const request = createInteractiveRequest();
+                const handler = jest.fn<(event: PaymentRequestUpdateEvent) => void>();
+
+                request.oncouponcodechange = handler;
+                request.oncouponcodechange = null;
+
+                expect(request.oncouponcodechange).toBeNull();
+                expect(setActiveEventsMock).toHaveBeenLastCalledWith(request.id, []);
+            });
+
+            it('should do nothing when assigned null without a previously registered handler', () => {
+                expect.hasAssertions();
+
+                const request = createInteractiveRequest();
+
+                request.onshippingaddresschange = null;
+
+                expect(request.onshippingaddresschange).toBeNull();
+                expect(subscriptions).toHaveLength(0);
+            });
+
+            it('should coexist with listeners registered through addEventListener', async () => {
+                expect.hasAssertions();
+
+                const request = createInteractiveRequest();
+                const attributeHandler = jest.fn<(event: PaymentRequestUpdateEvent) => void>();
+                const addedListener = jest.fn<(event: PaymentRequestUpdateEvent) => void>();
+
+                request.addEventListener('shippingaddresschange', addedListener);
+                request.onshippingaddresschange = attributeHandler;
+
+                emitNativeEvent('shippingaddresschange', { requestId: request.id, shippingAddress: address });
+                await nativeUpdate;
+
+                expect(addedListener).toHaveBeenCalledTimes(1);
+                expect(attributeHandler).toHaveBeenCalledTimes(1);
+            });
+
+            it('should register onpaymentmethodchange as a paymentmethodchange listener', () => {
+                expect.hasAssertions();
+
+                const request = createInteractiveRequest();
+                const handler = jest.fn<(event: PaymentMethodChangeEvent) => void>();
+
+                request.onpaymentmethodchange = handler;
+
+                expect(subscriptions).toHaveLength(1);
+                expect(subscriptions[0]?.type).toBe('paymentmethodchange');
+                expect(request.onpaymentmethodchange).toBe(handler);
+            });
         });
     });
 });

--- a/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.spec.ts
@@ -597,7 +597,7 @@ describe('PaymentRequest', () => {
         });
 
         it('should throw when `hasEnrolledInstrument` is called in invalid state', async () => {
-            expect.assertions(1);
+            expect.hasAssertions();
 
             const request = new PaymentRequest([androidMethodData], paymentDetails);
             request.state = 'closed';
@@ -608,7 +608,7 @@ describe('PaymentRequest', () => {
         });
 
         it('should return true from `hasEnrolledInstrument` when valid', async () => {
-            expect.assertions(2);
+            expect.hasAssertions();
 
             const request = new PaymentRequest([androidMethodData], paymentDetails);
             jest.mocked(NativePayments.hasEnrolledInstrument).mockResolvedValue(true);
@@ -1048,7 +1048,7 @@ describe('PaymentRequest', () => {
         });
 
         it('should throw when `hasEnrolledInstrument` is called in invalid state', async () => {
-            expect.assertions(1);
+            expect.hasAssertions();
 
             const request = new PaymentRequest([iosMethodData], paymentDetails);
             request.state = 'closed';
@@ -1059,7 +1059,7 @@ describe('PaymentRequest', () => {
         });
 
         it('should return true from `hasEnrolledInstrument` when valid', async () => {
-            expect.assertions(2);
+            expect.hasAssertions();
 
             const request = new PaymentRequest([iosMethodData], paymentDetails);
             jest.mocked(NativePayments.hasEnrolledInstrument).mockResolvedValue(true);
@@ -2871,6 +2871,40 @@ describe('PaymentRequest', () => {
                 expect(subscriptions).toHaveLength(1);
                 expect(subscriptions[0]?.type).toBe('paymentmethodchange');
                 expect(request.onpaymentmethodchange).toBe(handler);
+            });
+
+            it('should keep an explicit addEventListener registration alive when the same function is cleared as the attribute handler', async () => {
+                expect.hasAssertions();
+
+                const request = createInteractiveRequest();
+                const sharedListener = jest.fn<(event: PaymentRequestUpdateEvent) => void>();
+
+                request.addEventListener('shippingaddresschange', sharedListener);
+                request.onshippingaddresschange = sharedListener;
+                request.onshippingaddresschange = null;
+
+                emitNativeEvent('shippingaddresschange', { requestId: request.id, shippingAddress: address });
+                await nativeUpdate;
+
+                expect(sharedListener).toHaveBeenCalledTimes(1);
+            });
+
+            it('should keep an explicit addEventListener registration alive when the same function is replaced as the attribute handler', async () => {
+                expect.hasAssertions();
+
+                const request = createInteractiveRequest();
+                const sharedListener = jest.fn<(event: PaymentRequestUpdateEvent) => void>();
+                const replacementHandler = jest.fn<(event: PaymentRequestUpdateEvent) => void>();
+
+                request.addEventListener('shippingaddresschange', sharedListener);
+                request.onshippingaddresschange = sharedListener;
+                request.onshippingaddresschange = replacementHandler;
+
+                emitNativeEvent('shippingaddresschange', { requestId: request.id, shippingAddress: address });
+                await nativeUpdate;
+
+                expect(sharedListener).toHaveBeenCalledTimes(1);
+                expect(replacementHandler).toHaveBeenCalledTimes(1);
             });
         });
     });

--- a/packages/react-native-payments/src/class/payment-request/payment-request.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.ts
@@ -51,6 +51,7 @@ import type { ResolvedPaymentDetailsInterface } from '../../interface/resolved-p
 import type { PaymentMethodChangeEventListener } from '../../type/payment-method-change-event-listener.type';
 import type { PaymentRequestEventListener } from '../../type/payment-request-event-listener.type';
 import type { PaymentRequestEventType } from '../../type/payment-request-event.type';
+import type { PaymentRequestUpdateEvent } from '../payment-request-update-event/payment-request-update-event';
 import type { Maybe } from '@rnw-community/shared';
 import type { EmitterSubscription } from 'react-native';
 
@@ -76,6 +77,7 @@ export class PaymentRequest {
         PaymentRequestEventType,
         PaymentMethodChangeEventListener | PaymentRequestEventListener
     >();
+    private readonly attributeHandlerWrappers = new Map<PaymentRequestEventType, PaymentRequestEventListener>();
     private eventGeneration = 0;
     private isNativeEventsSynced = false;
 
@@ -303,19 +305,44 @@ export class PaymentRequest {
         type: PaymentRequestEventType,
         listener: Maybe<PaymentMethodChangeEventListener | PaymentRequestEventListener>
     ): void {
-        const previousListener = this.attributeHandlers.get(type);
-
-        if (isDefined(previousListener)) {
-            this.attributeHandlers.delete(type);
-            this.removeEventListener(type, previousListener as PaymentRequestEventListener);
-        }
-
         if (!isDefined(listener)) {
+            this.attributeHandlers.delete(type);
+            this.removeAttributeHandlerWrapper(type);
+
             return;
         }
 
         this.attributeHandlers.set(type, listener);
-        this.addEventListener(type, listener as PaymentRequestEventListener);
+        this.ensureAttributeHandlerWrapper(type);
+    }
+
+    private ensureAttributeHandlerWrapper(type: PaymentRequestEventType): void {
+        if (this.attributeHandlerWrappers.has(type)) {
+            return;
+        }
+
+        const wrapper: PaymentRequestEventListener = event => this.dispatchToAttributeHandler(type, event);
+
+        this.attributeHandlerWrappers.set(type, wrapper);
+        this.addEventListener(type, wrapper);
+    }
+
+    private removeAttributeHandlerWrapper(type: PaymentRequestEventType): void {
+        const wrapper = this.attributeHandlerWrappers.get(type);
+
+        if (!isDefined(wrapper)) {
+            return;
+        }
+
+        this.attributeHandlerWrappers.delete(type);
+        this.removeEventListener(type, wrapper);
+    }
+
+    private dispatchToAttributeHandler(
+        type: PaymentRequestEventType,
+        event: PaymentRequestUpdateEvent
+    ): Promise<void> | void {
+        return (this.attributeHandlers.get(type) as PaymentRequestEventListener)(event);
     }
 
     private handleAccept(details: string): AndroidPaymentResponse | IosPaymentResponse {

--- a/packages/react-native-payments/src/class/payment-request/payment-request.ts
+++ b/packages/react-native-payments/src/class/payment-request/payment-request.ts
@@ -26,6 +26,7 @@ import { validateDisplayItems } from '../../util/validate-display-items.util';
 import { validateModifiers } from '../../util/validate-modifiers.util';
 import { validatePaymentMethods } from '../../util/validate-payment-methods.util';
 import { validateShippingOptions } from '../../util/validate-shipping-options.util';
+import { validateShippingType } from '../../util/validate-shipping-type.util';
 import { validateTotal } from '../../util/validate-total.util';
 import { warnChangeEventError } from '../../util/warn-change-event-error.util';
 import { ChangeEventDispatcher } from '../change-event-dispatcher/change-event-dispatcher';
@@ -71,6 +72,10 @@ export class PaymentRequest {
     private readonly platformMethodData: AndroidPaymentMethodDataDataInterface | IosPaymentMethodDataDataInterface;
     private readonly eventRegistrations = new Map<PaymentRequestEventType, PaymentRequestEventRegistrationInterface>();
     private readonly pendingDispatchers = new Set<ChangeEventDispatcher>();
+    private readonly attributeHandlers = new Map<
+        PaymentRequestEventType,
+        PaymentMethodChangeEventListener | PaymentRequestEventListener
+    >();
     private eventGeneration = 0;
     private isNativeEventsSynced = false;
 
@@ -88,18 +93,7 @@ export class PaymentRequest {
         }
         this.id = details.id;
 
-        // 4. Process payment methods
-        validatePaymentMethods(methodData);
-        validateAndroidTransactionInfo(methodData, ConstructorError);
-
-        // 5. Process the total
-        validateTotal(details.total, ConstructorError);
-
-        // 6. If the displayItems member of details is present, then for each item in details.displayItems:
-        validateDisplayItems(ConstructorError, details.displayItems);
-
-        validateShippingOptions(ConstructorError, details.shippingOptions);
-        validateModifiers(ConstructorError, details.modifiers);
+        this.validateConstructorInputs(methodData, details);
 
         // 17. Set request.[[serializedMethodData]] to serializedMethodData.         */
         this.platformMethodData = this.findPlatformPaymentMethodData();
@@ -115,6 +109,42 @@ export class PaymentRequest {
         this.serializedMethodData = JSON.stringify(nativePlatformMethodData);
     }
 
+    // https://www.w3.org/TR/payment-request/#dom-paymentrequest-onshippingaddresschange
+    get onshippingaddresschange(): Maybe<PaymentRequestEventListener> {
+        return this.getAttributeHandler('shippingaddresschange') as Maybe<PaymentRequestEventListener>;
+    }
+
+    // https://www.w3.org/TR/payment-request/#dom-paymentrequest-onshippingoptionchange
+    get onshippingoptionchange(): Maybe<PaymentRequestEventListener> {
+        return this.getAttributeHandler('shippingoptionchange') as Maybe<PaymentRequestEventListener>;
+    }
+
+    // https://www.w3.org/TR/payment-request/#dom-paymentrequest-onpaymentmethodchange
+    get onpaymentmethodchange(): Maybe<PaymentMethodChangeEventListener> {
+        return this.getAttributeHandler('paymentmethodchange');
+    }
+
+    // couponcodechange is a PassKit extension: https://developer.apple.com/documentation/passkit/pkpaymentrequest/3801275-couponcode?language=objc
+    get oncouponcodechange(): Maybe<PaymentRequestEventListener> {
+        return this.getAttributeHandler('couponcodechange') as Maybe<PaymentRequestEventListener>;
+    }
+
+    set onshippingaddresschange(listener: Maybe<PaymentRequestEventListener>) {
+        this.setAttributeHandler('shippingaddresschange', listener);
+    }
+
+    set onshippingoptionchange(listener: Maybe<PaymentRequestEventListener>) {
+        this.setAttributeHandler('shippingoptionchange', listener);
+    }
+
+    set onpaymentmethodchange(listener: Maybe<PaymentMethodChangeEventListener>) {
+        this.setAttributeHandler('paymentmethodchange', listener);
+    }
+
+    set oncouponcodechange(listener: Maybe<PaymentRequestEventListener>) {
+        this.setAttributeHandler('couponcodechange', listener);
+    }
+
     // https://www.w3.org/TR/payment-request/#canmakepayment-method
     async canMakePayment(): Promise<boolean> {
         if (this.state !== 'created') {
@@ -122,6 +152,15 @@ export class PaymentRequest {
         }
 
         return NativePayments.canMakePayments(this.serializedMethodData);
+    }
+
+    // https://www.w3.org/TR/payment-request/#hasenrolledinstrument-method
+    async hasEnrolledInstrument(): Promise<boolean> {
+        if (this.state !== 'created') {
+            throw new DOMException(PaymentsErrorEnum.InvalidStateError);
+        }
+
+        return NativePayments.hasEnrolledInstrument(this.serializedMethodData);
     }
 
     // https://www.w3.org/TR/payment-request/#show-method
@@ -236,6 +275,47 @@ export class PaymentRequest {
     private closeRequest(): void {
         this.state = 'closed';
         this.clearEventRegistrations();
+    }
+
+    private validateConstructorInputs(methodData: PaymentMethodData[], details: PaymentDetailsInit): void {
+        // 4. Process payment methods
+        validatePaymentMethods(methodData);
+        validateAndroidTransactionInfo(methodData, ConstructorError);
+        validateShippingType(methodData, ConstructorError);
+
+        // 5. Process the total
+        validateTotal(details.total, ConstructorError);
+
+        // 6. If the displayItems member of details is present, then for each item in details.displayItems:
+        validateDisplayItems(ConstructorError, details.displayItems);
+
+        validateShippingOptions(ConstructorError, details.shippingOptions);
+        validateModifiers(ConstructorError, details.modifiers);
+    }
+
+    private getAttributeHandler(
+        type: PaymentRequestEventType
+    ): Maybe<PaymentMethodChangeEventListener | PaymentRequestEventListener> {
+        return this.attributeHandlers.get(type) ?? null;
+    }
+
+    private setAttributeHandler(
+        type: PaymentRequestEventType,
+        listener: Maybe<PaymentMethodChangeEventListener | PaymentRequestEventListener>
+    ): void {
+        const previousListener = this.attributeHandlers.get(type);
+
+        if (isDefined(previousListener)) {
+            this.attributeHandlers.delete(type);
+            this.removeEventListener(type, previousListener as PaymentRequestEventListener);
+        }
+
+        if (!isDefined(listener)) {
+            return;
+        }
+
+        this.attributeHandlers.set(type, listener);
+        this.addEventListener(type, listener as PaymentRequestEventListener);
     }
 
     private handleAccept(details: string): AndroidPaymentResponse | IosPaymentResponse {
@@ -576,6 +656,7 @@ export class PaymentRequest {
             ...(isShippingRequested && { requiredShippingContactFields: requestedShippingFields }),
             ...(isDefined(methodData.applicationData) && { applicationData: methodData.applicationData }),
             ...(isNotEmptyString(methodData.couponCode) && { couponCode: methodData.couponCode }),
+            ...(isDefined(methodData.shippingType) && { shippingType: methodData.shippingType }),
         };
     }
 

--- a/packages/react-native-payments/src/enum/payment-shipping-type.enum.ts
+++ b/packages/react-native-payments/src/enum/payment-shipping-type.enum.ts
@@ -1,0 +1,6 @@
+// https://www.w3.org/TR/payment-request/#dom-paymentoptions-shippingtype
+export enum PaymentShippingTypeEnum {
+    Delivery = 'delivery',
+    Pickup = 'pickup',
+    Shipping = 'shipping',
+}

--- a/packages/react-native-payments/src/index.ts
+++ b/packages/react-native-payments/src/index.ts
@@ -6,6 +6,7 @@ export { SupportedNetworkEnum } from './enum/supported-networks.enum';
 export { PaymentAddressFieldEnum } from './enum/payment-address-field.enum';
 export { PaymentContactFieldEnum } from './enum/payment-contact-field.enum';
 export { PaymentUpdateErrorTypeEnum } from './enum/payment-update-error-type.enum';
+export { PaymentShippingTypeEnum } from './enum/payment-shipping-type.enum';
 export { ConstructorError } from './error/constructor.error';
 export { DOMException } from './error/dom.exception';
 export { PaymentsError } from './error/payments.error';

--- a/packages/react-native-payments/src/interface/generic-payment-method-data-data.interface.ts
+++ b/packages/react-native-payments/src/interface/generic-payment-method-data-data.interface.ts
@@ -1,3 +1,4 @@
+import type { PaymentShippingTypeEnum } from '../enum/payment-shipping-type.enum';
 import type { SupportedNetworkEnum } from '../enum/supported-networks.enum';
 
 /**
@@ -16,5 +17,7 @@ export interface GenericPaymentMethodDataDataInterface {
     requestPayerPhone?: boolean;
     // If present PaymentResponse will have shippingAddress
     requestShipping?: boolean;
+    // https://www.w3.org/TR/payment-request/#dom-paymentoptions-shippingtype; forwarded to PKShippingType on iOS, no-op on Android
+    shippingType?: PaymentShippingTypeEnum;
     supportedNetworks: SupportedNetworkEnum[];
 }

--- a/packages/react-native-payments/src/util/validate-shipping-type.util.ts
+++ b/packages/react-native-payments/src/util/validate-shipping-type.util.ts
@@ -1,0 +1,19 @@
+import { isDefined } from '@rnw-community/shared';
+
+import { PaymentShippingTypeEnum } from '../enum/payment-shipping-type.enum';
+
+import type { PaymentMethodData } from '../@standard/w3c/payment-method-data';
+import type { ClassType } from '@rnw-community/shared';
+
+const validShippingTypes: readonly string[] = Object.values(PaymentShippingTypeEnum);
+
+// https://www.w3.org/TR/payment-request/#dom-paymentoptions-shippingtype
+export const validateShippingType = (methodData: PaymentMethodData[], ErrorType: ClassType<Error>): void => {
+    methodData.forEach(paymentMethodData => {
+        const { shippingType } = paymentMethodData.data;
+
+        if (isDefined(shippingType) && !validShippingTypes.includes(shippingType)) {
+            throw new ErrorType(`'${shippingType}' is not a valid shippingType`);
+        }
+    });
+};


### PR DESCRIPTION
## Summary
- Implement `hasEnrolledInstrument()` per the W3C spec's [hasEnrolledInstrument-method](https://www.w3.org/TR/payment-request/#hasenrolledinstrument-method): `InvalidStateError` when not `created`, iOS maps to PassKit's `canMakePaymentsUsingNetworks:` scoped to the request's `supportedNetworks`, Android answers via Google Pay's `isReadyToPay` with `existingPaymentMethodRequired: true` (documented as an optimistic signal, not a guarantee).
- Add the `onshippingaddresschange` / `onshippingoptionchange` / `onpaymentmethodchange` / `oncouponcodechange` event-handler attributes as thin properties over `addEventListener`/`removeEventListener`, with `EventTarget`-style replace semantics: assignment replaces the previous attribute handler, `null` clears it, and it coexists with listeners registered through `addEventListener`.
- Add `PaymentOptions.shippingType` (`PaymentShippingTypeEnum.Shipping` / `Delivery` / `Pickup`) to `methodData.data`, validated at construction and forwarded to `PKShippingType` on iOS (`Pickup` → `PKShippingTypeStorePickup`); no-op on Android (no equivalent concept).
- Update the readme's W3C compliance checklist and Known deviations to reflect the above truthfully, plus a new `PaymentShippingTypeEnum` type reference entry and an `Event-handler attributes` usage section.
- Turn off the core `grouped-accessor-pairs` ESLint rule: it structurally conflicts with `@typescript-eslint/member-ordering`'s get-before-set grouping once a class exposes more than one accessor pair (this PR is the first to add multiple getter/setter pairs to a single class in this codebase).

## Test plan
- [x] `yarn build && yarn ts && yarn lint && yarn test && yarn deadcode` all pass at the repo root
- [x] `yarn test:coverage` in `packages/react-native-payments` stays at 100% statements/branches/functions/lines
- [x] New/changed behavior covered by `payment-request.spec.ts`: `hasEnrolledInstrument` (invalid state + delegation) on both Android and iOS describe blocks, `shippingType` constructor validation + iOS serialization forwarding, and a dedicated `attribute-handler event listeners` describe block (default `null`, register/replace/clear, coexistence with `addEventListener`, `onpaymentmethodchange` typing)

Closes #455

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `hasEnrolledInstrument`, event-handler attributes, and `shippingType` to `PaymentRequest`
> - Adds `PaymentRequest.hasEnrolledInstrument()` on iOS (via `PKPaymentAuthorizationViewController canMakePaymentsUsingNetworks:`) and Android (via Google Pay `isReadyToPay` with `existingPaymentMethodRequired=true`), mirroring the W3C Payment Request API.
> - Adds IDL-compliant event-handler attribute getters/setters (`onshippingaddresschange`, `onshippingoptionchange`, `onpaymentmethodchange`, `oncouponcodechange`) that integrate with `addEventListener`/`removeEventListener`.
> - Adds `shippingType` support via a new `PaymentShippingTypeEnum` (`delivery`, `pickup`, `shipping`), validated at construction time and forwarded to `PKPaymentRequest.shippingType` on iOS (no-op on Android).
> - Behavioral Change: `canMakePayments` rejection on Android now calls `promise.reject()` directly instead of the module-level `rejectPromise()`, avoiding side effects on the stored `mPromise`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9beac8e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hasEnrolledInstrument()` to check whether a user has an available payment method.
  * Added shipping type support with delivery, pickup, and shipping options.
  * Added shipping-related event handler properties to payment requests.
  * Added validation for unsupported shipping types.
* **Documentation**
  * Documented shipping types, enrollment checks, event handlers, platform behavior, and known deviations.
* **Tests**
  * Added coverage for shipping types, enrollment checks, event handlers, and payment method changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->