### PR TITLE
docs(react-native-payments): clean up TODO ledger, extract roadmap.md

### DIFF
--- a/packages/react-native-payments/llms.txt
+++ b/packages/react-native-payments/llms.txt
@@ -14,6 +14,7 @@ handshake without a repo-wide search.
 - [readme.md — Known deviations](readme.md#known-deviations): Platform differences from the W3C spec — Android no-op change events, iOS shipping preselection, single-use `PaymentRequest`, `couponcodechange`.
 - [readme.md — Migrating from v2](readme.md#migrating-from-v2): Breaking changes and upgrade steps from the v2 native interface to v3.
 - [readme.md — Web(react-native-web)](readme.md#webreact-native-web): Browser fallback behavior via the W3C `PaymentRequest` implementation.
+- [roadmap.md](roadmap.md): Implementation notes for the open work items linked from the readme's TODO ledger.
 
 ## Architecture & conventions
 

--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -96,7 +96,7 @@ single-use — build a new one per payment attempt rather than reusing a settled
 ### Screenshots
 
 Recording is deferred — not a documentation gap, a scheduling one: capturing needs the on-device Maestro fleet, which
-is at capacity. The `Docs` [TODO](#todo) below carries the exact capture command so this stays actionable instead of
+is at capacity. [roadmap.md](./roadmap.md#docs) carries the exact capture command so this stays actionable instead of
 silently dropped; once captured, an Apple Pay and a Google Pay sheet GIF replace this placeholder, showing the exact
 flow from the snippet above.
 
@@ -1319,28 +1319,24 @@ version-skew issue above, not a New Architecture incompatibility.
 
 ### Docs
 
-- [ ] Add gifs to the docs showing payment sheets appearing on IOS and Android — add `startRecording: "sheet"` /
-      `stopRecording` around the sheet-presenting step of the `sheet_opens_on_show.yaml` flow documented in
-      [e2e/readme.md](../react-native-payments-example/e2e/readme.md#flows), then run `yarn workspace
-      @rnw-community/react-native-payments-example e2e:ios:bare` / `e2e:android:bare` (or the `:expo` targets) with
-      `MAESTRO_DEBUG_OUTPUT_DIRECTORY` set the same way the `ios-maestro.yml` / `android-maestro.yml` CI workflows set
-      it (`packages/react-native-payments-example/artifacts/maestro-<platform>-<target>`) so the `.mp4` lands next to
-      the other Maestro artifacts; convert with `ffmpeg -i sheet.mp4 -vf "fps=12,scale=320:-1" sheet.gif`, then embed
-      under [Screenshots](#screenshots).
-- [x] Provide migration guide from `react-native-payments`. — see
-      [Migrating from `react-native-payments` (upstream)](#migrating-from-react-native-payments-upstream)
+- [ ] Payment sheet GIFs for iOS and Android — tracked in
+      [#469](https://github.com/rnw-community/rnw-community/issues/469); capture procedure in
+      [roadmap.md](./roadmap.md#docs).
 
 ### Native
 
-- [ ] Investigate and implement `shipping options` on Android (iOS passes them to PassKit with a `shippingoptionchange`
-      listener).
-- [ ] Investigate and implement `coupons` support on Android (iOS enables the PassKit coupon field with a
-      `couponcodechange` listener).
-- [ ] Rewrite IOS to swift?
-- [ ] Rewrite Android to Kotlin?
-- [ ] Can we avoid modifying `AppDelegate.h` with importing `PassKit`?
+- [ ] Shipping options and coupon support on Android — tracked in
+      [#438](https://github.com/rnw-community/rnw-community/issues/438).
+- Rewrite iOS to Swift — **deferred indefinitely**: Codegen has no Swift TurboModule support, so a rewrite would add a
+  bridging layer on top of the existing ObjC++ interop instead of removing it; decision recorded on
+  [#442](https://github.com/rnw-community/rnw-community/issues/442).
+- [ ] Rewrite Android to Kotlin — decided, low effort; tracked in
+      [#442](https://github.com/rnw-community/rnw-community/issues/442).
+- [ ] Drop the `AppDelegate.h` PassKit import requirement — looks droppable since the podspec already links the
+      framework, needs a build-verify pass; tracked in
+      [#442](https://github.com/rnw-community/rnw-community/issues/442).
 
-### W3C compliance checklist
+## W3C compliance checklist
 
 - [x] [PaymentRequestUpdateEvent](https://www.w3.org/TR/payment-request/#dom-paymentrequestupdateevent) — JavaScript
       layer and iOS PassKit delivery implemented (see [Payment change events](#payment-change-events)); on-device
@@ -1364,7 +1360,7 @@ version-skew issue above, not a New Architecture incompatibility.
       [Retrying the Payment](#7-retrying-the-payment) and [Known deviations](#known-deviations)
 - [x] Implement `PaymentResponse` `toJSON()` method — see [Processing the PaymentResponse](#5-processing-the-paymentresponse)
 
-#### Known deviations
+### Known deviations
 
 - **Android change events are a no-op.** Google Pay renders its sheet in its own activity and never asks the app for
   an in-sheet update, so `addEventListener` can be called but a registered listener never fires on Android.
@@ -1399,11 +1395,6 @@ version-skew issue above, not a New Architecture incompatibility.
   native show-path (a second, JS-observable authorization channel) that is out of scope here. On Android, `retry()` is a
   documented no-op: it resolves without any visual effect, consistent with `complete()` and `abort()`'s existing no-op
   boundary on Android (Google Pay's sheet is a separate activity with no in-sheet update mechanism at all).
-
-### Other
-
-- [ ] Refactor `utils`
-- [ ] Find alternative/suctom implementation for the `validator` library
 
 ## License
 

--- a/packages/react-native-payments/roadmap.md
+++ b/packages/react-native-payments/roadmap.md
@@ -1,0 +1,59 @@
+# Roadmap
+
+Implementation notes for the open work items linked from [readme.md](./readme.md#todo). Each section maps to one
+tracked GitHub issue; the readme keeps a one-line pointer, the detail lives here.
+
+## Docs
+
+### Payment sheet GIFs — [#469](https://github.com/rnw-community/rnw-community/issues/469)
+
+Capture procedure once the on-device Maestro fleet has capacity:
+
+1. Add `startRecording: "sheet"` / `stopRecording` around the sheet-presenting step of the `sheet_opens_on_show.yaml`
+   flow documented in [e2e/readme.md](../react-native-payments-example/e2e/readme.md#flows).
+2. Run `yarn workspace @rnw-community/react-native-payments-example e2e:ios:bare` / `e2e:android:bare` (or the
+   `:expo` targets) with `MAESTRO_DEBUG_OUTPUT_DIRECTORY` set the same way the `ios-maestro.yml` /
+   `android-maestro.yml` CI workflows set it
+   (`packages/react-native-payments-example/artifacts/maestro-<platform>-<target>`), so the `.mp4` lands next to the
+   other Maestro artifacts.
+3. Convert with `ffmpeg -i sheet.mp4 -vf "fps=12,scale=320:-1" sheet.gif`.
+4. Embed the result under [Screenshots](./readme.md#screenshots), replacing the placeholder.
+
+## Native
+
+### Android shipping options and coupon support — [#438](https://github.com/rnw-community/rnw-community/issues/438)
+
+Google Pay's `loadPaymentData` supports dynamic price updates via `callbackIntents`
+(`SHIPPING_ADDRESS`, `SHIPPING_OPTION`) and `PaymentDataCallbacks`, meaning `shippingaddresschange` /
+`shippingoptionchange` could fire on Android through the same `updateWith` contract iOS already uses. Coupons are
+a separate spike: investigate the Google Pay offer/promo surface, documenting the outcome either way (`couponcodechange`
+would stay iOS-only if unsupported).
+
+### Native modernization — [#442](https://github.com/rnw-community/rnw-community/issues/442)
+
+Spike findings (decision recorded on the issue):
+
+- **iOS → Swift: deferred indefinitely.** `Payments.mm`/`Payments.h` (1079 + 24 lines, ObjC++) implement a hardened
+  PassKit delegate lifecycle — per-event pending-completion tracking with superseded-event detection, a teardown
+  state machine invoked from five call sites, iOS 15+ conditional coupon-code support, and ~30 delegate
+  callbacks/helpers. Codegen has no Swift TurboModule support today, so a Swift rewrite would sit behind an
+  Objective-C++ spec surface anyway — it adds a bridging layer without removing the interop this module already has,
+  while asking to re-verify ~1100 lines of delegate state whose regressions are silent runtime sheet hangs, not
+  compile errors. Effort: L. Risk: high. Revisit only as part of an Expo Modules API spike (see #445), not as a
+  standalone plain-Swift TurboModule rewrite.
+- **Android → Kotlin: do.** `PaymentsModule.java` (284 lines) is a single activity-result round trip, not a delegate
+  protocol — `abort`/`complete`/`setActiveEvents`/`updatePaymentDetails` are no-ops that resolve immediately, no
+  coupon codes, no in-sheet change events, no teardown state machine. The oldarch/newarch split already isolates the
+  codegen boundary in one abstract spec file, so Kotlin interops with the generated `NativePaymentsSpec` without a
+  bridging shim. Effort: S. Risk: low.
+- **`AppDelegate.h` PassKit import: document + verify.** The regenerated bare example's `AppDelegate.swift` (RN
+  0.86 community template) contains no `import PassKit`, and `react-native-payments.podspec` already declares
+  `s.frameworks = "PassKit", "Contacts"`, linking the framework at the Pod target level — the readme's "add this
+  import" instructions look like they predate that framework-level linking. Not yet build-verified; needs a
+  `pod install` + build against both the ObjC and Swift `AppDelegate` templates before the readme instruction is
+  dropped. Effort: XS.
+
+## Related
+
+- Epic: [#372](https://github.com/rnw-community/rnw-community/issues/372) — react-native-payments revival
+- Docs Oasis: [#467](https://github.com/rnw-community/rnw-community/issues/467) — documentation platform umbrella

--- a/packages/react-native-payments/roadmap.md
+++ b/packages/react-native-payments/roadmap.md
@@ -1,7 +1,7 @@
 # Roadmap
 
-Implementation notes for the open work items linked from [readme.md](./readme.md#todo). Each section maps to one
-tracked GitHub issue; the readme keeps a one-line pointer, the detail lives here.
+Implementation notes for the open work items linked from [readme.md](./readme.md#todo). Each issue subsection maps to
+one tracked GitHub issue; the readme keeps a one-line pointer, the detail lives here.
 
 ## Docs
 
@@ -11,11 +11,13 @@ Capture procedure once the on-device Maestro fleet has capacity:
 
 1. Add `startRecording: "sheet"` / `stopRecording` around the sheet-presenting step of the `sheet_opens_on_show.yaml`
    flow documented in [e2e/readme.md](../react-native-payments-example/e2e/readme.md#flows).
-2. Run `yarn workspace @rnw-community/react-native-payments-example e2e:ios:bare` / `e2e:android:bare` (or the
-   `:expo` targets) with `MAESTRO_DEBUG_OUTPUT_DIRECTORY` set the same way the `ios-maestro.yml` /
-   `android-maestro.yml` CI workflows set it
+2. Run `maestro test --test-output-dir "$MAESTRO_DEBUG_OUTPUT_DIRECTORY" -e APP_ID=... e2e/flows` from
+   `packages/react-native-payments-example` (the `e2e:ios:bare` / `e2e:android:bare` / `:expo` scripts in
+   `package.json` don't pass `--test-output-dir` today — add it for the capture run), with
+   `MAESTRO_DEBUG_OUTPUT_DIRECTORY` set to the same path the `ios-maestro.yml` / `android-maestro.yml` CI workflows
+   use for their post-run screenshot/artifact upload
    (`packages/react-native-payments-example/artifacts/maestro-<platform>-<target>`), so the `.mp4` lands next to the
-   other Maestro artifacts.
+   other Maestro artifacts instead of Maestro's default `~/.maestro/tests/<datetime>/`.
 3. Convert with `ffmpeg -i sheet.mp4 -vf "fps=12,scale=320:-1" sheet.gif`.
 4. Embed the result under [Screenshots](./readme.md#screenshots), replacing the placeholder.
 
@@ -25,9 +27,16 @@ Capture procedure once the on-device Maestro fleet has capacity:
 
 Google Pay's `loadPaymentData` supports dynamic price updates via `callbackIntents`
 (`SHIPPING_ADDRESS`, `SHIPPING_OPTION`) and `PaymentDataCallbacks`, meaning `shippingaddresschange` /
-`shippingoptionchange` could fire on Android through the same `updateWith` contract iOS already uses. Coupons are
-a separate spike: investigate the Google Pay offer/promo surface, documenting the outcome either way (`couponcodechange`
-would stay iOS-only if unsupported).
+`shippingoptionchange` could fire on Android and feed the same `updateWith` contract iOS already uses — but this is
+new infrastructure, not a small tweak to the existing no-op: `AndroidManifest.xml` currently declares no services at
+all, and `PaymentsModule.java`'s `setActiveEvents`/`updatePaymentDetails` resolve immediately without touching Google
+Pay. Shipping on Android would require registering a `Service` extending `BasePaymentDataCallbacks` in the manifest
+(with the `com.google.android.gms.permission.BIND_PAYMENTS_CALLBACK_SERVICE` permission and a
+`com.google.android.gms.wallet.callback.PAYMENT_DATA_CALLBACKS` intent filter), implementing `onPaymentDataChanged`
+there, and adapting its result into the existing `updatePaymentDetails` call so JS `updateWith` observes it the same
+way it does on iOS; `PAYMENT_AUTHORIZATION`/`onPaymentAuthorized` is a separate, unrelated callback and is only needed
+if in-sheet authorization review is also in scope. Coupons are a separate spike: investigate the Google Pay
+offer/promo surface, documenting the outcome either way (`couponcodechange` would stay iOS-only if unsupported).
 
 ### Native modernization — [#442](https://github.com/rnw-community/rnw-community/issues/442)
 
@@ -36,11 +45,11 @@ Spike findings (decision recorded on the issue):
 - **iOS → Swift: deferred indefinitely.** `Payments.mm`/`Payments.h` (1079 + 24 lines, ObjC++) implement a hardened
   PassKit delegate lifecycle — per-event pending-completion tracking with superseded-event detection, a teardown
   state machine invoked from five call sites, iOS 15+ conditional coupon-code support, and ~30 delegate
-  callbacks/helpers. Codegen has no Swift TurboModule support today, so a Swift rewrite would sit behind an
-  Objective-C++ spec surface anyway — it adds a bridging layer without removing the interop this module already has,
-  while asking to re-verify ~1100 lines of delegate state whose regressions are silent runtime sheet hangs, not
-  compile errors. Effort: L. Risk: high. Revisit only as part of an Expo Modules API spike (see #445), not as a
-  standalone plain-Swift TurboModule rewrite.
+  callbacks/helpers. Codegen (React Native 0.86.2, the version this monorepo is pinned to) has no Swift TurboModule
+  support — it only emits Objective-C++ glue — so a Swift rewrite would still sit behind an Objective-C++ spec surface,
+  adding a bridging layer without removing the interop this module already has, while asking to re-verify ~1100 lines
+  of delegate state whose regressions are silent runtime sheet hangs, not compile errors. Effort: L. Risk: high.
+  Revisit only as part of an Expo Modules API spike (see #445), not as a standalone plain-Swift TurboModule rewrite.
 - **Android → Kotlin: do.** `PaymentsModule.java` (284 lines) is a single activity-result round trip, not a delegate
   protocol — `abort`/`complete`/`setActiveEvents`/`updatePaymentDetails` are no-ops that resolve immediately, no
   coupon codes, no in-sheet change events, no teardown state machine. The oldarch/newarch split already isolates the

--- a/packages/react-native-payments/roadmap.md
+++ b/packages/react-native-payments/roadmap.md
@@ -14,10 +14,12 @@ Capture procedure once the on-device Maestro fleet has capacity:
 2. Run `maestro test --test-output-dir "$MAESTRO_DEBUG_OUTPUT_DIRECTORY" -e APP_ID=... e2e/flows` from
    `packages/react-native-payments-example` (the `e2e:ios:bare` / `e2e:android:bare` / `:expo` scripts in
    `package.json` don't pass `--test-output-dir` today — add it for the capture run), with
-   `MAESTRO_DEBUG_OUTPUT_DIRECTORY` set to the same path the `ios-maestro.yml` / `android-maestro.yml` CI workflows
-   use for their post-run screenshot/artifact upload
-   (`packages/react-native-payments-example/artifacts/maestro-<platform>-<target>`), so the `.mp4` lands next to the
-   other Maestro artifacts instead of Maestro's default `~/.maestro/tests/<datetime>/`.
+   `MAESTRO_DEBUG_OUTPUT_DIRECTORY` set to an **absolute** path the same way `ios-maestro.yml` / `android-maestro.yml`
+   do for their post-run screenshot/artifact upload (`${{ github.workspace }}/packages/react-native-payments-example/artifacts/maestro-<platform>-<target>`
+   in CI; locally, `$(git rev-parse --show-toplevel)/packages/react-native-payments-example/artifacts/maestro-<platform>-<target>`) —
+   a relative value resolves under the current directory, which is already `packages/react-native-payments-example`,
+   and would nest a duplicate `packages/react-native-payments-example/` segment. This makes the `.mp4` land there
+   instead of Maestro's default `~/.maestro/tests/<datetime>/`.
 3. Convert with `ffmpeg -i sheet.mp4 -vf "fps=12,scale=320:-1" sheet.gif`.
 4. Embed the result under [Screenshots](./readme.md#screenshots), replacing the placeholder.
 
@@ -32,11 +34,15 @@ new infrastructure, not a small tweak to the existing no-op: `AndroidManifest.xm
 all, and `PaymentsModule.java`'s `setActiveEvents`/`updatePaymentDetails` resolve immediately without touching Google
 Pay. Shipping on Android would require registering a `Service` extending `BasePaymentDataCallbacks` in the manifest
 (with the `com.google.android.gms.permission.BIND_PAYMENTS_CALLBACK_SERVICE` permission and a
-`com.google.android.gms.wallet.callback.PAYMENT_DATA_CALLBACKS` intent filter), implementing `onPaymentDataChanged`
-there, and adapting its result into the existing `updatePaymentDetails` call so JS `updateWith` observes it the same
-way it does on iOS; `PAYMENT_AUTHORIZATION`/`onPaymentAuthorized` is a separate, unrelated callback and is only needed
-if in-sheet authorization review is also in scope. Coupons are a separate spike: investigate the Google Pay
-offer/promo surface, documenting the outcome either way (`couponcodechange` would stay iOS-only if unsupported).
+`com.google.android.gms.wallet.callback.PAYMENT_DATA_CALLBACKS` intent filter) that overrides
+`onPaymentDataChanged(IntermediatePaymentData, OnCompleteListener<PaymentDataRequestUpdate>)` for the declared
+`SHIPPING_ADDRESS`/`SHIPPING_OPTION` callback intents, adapting the `PaymentDataRequestUpdate` handed to that
+listener into the existing `updatePaymentDetails` call so JS `updateWith` observes it the same way it does on iOS.
+`onPaymentAuthorized` is a second override on that same `BasePaymentDataCallbacks` service — not a separate
+mechanism — required only when `PAYMENT_AUTHORIZATION` is also declared in `callbackIntents` for in-sheet
+authorization review, which is out of scope for the shipping/coupon work here. Coupons are a separate spike:
+investigate the Google Pay offer/promo surface, documenting the outcome either way (`couponcodechange` would stay
+iOS-only if unsupported).
 
 ### Native modernization — [#442](https://github.com/rnw-community/rnw-community/issues/442)
 


### PR DESCRIPTION
## Summary
- Removed readme TODO rows for work already shipped and verified against `src`: `Refactor utils` and the validator-dependency row (done in #437/#441 — no `validator` dep in `package.json`, `utils` already split into single-purpose files), and the `Provide migration guide` row (done in #439/#464 — see `Migrating from react-native-payments (upstream)`).
- Converted the remaining genuinely-open Native/Docs rows into one-line issue links: shipping options + coupons on Android → #438, the Swift/Kotlin/AppDelegate-import decisions → #442 (spike findings quoted from the issue, including the "defer Swift indefinitely / do Kotlin now / verify-then-drop the PassKit import" recommendation), and the sheet-GIF capture row → #469. Dropped the now-empty `### Other` subsection.
- Verified every W3C compliance checklist row against `src` (change events, `PaymentDetailsModifier`, error taxonomy, `hasEnrolledInstrument`, `on*change` attributes, `shippingType`, `retry()`, `toJSON()` are all implemented) — the checklist was already accurate and fully checked, so it's left untouched content-wise, just lifted from a `### ` subheading under `## TODO` to its own `## W3C compliance checklist` section since nothing under it is actually outstanding. `Known deviations` keeps its existing anchor (`#known-deviations`) since five other readme sections link to it.
- Added `packages/react-native-payments/roadmap.md` holding the implementation notes for the open work (GIF capture procedure, #438/#442 spike detail) so the readme's TODO ledger stays a skimmable list of issue links; linked from the readme (TODO row + Screenshots section) and from `llms.txt`.

No source changes — docs only.

Refs #472

## Test plan
- [x] `yarn ts`
- [x] `yarn lint`
- [x] `yarn test`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract roadmap.md and clean up TODO ledger in react-native-payments docs
> - Moves detailed implementation notes (GIF capture procedure, Android shipping/coupon callbackIntents, Kotlin/Swift rewrite decisions) out of [readme.md](https://github.com/rnw-community/rnw-community/pull/481/files#diff-6190e5c40ba924df626fcc867585c216eb1de7d6d5d2d5ecdf36a25525783239) into a new [roadmap.md](https://github.com/rnw-community/rnw-community/pull/481/files#diff-f5d5ab50dfdeddb3cbff6e808eb8c7decd0fd29c75d48761513ea856d360ef3e).
> - Consolidates TODO items in the readme to point to issue numbers (#438, #442, #469) and roadmap sections instead of inline instructions.
> - Removes the 'Other' TODO section and promotes W3C compliance headings one level up.
> - Adds a [llms.txt](https://github.com/rnw-community/rnw-community/pull/481/files#diff-25404be6cad8423bff357ffc2bc744672de64f8dbbdfabe1e427ae620e14e378) entry linking to roadmap.md.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 625dee2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a roadmap covering payment-sheet recording, Android shipping and coupon support, native modernization, and PassKit verification.
  - Updated the README with a roadmap link, clearer tracked work items, and documented implementation decisions.
  - Replaced obsolete TODO guidance, reorganized known deviations, and improved references to outstanding payment-related work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->