### PR TITLE
docs: sanction scoped tsdoc on exported public api declarations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,20 @@ Allowed pragma comments only (no other exceptions):
 - `// eslint-disable-next-line <rule>` — suppressing a specific lint rule with good reason
 - `/* istanbul ignore <next|else|if> -- <why> */` — **last resort** for truly unreachable branches; PREFER restructuring code to eliminate the dead branch entirely
 
-No JSDoc usage examples in source. No `@example`, no `@see`. Examples live in `readme.md` and per-entity `.md` files.
+**Scoped TSDoc on the public API — the one sanctioned documentation comment.** Every EXPORTED public API declaration
+(class, method, interface, type, function reachable from a package's `index.ts`) carries a TSDoc block of exactly this
+shape, and nothing else may:
+
+- one sentence: what it is and when to reach for it (mirrors the entity doc's "why" line)
+- `@see` links only: the entity's doc page and the governing spec (W3C / Apple / Google) where one exists
+
+Still forbidden everywhere, including on public API: `@example` (examples live in the docs), narrative/multi-paragraph
+blocks, `@param`/`@returns` prose that restates the types, TSDoc on non-exported or private members, and all other
+inline comments per the rules above. Rationale: consumers' IDEs and AI agents read the published `.d.ts` — the
+one-liner + `@see` gives them the entry point without duplicating the docs. Enforced by lint (required on exports,
+banned elsewhere) once the public surface is annotated.
+
+No JSDoc usage examples in source. Examples live in the docs tree and per-entity `.md` files.
 
 ### Decorator factories — `experimentalDecorators` only
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ Suffix patterns:
 - **`readme.md`** at the package root — documents what each public export does, with one minimal usage example per entity
 - **Per-entity `<entity>.md`** (optional) — a 5–20 line file next to the source with a focused example
 
-Allowed pragma comments only (no other exceptions):
+Allowed pragma comments only (the scoped public-API TSDoc below is the single other exception):
 
 - `// eslint-disable-next-line <rule>` — suppressing a specific lint rule with good reason
 - `/* istanbul ignore <next|else|if> -- <why> */` — **last resort** for truly unreachable branches; PREFER restructuring code to eliminate the dead branch entirely
@@ -111,7 +111,10 @@ Allowed pragma comments only (no other exceptions):
 shape, and nothing else may:
 
 - one sentence: what it is and when to reach for it (mirrors the entity doc's "why" line)
-- `@see` links only: the entity's doc page and the governing spec (W3C / Apple / Google) where one exists
+- `@see` links only: the entity's canonical doc target and the governing spec (W3C / Apple / Google) where one exists.
+  The canonical doc target is resolved in this order: the package's `docs/api/<entity>.md` (once a docs tree exists) →
+  the colocated `<entity>.md` → the package `readme.md` section anchor for that export. Every public export always has
+  at least the readme anchor, so the rule is always satisfiable.
 
 Still forbidden everywhere, including on public API: `@example` (examples live in the docs), narrative/multi-paragraph
 blocks, `@param`/`@returns` prose that restates the types, TSDoc on non-exported or private members, and all other


### PR DESCRIPTION
Implements the policy half of #471 (maintainer-approved on the issue): the comments policy now sanctions exactly one documentation-comment form — a TSDoc block on exported public API declarations, limited to a one-sentence summary plus @see links (docs page + governing spec). Everything else stays forbidden, including @example, param/return prose, and TSDoc on non-exported members. Rationale: consumers' IDEs and AI agents read the published .d.ts; the one-liner + @see is the entry point that doesn't duplicate the docs tree.

The full public-surface annotation + two-way lint enforcement lands as #471's implementation PR.

Refs #471

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document scoped TSDoc rules for exported public API declarations in AGENTS.md
> Updates [AGENTS.md](https://github.com/rnw-community/rnw-community/pull/479/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) to define when and how TSDoc comments are permitted in source files.
>
> - Adds a new "Scoped TSDoc on the public API" subsection with rules: one-sentence description per exported symbol, `@see` links only, and a canonical doc resolution order (`docs/api/<entity>.md` → colocated `<entity>.md` → package readme anchor).
> - Explicitly forbids `@example`, narrative blocks, `@param`/`@returns` restatements, and TSDoc on non-exported or private members.
> - Removes `@see` from the existing ban on JSDoc usage examples, since `@see` is now allowed under the new rules.
> - Notes that lint enforcement (required on exports, banned elsewhere) is planned but not yet active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60b7455.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated comment guidelines to allow concise TSDoc on exported public APIs.
  * Permitted optional references to related documentation and governing specifications.
  * Clarified that examples, redundant parameter or return descriptions, private-member TSDoc, and other inline comments remain disallowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->