### PR TITLE
fix(react-native-payments): harden expo config plugins

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -55,6 +55,7 @@
         "webpack-node-externals",
         "react-dom",
         "@expo/config-plugins",
+        "expo",
         "ioredis",
         "prom-client",
         "redlock",

--- a/packages/react-native-payments/jest.config.js
+++ b/packages/react-native-payments/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
     ...require('../../get-jest.config.js')('react-native-payments'),
+    collectCoverageFrom: ['src/**/*.ts', '!src/**/*.spec.ts', '!src/**/*.web.ts'],
     coverageThreshold: {
         global: {
             branches: 100,

--- a/packages/react-native-payments/package.json
+++ b/packages/react-native-payments/package.json
@@ -91,9 +91,14 @@
         "react-native": "^0.86.2"
     },
     "peerDependencies": {
-        "expo": ">=48.0.0",
+        "expo": "*",
         "react": ">=17",
         "react-native": ">=0.64"
+    },
+    "peerDependenciesMeta": {
+        "expo": {
+            "optional": true
+        }
     },
     "codegenConfig": {
         "name": "RNPaymentsSpec",

--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -166,7 +166,7 @@ dependencies {
 
 ### Expo setup
 
-To integrate with Expo [custom builds](https://docs.expo.dev/custom-builds/get-started/), you need to add the `@rnw-community/react-native-payments` plugin into your `app.config.js`:
+This package links native code (PassKit on iOS, the Google Pay API on Android), so it cannot run inside **Expo Go**. It requires an Expo [custom build](https://docs.expo.dev/custom-builds/get-started/) (a.k.a. development build / `expo-dev-client`) — add the `@rnw-community/react-native-payments` plugin into your `app.config.js`:
 
 1. Update your `app.config.js` configuration:
 
@@ -193,11 +193,23 @@ export default {
 }
 ```
 
+#### Plugin options reference
+
+| Option | Type | Default | What it mutates |
+| --- | --- | --- | --- |
+| `merchantIdentifier` | `string \| string[]` | *(required)* | iOS `Info.plist` entitlements: appends every non-empty identifier to `com.apple.developer.in-app-payments`, de-duplicated. Throws at prebuild time if no non-empty identifier is provided. |
+| `supportedNetworks` | `SupportedNetworkEnum[]` | every `SupportedNetworkEnum` value | Android `AndroidManifest.xml`: writes the comma-joined list as the `com.rnw-community.react-native-payments.supported-networks` meta-data value on the main application. Throws if given an empty array or a value outside `SupportedNetworkEnum`. |
+| `googlePayEnvironment` | `EnvironmentEnum` | `EnvironmentEnum.PRODUCTION` | Android `AndroidManifest.xml`: writes the `com.google.android.gms.wallet.api.environment` meta-data value on the main application. Throws if given a value outside `EnvironmentEnum`. |
+
+`withGooglePay` also always writes `com.google.android.gms.wallet.api.enabled=true` (no option needed) so the Google Pay API is enabled for the app. `SupportedNetworkEnum` and `EnvironmentEnum` are both exported from the package root.
+
 2. Prebuild your project:
 
 ```bash
 npx expo prebuild --clean
 ```
+
+Building the package before prebuild is required for local/monorepo consumers: `expo prebuild` resolves `@rnw-community/react-native-payments/app.plugin` through the package's `exports` map, which only points at `dist` — run `yarn build` (or your workspace's build step) for this package before `expo prebuild` if you are linking it locally rather than installing it from npm.
 
 ## Usage
 

--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -197,7 +197,7 @@ export default {
 
 | Option | Type | Default | What it mutates |
 | --- | --- | --- | --- |
-| `merchantIdentifier` | `string \| string[]` | *(required)* | iOS `Info.plist` entitlements: appends every non-empty identifier to `com.apple.developer.in-app-payments`, de-duplicated. Throws at prebuild time if no non-empty identifier is provided. |
+| `merchantIdentifier` | `string \| string[]` | *(required)* | iOS entitlements plist: appends every non-empty identifier to `com.apple.developer.in-app-payments`, de-duplicated. Throws at prebuild time if no non-empty identifier is provided. |
 | `supportedNetworks` | `SupportedNetworkEnum[]` | every `SupportedNetworkEnum` value | Android `AndroidManifest.xml`: writes the comma-joined list as the `com.rnw-community.react-native-payments.supported-networks` meta-data value on the main application. Throws if given an empty array or a value outside `SupportedNetworkEnum`. |
 | `googlePayEnvironment` | `EnvironmentEnum` | `EnvironmentEnum.PRODUCTION` | Android `AndroidManifest.xml`: writes the `com.google.android.gms.wallet.api.environment` meta-data value on the main application. Throws if given a value outside `EnvironmentEnum`. |
 

--- a/packages/react-native-payments/src/expo-plugins/plugin-default-options.constant.ts
+++ b/packages/react-native-payments/src/expo-plugins/plugin-default-options.constant.ts
@@ -1,0 +1,7 @@
+import { EnvironmentEnum } from '../enum/environment.enum';
+import { SupportedNetworkEnum } from '../enum/supported-networks.enum';
+
+export const PLUGIN_DEFAULT_OPTIONS = {
+    supportedNetworks: Object.values(SupportedNetworkEnum),
+    googlePayEnvironment: EnvironmentEnum.PRODUCTION,
+} as const;

--- a/packages/react-native-payments/src/expo-plugins/plugin.props.ts
+++ b/packages/react-native-payments/src/expo-plugins/plugin.props.ts
@@ -1,3 +1,8 @@
+import type { EnvironmentEnum } from '../enum/environment.enum';
+import type { SupportedNetworkEnum } from '../enum/supported-networks.enum';
+
 export interface ReactNativePaymentsPluginProps {
     merchantIdentifier: string | string[];
+    supportedNetworks?: SupportedNetworkEnum[];
+    googlePayEnvironment?: EnvironmentEnum;
 }

--- a/packages/react-native-payments/src/expo-plugins/validate-google-pay-environment.util.spec.ts
+++ b/packages/react-native-payments/src/expo-plugins/validate-google-pay-environment.util.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { EnvironmentEnum } from '../enum/environment.enum';
+
+import { validateGooglePayEnvironment } from './validate-google-pay-environment.util';
+
+describe('validateGooglePayEnvironment', () => {
+    it('should default to PRODUCTION when undefined', () => {
+        expect.assertions(1);
+
+         
+        expect(validateGooglePayEnvironment(undefined)).toBe(EnvironmentEnum.PRODUCTION);
+    });
+
+    it('should return the provided environment when valid', () => {
+        expect.assertions(1);
+
+        expect(validateGooglePayEnvironment(EnvironmentEnum.TEST)).toBe(EnvironmentEnum.TEST);
+    });
+
+    it('should throw naming the valid environments when given an invalid value', () => {
+        expect.assertions(1);
+
+        expect(() => validateGooglePayEnvironment('STAGING' as never)).toThrow(
+            'Invalid "googlePayEnvironment" plugin option value: "STAGING". Valid values: "PRODUCTION", "TEST"'
+        );
+    });
+});

--- a/packages/react-native-payments/src/expo-plugins/validate-google-pay-environment.util.ts
+++ b/packages/react-native-payments/src/expo-plugins/validate-google-pay-environment.util.ts
@@ -1,0 +1,23 @@
+import { isDefined } from '@rnw-community/shared';
+
+import { EnvironmentEnum } from '../enum/environment.enum';
+
+import { PLUGIN_DEFAULT_OPTIONS } from './plugin-default-options.constant';
+
+const validEnvironments: readonly string[] = Object.values(EnvironmentEnum);
+
+export const validateGooglePayEnvironment = (googlePayEnvironment: EnvironmentEnum | undefined): EnvironmentEnum => {
+    if (!isDefined(googlePayEnvironment)) {
+        return PLUGIN_DEFAULT_OPTIONS.googlePayEnvironment;
+    }
+
+    if (!validEnvironments.includes(googlePayEnvironment)) {
+        const validEnvironmentList = validEnvironments.map(environment => `"${environment}"`).join(', ');
+
+        throw new Error(
+            `Invalid "googlePayEnvironment" plugin option value: "${googlePayEnvironment}". Valid values: ${validEnvironmentList}`
+        );
+    }
+
+    return googlePayEnvironment;
+};

--- a/packages/react-native-payments/src/expo-plugins/validate-supported-networks.util.spec.ts
+++ b/packages/react-native-payments/src/expo-plugins/validate-supported-networks.util.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { SupportedNetworkEnum } from '../enum/supported-networks.enum';
+
+import { validateSupportedNetworks } from './validate-supported-networks.util';
+
+describe('validateSupportedNetworks', () => {
+    it('should default to every supported network when undefined', () => {
+        expect.assertions(1);
+
+         
+        expect(validateSupportedNetworks(undefined)).toStrictEqual(Object.values(SupportedNetworkEnum));
+    });
+
+    it('should return the provided networks unchanged when all are valid', () => {
+        expect.assertions(1);
+
+        expect(validateSupportedNetworks([SupportedNetworkEnum.Visa, SupportedNetworkEnum.Mastercard])).toStrictEqual([
+            SupportedNetworkEnum.Visa,
+            SupportedNetworkEnum.Mastercard,
+        ]);
+    });
+
+    it('should throw when given an empty array', () => {
+        expect.assertions(1);
+
+        expect(() => validateSupportedNetworks([])).toThrow(
+            'Please provide at least one "supportedNetworks" plugin option value'
+        );
+    });
+
+    it('should throw naming every invalid network', () => {
+        expect.assertions(1);
+
+        expect(() => validateSupportedNetworks(['visa', 'unknown-network', 'another-unknown'] as never)).toThrow(
+            'Invalid "supportedNetworks" plugin option value(s): "unknown-network", "another-unknown"'
+        );
+    });
+});

--- a/packages/react-native-payments/src/expo-plugins/validate-supported-networks.util.ts
+++ b/packages/react-native-payments/src/expo-plugins/validate-supported-networks.util.ts
@@ -1,0 +1,29 @@
+import { isDefined, isEmptyArray, isNotEmptyArray } from '@rnw-community/shared';
+
+import { SupportedNetworkEnum } from '../enum/supported-networks.enum';
+
+import { PLUGIN_DEFAULT_OPTIONS } from './plugin-default-options.constant';
+
+const validSupportedNetworks: readonly string[] = Object.values(SupportedNetworkEnum);
+
+export const validateSupportedNetworks = (
+    supportedNetworks: SupportedNetworkEnum[] | undefined
+): SupportedNetworkEnum[] => {
+    if (!isDefined(supportedNetworks)) {
+        return PLUGIN_DEFAULT_OPTIONS.supportedNetworks;
+    }
+
+    if (isEmptyArray(supportedNetworks)) {
+        throw new Error('Please provide at least one "supportedNetworks" plugin option value');
+    }
+
+    const invalidNetworks = supportedNetworks.filter(network => !validSupportedNetworks.includes(network));
+
+    if (isNotEmptyArray(invalidNetworks)) {
+        const invalidNetworkList = invalidNetworks.map(network => `"${network}"`).join(', ');
+
+        throw new Error(`Invalid "supportedNetworks" plugin option value(s): ${invalidNetworkList}`);
+    }
+
+    return supportedNetworks;
+};

--- a/packages/react-native-payments/src/expo-plugins/with-apple-pay.spec.ts
+++ b/packages/react-native-payments/src/expo-plugins/with-apple-pay.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, jest } from '@jest/globals';
 
+import { EnvironmentEnum } from '../enum/environment.enum';
+import { SupportedNetworkEnum } from '../enum/supported-networks.enum';
+
 import { withApplePay } from './with-apple-pay';
+
+import type { ReactNativePaymentsPluginProps } from './plugin.props';
 
 jest.mock('expo/config-plugins', () => ({
     withEntitlementsPlist: jest.fn((config: unknown, modifier: (config: unknown) => unknown) => modifier(config)),
@@ -69,6 +74,20 @@ describe('withApplePay', () => {
         expect(() => withApplePay(createConfig() as never, {} as never)).toThrow(
             'Please provide "@rnw-community/react-native-payments" plugin option "merchantIdentifier"'
         );
+    });
+
+    it('should ignore Google Pay-only options and keep entitling the given merchant identifier', () => {
+        expect.assertions(1);
+
+        const props: ReactNativePaymentsPluginProps = {
+            merchantIdentifier: 'merchant.com.example',
+            supportedNetworks: [SupportedNetworkEnum.Visa],
+            googlePayEnvironment: EnvironmentEnum.TEST,
+        };
+
+        const result = withApplePay(createConfig(), props) as unknown as { modResults: Record<string, string[]> };
+
+        expect(result.modResults[ENTITLEMENT_KEY]).toStrictEqual(['merchant.com.example']);
     });
 
     it('should throw when every provided identifier is empty', () => {

--- a/packages/react-native-payments/src/expo-plugins/with-google-pay.spec.ts
+++ b/packages/react-native-payments/src/expo-plugins/with-google-pay.spec.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { EnvironmentEnum } from '../enum/environment.enum';
+import { SupportedNetworkEnum } from '../enum/supported-networks.enum';
+
+import { withGooglePay } from './with-google-pay';
+
+jest.mock('@expo/config-plugins', () => ({
+    ...jest.requireActual<typeof import('@expo/config-plugins')>('@expo/config-plugins'),
+    withAndroidManifest: jest.fn((config: unknown, modifier: (config: unknown) => unknown) => modifier(config)),
+}));
+
+const ENABLED_META_DATA_NAME = 'com.google.android.gms.wallet.api.enabled';
+const ENVIRONMENT_META_DATA_NAME = 'com.google.android.gms.wallet.api.environment';
+const SUPPORTED_NETWORKS_META_DATA_NAME = 'com.rnw-community.react-native-payments.supported-networks';
+
+type MetaDataItem = { $: { 'android:name': string; 'android:value': string } };
+
+const createConfig = (metaData: MetaDataItem[] = []) => ({
+    name: 'test',
+    slug: 'test',
+    modResults: {
+        manifest: {
+            application: [
+                {
+                    // eslint-disable-next-line id-length
+                    $: { 'android:name': '.MainApplication' },
+                    'meta-data': metaData,
+                },
+            ],
+        },
+    },
+});
+
+const runPlugin = (
+    props: { merchantIdentifier: string; supportedNetworks?: SupportedNetworkEnum[]; googlePayEnvironment?: EnvironmentEnum },
+    metaData?: MetaDataItem[]
+) => {
+    const result = withGooglePay(createConfig(metaData), props) as unknown as {
+        modResults: { manifest: { application: [{ 'meta-data': MetaDataItem[] }] } };
+    };
+
+    return result.modResults.manifest.application[0]['meta-data'];
+};
+
+const findMetaDataValue = (metaData: MetaDataItem[], name: string) =>
+    metaData.find(item => item.$['android:name'] === name)?.$['android:value'];
+
+describe('withGooglePay', () => {
+    it('should add the wallet enabled meta-data', () => {
+        expect.assertions(1);
+
+        const metaData = runPlugin({ merchantIdentifier: 'merchant.com.example' });
+
+        expect(findMetaDataValue(metaData, ENABLED_META_DATA_NAME)).toBe('true');
+    });
+
+    it('should default the environment meta-data to PRODUCTION', () => {
+        expect.assertions(1);
+
+        const metaData = runPlugin({ merchantIdentifier: 'merchant.com.example' });
+
+        expect(findMetaDataValue(metaData, ENVIRONMENT_META_DATA_NAME)).toBe(EnvironmentEnum.PRODUCTION);
+    });
+
+    it('should use the provided environment', () => {
+        expect.assertions(1);
+
+        const metaData = runPlugin({
+            merchantIdentifier: 'merchant.com.example',
+            googlePayEnvironment: EnvironmentEnum.TEST,
+        });
+
+        expect(findMetaDataValue(metaData, ENVIRONMENT_META_DATA_NAME)).toBe(EnvironmentEnum.TEST);
+    });
+
+    it('should default supportedNetworks meta-data to every supported network', () => {
+        expect.assertions(1);
+
+        const metaData = runPlugin({ merchantIdentifier: 'merchant.com.example' });
+
+        expect(findMetaDataValue(metaData, SUPPORTED_NETWORKS_META_DATA_NAME)).toBe(
+            Object.values(SupportedNetworkEnum).join(',')
+        );
+    });
+
+    it('should use the provided supportedNetworks', () => {
+        expect.assertions(1);
+
+        const metaData = runPlugin({
+            merchantIdentifier: 'merchant.com.example',
+            supportedNetworks: [SupportedNetworkEnum.Visa, SupportedNetworkEnum.Mastercard],
+        });
+
+        expect(findMetaDataValue(metaData, SUPPORTED_NETWORKS_META_DATA_NAME)).toBe('visa,masterCard');
+    });
+
+    it('should not duplicate the wallet enabled meta-data when it already exists', () => {
+        expect.assertions(1);
+
+        // eslint-disable-next-line id-length
+        const existing = [{ $: { 'android:name': ENABLED_META_DATA_NAME, 'android:value': 'true' } }];
+
+        const metaData = runPlugin({ merchantIdentifier: 'merchant.com.example' }, existing);
+
+        expect(metaData.filter(item => item.$['android:name'] === ENABLED_META_DATA_NAME)).toHaveLength(1);
+    });
+
+    it('should throw when supportedNetworks is invalid', () => {
+        expect.assertions(1);
+
+        expect(() =>
+            runPlugin({
+                merchantIdentifier: 'merchant.com.example',
+                supportedNetworks: ['not-a-network'] as never,
+            })
+        ).toThrow('Invalid "supportedNetworks" plugin option value(s): "not-a-network"');
+    });
+
+    it('should throw when googlePayEnvironment is invalid', () => {
+        expect.assertions(1);
+
+        expect(() =>
+            runPlugin({
+                merchantIdentifier: 'merchant.com.example',
+                googlePayEnvironment: 'STAGING' as never,
+            })
+        ).toThrow('Invalid "googlePayEnvironment" plugin option value: "STAGING"');
+    });
+
+    it('should throw when the AndroidManifest has no MainApplication', () => {
+        expect.assertions(1);
+
+        const config = {
+            name: 'test',
+            slug: 'test',
+            modResults: { manifest: { application: [] } },
+        };
+
+        expect(() => withGooglePay(config as never, { merchantIdentifier: 'merchant.com.example' })).toThrow(
+            'AndroidManifest.xml is missing the required MainApplication element'
+        );
+    });
+});

--- a/packages/react-native-payments/src/expo-plugins/with-google-pay.ts
+++ b/packages/react-native-payments/src/expo-plugins/with-google-pay.ts
@@ -1,29 +1,37 @@
-import { withAndroidManifest } from '@expo/config-plugins';
+import { AndroidConfig, withAndroidManifest } from '@expo/config-plugins';
+
+import { validateGooglePayEnvironment } from './validate-google-pay-environment.util';
+import { validateSupportedNetworks } from './validate-supported-networks.util';
 
 import type { ReactNativePaymentsPluginProps } from './plugin.props';
 import type { ConfigPlugin } from '@expo/config-plugins';
 
-export const withGooglePay: ConfigPlugin<ReactNativePaymentsPluginProps> = initialConfig =>
-    withAndroidManifest(initialConfig, config => {
-        const androidManifest = config.modResults;
-        const mainApplication = androidManifest.manifest.application?.[0];
+export const withGooglePay: ConfigPlugin<ReactNativePaymentsPluginProps> = (
+    initialConfig,
+    { supportedNetworks, googlePayEnvironment }
+) => {
+    const validatedSupportedNetworks = validateSupportedNetworks(supportedNetworks);
+    const validatedGooglePayEnvironment = validateGooglePayEnvironment(googlePayEnvironment);
 
-        if (mainApplication) {
-            const existingMetaData = mainApplication['meta-data']?.find(
-                metadata => metadata.$['android:name'] === 'com.google.android.gms.wallet.api.enabled'
-            );
+    return withAndroidManifest(initialConfig, config => {
+        const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
 
-            if (!existingMetaData) {
-                mainApplication['meta-data'] ??= [];
-                mainApplication['meta-data'].push({
-                    // eslint-disable-next-line id-length
-                    $: {
-                        'android:name': 'com.google.android.gms.wallet.api.enabled',
-                        'android:value': 'true',
-                    },
-                });
-            }
-        }
+        AndroidConfig.Manifest.addMetaDataItemToMainApplication(
+            mainApplication,
+            'com.google.android.gms.wallet.api.enabled',
+            'true'
+        );
+        AndroidConfig.Manifest.addMetaDataItemToMainApplication(
+            mainApplication,
+            'com.google.android.gms.wallet.api.environment',
+            validatedGooglePayEnvironment
+        );
+        AndroidConfig.Manifest.addMetaDataItemToMainApplication(
+            mainApplication,
+            'com.rnw-community.react-native-payments.supported-networks',
+            validatedSupportedNetworks.join(',')
+        );
 
         return config;
     });
+};

--- a/packages/react-native-payments/src/expo-plugins/with-payments.spec.ts
+++ b/packages/react-native-payments/src/expo-plugins/with-payments.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { withApplePay } from './with-apple-pay';
+import { withGooglePay } from './with-google-pay';
+import { withPayments } from './with-payments';
+
+jest.mock('./with-apple-pay', () => ({ withApplePay: jest.fn(config => config) }));
+jest.mock('./with-google-pay', () => ({ withGooglePay: jest.fn(config => config) }));
+
+const createConfig = () => ({ name: 'test', slug: 'test', _internal: { projectRoot: '/project' } });
+
+describe('withPayments', () => {
+    it('should apply withApplePay with the given props', () => {
+        expect.assertions(1);
+
+        const props = { merchantIdentifier: 'merchant.com.example' };
+
+        withPayments(createConfig(), props);
+
+        expect(withApplePay).toHaveBeenCalledWith(expect.objectContaining({ name: 'test' }), props);
+    });
+
+    it('should apply withGooglePay with the given props', () => {
+        expect.assertions(1);
+
+        const props = { merchantIdentifier: 'merchant.com.example' };
+
+        withPayments(createConfig(), props);
+
+        expect(withGooglePay).toHaveBeenCalledWith(expect.objectContaining({ name: 'test' }), props);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6016,9 +6016,12 @@ __metadata:
     react-native: "npm:^0.86.2"
     react-native-uuid: "npm:^2.0.4"
   peerDependencies:
-    expo: ">=48.0.0"
+    expo: "*"
     react: ">=17"
     react-native: ">=0.64"
+  peerDependenciesMeta:
+    expo:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Implements the A+C scope of #445 (harden `react-native-payments`' Expo config plugins), per the issue's own spike/audit comment.

- **Typed plugin options**: `ReactNativePaymentsPluginProps` gains `supportedNetworks` (defaults to every `SupportedNetworkEnum` value) and `googlePayEnvironment` (defaults to `EnvironmentEnum.PRODUCTION`), each validated with a clear thrown error and threaded into `withGooglePay`'s `AndroidManifest.xml` meta-data via `@expo/config-plugins`' `AndroidConfig.Manifest` helpers (replacing manual manifest indexing, which also removes a previously-untestable silent no-op branch in favor of a fail-fast throw when `AndroidManifest.xml` has no `MainApplication`).
- **Unit tests for every plugin mod**: `withGooglePay` and `withPayments` had none; added fixture-driven specs asserting on `AndroidManifest`/config mod results (fixtures inlined per repo convention), and strengthened `withApplePay`'s spec with a case covering Google Pay-only options being ignored.
- **Closed the coverage-gate blind spot**: the package's `jest.config.js` had no `collectCoverageFrom`, so Jest only counted files a spec happened to import — `withGooglePay`/`withPayments` were invisible to the 100% threshold despite it reporting green. Added `collectCoverageFrom` (all of `src`, excluding specs and `.web.ts` platform shims) so a future untested plugin file fails the gate instead of silently disappearing from the report. Coverage stays 100% statements/branches/functions/lines with `expo-plugins/**` now genuinely included.
- **readme**: Expo section gains a plugin options reference table (option, type, default, what it mutates), an explicit Expo Go incompatibility note, and the "build before prebuild" caveat for local/monorepo consumers (the `exports['./app.plugin']` map only resolves to `dist`).
- **package.json metadata**: the `expo` peer dependency is only reached from the `./app.plugin` subpath, never from the package's main entry, so it's now `"*"` + `peerDependenciesMeta.expo.optional = true` per Expo's own library-authoring guidance — this also resolves two pre-existing peer-dependency warnings for the workspace's bare example app, which has no `expo` installed.

## Deferred (explicitly out of scope here)

Per this task's own instructions, `.github/workflows` is untouched — the CI prebuild-smoke wiring (`expo prebuild` applying all three plugins cleanly on the example app, as a named gate rather than incidental Maestro setup) is deferred until #457 merges. That item remains open against #445.

Refs #445

## Test plan
- [x] `yarn build && yarn ts && yarn lint && yarn test && yarn deadcode` all green
- [x] `yarn test:coverage` for `@rnw-community/react-native-payments`: 100% statements/branches/functions/lines (423/423, 313/313, 117/117, 415/415), `src/expo-plugins/**` included
- [x] TDD: new specs written and observed failing (RED) against the prior/unimplemented behavior before implementing (GREEN)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden `withGooglePay` Expo config plugin with input validation and default options
> - Adds `validateSupportedNetworks` and `validateGooglePayEnvironment` utilities that default to all supported networks and `PRODUCTION` respectively, throwing descriptive errors on invalid input.
> - Updates `withGooglePay` to accept `supportedNetworks` and `googlePayEnvironment` props, validate them, and unconditionally write three meta-data entries to `AndroidManifest.xml` via `getMainApplicationOrThrow`.
> - Marks the `expo` peer dependency as optional in [package.json](https://github.com/rnw-community/rnw-community/pull/466/files#diff-9140d7c61cb23d744d243d1c4539521304e96a0bbd871e0045e20b82ea8d3813) and expands Expo setup docs in the readme.
> - Behavioral Change: `withGooglePay` now throws if `MainApplication` is missing or if provided network/environment values are invalid; previously invalid or missing meta-data may have been silently skipped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 444aac4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->