### PR TITLE
ci: rewrite codecov.yml flags and wire OIDC upload

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,173 +69,173 @@ jobs:
                 run: yarn turbo run test:coverage --affected
 
             -   name: Upload coverage - decorators-core
-                if: hashFiles('packages/decorators-core/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/decorators-core/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/decorators-core/coverage/lcov.info
                     flags: decorators-core
 
             -   name: Upload coverage - eslint-plugin
-                if: hashFiles('packages/eslint-plugin/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/eslint-plugin/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/eslint-plugin/coverage/lcov.info
                     flags: eslint-plugin
 
             -   name: Upload coverage - fast-style
-                if: hashFiles('packages/fast-style/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/fast-style/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/fast-style/coverage/lcov.info
                     flags: fast-style
 
             -   name: Upload coverage - histogram-metric-decorator
-                if: hashFiles('packages/histogram-metric-decorator/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/histogram-metric-decorator/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/histogram-metric-decorator/coverage/lcov.info
                     flags: histogram-metric-decorator
 
             -   name: Upload coverage - lock-decorator
-                if: hashFiles('packages/lock-decorator/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/lock-decorator/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/lock-decorator/coverage/lcov.info
                     flags: lock-decorator
 
             -   name: Upload coverage - log-decorator
-                if: hashFiles('packages/log-decorator/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/log-decorator/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/log-decorator/coverage/lcov.info
                     flags: log-decorator
 
             -   name: Upload coverage - nestjs-enterprise
-                if: hashFiles('packages/nestjs-enterprise/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/nestjs-enterprise/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/nestjs-enterprise/coverage/lcov.info
                     flags: nestjs-enterprise
 
             -   name: Upload coverage - nestjs-rxjs-lock
-                if: hashFiles('packages/nestjs-rxjs-lock/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/nestjs-rxjs-lock/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/nestjs-rxjs-lock/coverage/lcov.info
                     flags: nestjs-rxjs-lock
 
             -   name: Upload coverage - nestjs-rxjs-logger
-                if: hashFiles('packages/nestjs-rxjs-logger/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/nestjs-rxjs-logger/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/nestjs-rxjs-logger/coverage/lcov.info
                     flags: nestjs-rxjs-logger
 
             -   name: Upload coverage - nestjs-rxjs-metrics
-                if: hashFiles('packages/nestjs-rxjs-metrics/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/nestjs-rxjs-metrics/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/nestjs-rxjs-metrics/coverage/lcov.info
                     flags: nestjs-rxjs-metrics
 
             -   name: Upload coverage - nestjs-rxjs-redis
-                if: hashFiles('packages/nestjs-rxjs-redis/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/nestjs-rxjs-redis/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/nestjs-rxjs-redis/coverage/lcov.info
                     flags: nestjs-rxjs-redis
 
             -   name: Upload coverage - nestjs-typed-config
-                if: hashFiles('packages/nestjs-typed-config/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/nestjs-typed-config/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/nestjs-typed-config/coverage/lcov.info
                     flags: nestjs-typed-config
 
             -   name: Upload coverage - object-field-tree
-                if: hashFiles('packages/object-field-tree/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/object-field-tree/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/object-field-tree/coverage/lcov.info
                     flags: object-field-tree
 
             -   name: Upload coverage - platform
-                if: hashFiles('packages/platform/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/platform/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/platform/coverage/lcov.info
                     flags: platform
 
             -   name: Upload coverage - react-native-payments
-                if: hashFiles('packages/react-native-payments/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/react-native-payments/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/react-native-payments/coverage/lcov.info
                     flags: react-native-payments
 
             -   name: Upload coverage - redux-loadable
-                if: hashFiles('packages/redux-loadable/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/redux-loadable/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/redux-loadable/coverage/lcov.info
                     flags: redux-loadable
 
             -   name: Upload coverage - rxjs-errors
-                if: hashFiles('packages/rxjs-errors/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/rxjs-errors/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/rxjs-errors/coverage/lcov.info
                     flags: rxjs-errors
 
             -   name: Upload coverage - shared
-                if: hashFiles('packages/shared/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/shared/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/shared/coverage/lcov.info
                     flags: shared
 
             -   name: Upload coverage - wdio
-                if: hashFiles('packages/wdio/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+                if: hashFiles('packages/wdio/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    use_oidc: true
-                    fail_ci_if_error: true
+                    use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     files: packages/wdio/coverage/lcov.info
                     flags: wdio
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,6 +74,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/decorators-core/coverage/lcov.info
                     flags: decorators-core
 
@@ -83,6 +84,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/eslint-plugin/coverage/lcov.info
                     flags: eslint-plugin
 
@@ -92,6 +94,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/fast-style/coverage/lcov.info
                     flags: fast-style
 
@@ -101,6 +104,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/histogram-metric-decorator/coverage/lcov.info
                     flags: histogram-metric-decorator
 
@@ -110,6 +114,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/lock-decorator/coverage/lcov.info
                     flags: lock-decorator
 
@@ -119,6 +124,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/log-decorator/coverage/lcov.info
                     flags: log-decorator
 
@@ -128,6 +134,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/nestjs-enterprise/coverage/lcov.info
                     flags: nestjs-enterprise
 
@@ -137,6 +144,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/nestjs-rxjs-lock/coverage/lcov.info
                     flags: nestjs-rxjs-lock
 
@@ -146,6 +154,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/nestjs-rxjs-logger/coverage/lcov.info
                     flags: nestjs-rxjs-logger
 
@@ -155,6 +164,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/nestjs-rxjs-metrics/coverage/lcov.info
                     flags: nestjs-rxjs-metrics
 
@@ -164,6 +174,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/nestjs-rxjs-redis/coverage/lcov.info
                     flags: nestjs-rxjs-redis
 
@@ -173,6 +184,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/nestjs-typed-config/coverage/lcov.info
                     flags: nestjs-typed-config
 
@@ -182,6 +194,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/object-field-tree/coverage/lcov.info
                     flags: object-field-tree
 
@@ -191,6 +204,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/platform/coverage/lcov.info
                     flags: platform
 
@@ -200,6 +214,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/react-native-payments/coverage/lcov.info
                     flags: react-native-payments
 
@@ -209,6 +224,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/redux-loadable/coverage/lcov.info
                     flags: redux-loadable
 
@@ -218,6 +234,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/rxjs-errors/coverage/lcov.info
                     flags: rxjs-errors
 
@@ -227,6 +244,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/shared/coverage/lcov.info
                     flags: shared
 
@@ -236,6 +254,7 @@ jobs:
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                    disable_search: true
                     files: packages/wdio/coverage/lcov.info
                     flags: wdio
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,7 +70,7 @@ jobs:
 
             -   name: Upload coverage - decorators-core
                 if: hashFiles('packages/decorators-core/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -79,7 +79,7 @@ jobs:
 
             -   name: Upload coverage - eslint-plugin
                 if: hashFiles('packages/eslint-plugin/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -88,7 +88,7 @@ jobs:
 
             -   name: Upload coverage - fast-style
                 if: hashFiles('packages/fast-style/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -97,7 +97,7 @@ jobs:
 
             -   name: Upload coverage - histogram-metric-decorator
                 if: hashFiles('packages/histogram-metric-decorator/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -106,7 +106,7 @@ jobs:
 
             -   name: Upload coverage - lock-decorator
                 if: hashFiles('packages/lock-decorator/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -115,7 +115,7 @@ jobs:
 
             -   name: Upload coverage - log-decorator
                 if: hashFiles('packages/log-decorator/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -124,7 +124,7 @@ jobs:
 
             -   name: Upload coverage - nestjs-enterprise
                 if: hashFiles('packages/nestjs-enterprise/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -133,7 +133,7 @@ jobs:
 
             -   name: Upload coverage - nestjs-rxjs-lock
                 if: hashFiles('packages/nestjs-rxjs-lock/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -142,7 +142,7 @@ jobs:
 
             -   name: Upload coverage - nestjs-rxjs-logger
                 if: hashFiles('packages/nestjs-rxjs-logger/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -151,7 +151,7 @@ jobs:
 
             -   name: Upload coverage - nestjs-rxjs-metrics
                 if: hashFiles('packages/nestjs-rxjs-metrics/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -160,7 +160,7 @@ jobs:
 
             -   name: Upload coverage - nestjs-rxjs-redis
                 if: hashFiles('packages/nestjs-rxjs-redis/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -169,7 +169,7 @@ jobs:
 
             -   name: Upload coverage - nestjs-typed-config
                 if: hashFiles('packages/nestjs-typed-config/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -178,7 +178,7 @@ jobs:
 
             -   name: Upload coverage - object-field-tree
                 if: hashFiles('packages/object-field-tree/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -187,7 +187,7 @@ jobs:
 
             -   name: Upload coverage - platform
                 if: hashFiles('packages/platform/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -196,7 +196,7 @@ jobs:
 
             -   name: Upload coverage - react-native-payments
                 if: hashFiles('packages/react-native-payments/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -205,7 +205,7 @@ jobs:
 
             -   name: Upload coverage - redux-loadable
                 if: hashFiles('packages/redux-loadable/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -214,7 +214,7 @@ jobs:
 
             -   name: Upload coverage - rxjs-errors
                 if: hashFiles('packages/rxjs-errors/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -223,7 +223,7 @@ jobs:
 
             -   name: Upload coverage - shared
                 if: hashFiles('packages/shared/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
@@ -232,7 +232,7 @@ jobs:
 
             -   name: Upload coverage - wdio
                 if: hashFiles('packages/wdio/coverage/lcov.info') != ''
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
                 with:
                     use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                     fail_ci_if_error: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,6 +22,7 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
+            id-token: write
             issues: write
             pull-requests: write
 
@@ -67,12 +68,176 @@ jobs:
             -   name: Unit tests
                 run: yarn turbo run test:coverage --affected
 
-            -   name: Upload coverage to Codecov
+            -   name: Upload coverage - decorators-core
+                if: hashFiles('packages/decorators-core/coverage/lcov.info') != ''
                 uses: codecov/codecov-action@v5
                 with:
-                    token: ${{ secrets.CODECOV_TOKEN }}
+                    use_oidc: true
                     fail_ci_if_error: true
-                    verbose: true
+                    files: packages/decorators-core/coverage/lcov.info
+                    flags: decorators-core
+
+            -   name: Upload coverage - eslint-plugin
+                if: hashFiles('packages/eslint-plugin/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/eslint-plugin/coverage/lcov.info
+                    flags: eslint-plugin
+
+            -   name: Upload coverage - fast-style
+                if: hashFiles('packages/fast-style/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/fast-style/coverage/lcov.info
+                    flags: fast-style
+
+            -   name: Upload coverage - histogram-metric-decorator
+                if: hashFiles('packages/histogram-metric-decorator/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/histogram-metric-decorator/coverage/lcov.info
+                    flags: histogram-metric-decorator
+
+            -   name: Upload coverage - lock-decorator
+                if: hashFiles('packages/lock-decorator/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/lock-decorator/coverage/lcov.info
+                    flags: lock-decorator
+
+            -   name: Upload coverage - log-decorator
+                if: hashFiles('packages/log-decorator/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/log-decorator/coverage/lcov.info
+                    flags: log-decorator
+
+            -   name: Upload coverage - nestjs-enterprise
+                if: hashFiles('packages/nestjs-enterprise/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/nestjs-enterprise/coverage/lcov.info
+                    flags: nestjs-enterprise
+
+            -   name: Upload coverage - nestjs-rxjs-lock
+                if: hashFiles('packages/nestjs-rxjs-lock/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/nestjs-rxjs-lock/coverage/lcov.info
+                    flags: nestjs-rxjs-lock
+
+            -   name: Upload coverage - nestjs-rxjs-logger
+                if: hashFiles('packages/nestjs-rxjs-logger/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/nestjs-rxjs-logger/coverage/lcov.info
+                    flags: nestjs-rxjs-logger
+
+            -   name: Upload coverage - nestjs-rxjs-metrics
+                if: hashFiles('packages/nestjs-rxjs-metrics/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/nestjs-rxjs-metrics/coverage/lcov.info
+                    flags: nestjs-rxjs-metrics
+
+            -   name: Upload coverage - nestjs-rxjs-redis
+                if: hashFiles('packages/nestjs-rxjs-redis/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/nestjs-rxjs-redis/coverage/lcov.info
+                    flags: nestjs-rxjs-redis
+
+            -   name: Upload coverage - nestjs-typed-config
+                if: hashFiles('packages/nestjs-typed-config/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/nestjs-typed-config/coverage/lcov.info
+                    flags: nestjs-typed-config
+
+            -   name: Upload coverage - object-field-tree
+                if: hashFiles('packages/object-field-tree/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/object-field-tree/coverage/lcov.info
+                    flags: object-field-tree
+
+            -   name: Upload coverage - platform
+                if: hashFiles('packages/platform/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/platform/coverage/lcov.info
+                    flags: platform
+
+            -   name: Upload coverage - react-native-payments
+                if: hashFiles('packages/react-native-payments/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/react-native-payments/coverage/lcov.info
+                    flags: react-native-payments
+
+            -   name: Upload coverage - redux-loadable
+                if: hashFiles('packages/redux-loadable/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/redux-loadable/coverage/lcov.info
+                    flags: redux-loadable
+
+            -   name: Upload coverage - rxjs-errors
+                if: hashFiles('packages/rxjs-errors/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/rxjs-errors/coverage/lcov.info
+                    flags: rxjs-errors
+
+            -   name: Upload coverage - shared
+                if: hashFiles('packages/shared/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/shared/coverage/lcov.info
+                    flags: shared
+
+            -   name: Upload coverage - wdio
+                if: hashFiles('packages/wdio/coverage/lcov.info') != ''
+                uses: codecov/codecov-action@v5
+                with:
+                    use_oidc: true
+                    fail_ci_if_error: true
+                    files: packages/wdio/coverage/lcov.info
+                    flags: wdio
 
     required-checks:
         name: Required checks

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,7 +69,7 @@ jobs:
                 run: yarn turbo run test:coverage --affected
 
             -   name: Upload coverage - decorators-core
-                if: hashFiles('packages/decorators-core/coverage/lcov.info') != ''
+                if: hashFiles('packages/decorators-core/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -78,7 +78,7 @@ jobs:
                     flags: decorators-core
 
             -   name: Upload coverage - eslint-plugin
-                if: hashFiles('packages/eslint-plugin/coverage/lcov.info') != ''
+                if: hashFiles('packages/eslint-plugin/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -87,7 +87,7 @@ jobs:
                     flags: eslint-plugin
 
             -   name: Upload coverage - fast-style
-                if: hashFiles('packages/fast-style/coverage/lcov.info') != ''
+                if: hashFiles('packages/fast-style/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -96,7 +96,7 @@ jobs:
                     flags: fast-style
 
             -   name: Upload coverage - histogram-metric-decorator
-                if: hashFiles('packages/histogram-metric-decorator/coverage/lcov.info') != ''
+                if: hashFiles('packages/histogram-metric-decorator/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -105,7 +105,7 @@ jobs:
                     flags: histogram-metric-decorator
 
             -   name: Upload coverage - lock-decorator
-                if: hashFiles('packages/lock-decorator/coverage/lcov.info') != ''
+                if: hashFiles('packages/lock-decorator/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -114,7 +114,7 @@ jobs:
                     flags: lock-decorator
 
             -   name: Upload coverage - log-decorator
-                if: hashFiles('packages/log-decorator/coverage/lcov.info') != ''
+                if: hashFiles('packages/log-decorator/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -123,7 +123,7 @@ jobs:
                     flags: log-decorator
 
             -   name: Upload coverage - nestjs-enterprise
-                if: hashFiles('packages/nestjs-enterprise/coverage/lcov.info') != ''
+                if: hashFiles('packages/nestjs-enterprise/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -132,7 +132,7 @@ jobs:
                     flags: nestjs-enterprise
 
             -   name: Upload coverage - nestjs-rxjs-lock
-                if: hashFiles('packages/nestjs-rxjs-lock/coverage/lcov.info') != ''
+                if: hashFiles('packages/nestjs-rxjs-lock/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -141,7 +141,7 @@ jobs:
                     flags: nestjs-rxjs-lock
 
             -   name: Upload coverage - nestjs-rxjs-logger
-                if: hashFiles('packages/nestjs-rxjs-logger/coverage/lcov.info') != ''
+                if: hashFiles('packages/nestjs-rxjs-logger/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -150,7 +150,7 @@ jobs:
                     flags: nestjs-rxjs-logger
 
             -   name: Upload coverage - nestjs-rxjs-metrics
-                if: hashFiles('packages/nestjs-rxjs-metrics/coverage/lcov.info') != ''
+                if: hashFiles('packages/nestjs-rxjs-metrics/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -159,7 +159,7 @@ jobs:
                     flags: nestjs-rxjs-metrics
 
             -   name: Upload coverage - nestjs-rxjs-redis
-                if: hashFiles('packages/nestjs-rxjs-redis/coverage/lcov.info') != ''
+                if: hashFiles('packages/nestjs-rxjs-redis/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -168,7 +168,7 @@ jobs:
                     flags: nestjs-rxjs-redis
 
             -   name: Upload coverage - nestjs-typed-config
-                if: hashFiles('packages/nestjs-typed-config/coverage/lcov.info') != ''
+                if: hashFiles('packages/nestjs-typed-config/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -177,7 +177,7 @@ jobs:
                     flags: nestjs-typed-config
 
             -   name: Upload coverage - object-field-tree
-                if: hashFiles('packages/object-field-tree/coverage/lcov.info') != ''
+                if: hashFiles('packages/object-field-tree/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -186,7 +186,7 @@ jobs:
                     flags: object-field-tree
 
             -   name: Upload coverage - platform
-                if: hashFiles('packages/platform/coverage/lcov.info') != ''
+                if: hashFiles('packages/platform/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -195,7 +195,7 @@ jobs:
                     flags: platform
 
             -   name: Upload coverage - react-native-payments
-                if: hashFiles('packages/react-native-payments/coverage/lcov.info') != ''
+                if: hashFiles('packages/react-native-payments/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -204,7 +204,7 @@ jobs:
                     flags: react-native-payments
 
             -   name: Upload coverage - redux-loadable
-                if: hashFiles('packages/redux-loadable/coverage/lcov.info') != ''
+                if: hashFiles('packages/redux-loadable/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -213,7 +213,7 @@ jobs:
                     flags: redux-loadable
 
             -   name: Upload coverage - rxjs-errors
-                if: hashFiles('packages/rxjs-errors/coverage/lcov.info') != ''
+                if: hashFiles('packages/rxjs-errors/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -222,7 +222,7 @@ jobs:
                     flags: rxjs-errors
 
             -   name: Upload coverage - shared
-                if: hashFiles('packages/shared/coverage/lcov.info') != ''
+                if: hashFiles('packages/shared/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true
@@ -231,7 +231,7 @@ jobs:
                     flags: shared
 
             -   name: Upload coverage - wdio
-                if: hashFiles('packages/wdio/coverage/lcov.info') != ''
+                if: hashFiles('packages/wdio/coverage/lcov.info') != '' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
                 uses: codecov/codecov-action@v5
                 with:
                     use_oidc: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,96 +1,283 @@
+codecov:
+  require_ci_to_pass: true
+
+comment:
+  layout: "condensed_header, diff, flags, condensed_footer"
+  require_changes: true
+
 coverage:
+  precision: 2
+  round: down
   status:
     project:
       default: off
+      decorators-core:
+        flags:
+          - decorators-core
+        target: 99.9
+        threshold: 0.5%
+      eslint-plugin:
+        flags:
+          - eslint-plugin
+        target: 94.1
+        threshold: 0.5%
       fast-style:
         flags:
           - fast-style
-      hoverable:
+        target: 99.9
+        threshold: 0.5%
+      histogram-metric-decorator:
         flags:
-          - hoverable
+          - histogram-metric-decorator
+        target: 99.9
+        threshold: 0.5%
+      lock-decorator:
+        flags:
+          - lock-decorator
+        target: 99.9
+        threshold: 0.5%
+      log-decorator:
+        flags:
+          - log-decorator
+        target: 99.9
+        threshold: 0.5%
+      nestjs-enterprise:
+        flags:
+          - nestjs-enterprise
+        target: 99.9
+        threshold: 0.5%
       nestjs-rxjs-lock:
         flags:
           - nestjs-rxjs-lock
+        target: 99.9
+        threshold: 0.5%
       nestjs-rxjs-logger:
         flags:
           - nestjs-rxjs-logger
+        target: 99.9
+        threshold: 0.5%
       nestjs-rxjs-metrics:
         flags:
           - nestjs-rxjs-metrics
+        target: 99.9
+        threshold: 0.5%
       nestjs-rxjs-redis:
         flags:
           - nestjs-rxjs-redis
+        target: 99.9
+        threshold: 0.5%
       nestjs-typed-config:
         flags:
           - nestjs-typed-config
-      nestjs-webpack-swc:
-        flags:
-          - nestjs-webpack-swc
+        target: 99.9
+        threshold: 0.5%
       object-field-tree:
         flags:
           - object-field-tree
+        target: 99.9
+        threshold: 0.5%
       platform:
         flags:
           - platform
+        target: 99.9
+        threshold: 0.5%
       react-native-payments:
         flags:
           - react-native-payments
+        target: 100
+        threshold: 0%
       redux-loadable:
         flags:
           - redux-loadable
+        target: 99.9
+        threshold: 0.5%
       rxjs-errors:
         flags:
           - rxjs-errors
+        target: 99.9
+        threshold: 0.5%
       shared:
         flags:
           - shared
+        target: 99.9
+        threshold: 0.5%
       wdio:
         flags:
           - wdio
+        target: 99.9
+        threshold: 0.5%
+    patch:
+      default: off
+      decorators-core:
+        flags:
+          - decorators-core
+        target: 99.9
+        threshold: 1%
+      eslint-plugin:
+        flags:
+          - eslint-plugin
+        target: 94.1
+        threshold: 1%
+      fast-style:
+        flags:
+          - fast-style
+        target: 99.9
+        threshold: 1%
+      histogram-metric-decorator:
+        flags:
+          - histogram-metric-decorator
+        target: 99.9
+        threshold: 1%
+      lock-decorator:
+        flags:
+          - lock-decorator
+        target: 99.9
+        threshold: 1%
+      log-decorator:
+        flags:
+          - log-decorator
+        target: 99.9
+        threshold: 1%
+      nestjs-enterprise:
+        flags:
+          - nestjs-enterprise
+        target: 99.9
+        threshold: 1%
+      nestjs-rxjs-lock:
+        flags:
+          - nestjs-rxjs-lock
+        target: 99.9
+        threshold: 1%
+      nestjs-rxjs-logger:
+        flags:
+          - nestjs-rxjs-logger
+        target: 99.9
+        threshold: 1%
+      nestjs-rxjs-metrics:
+        flags:
+          - nestjs-rxjs-metrics
+        target: 99.9
+        threshold: 1%
+      nestjs-rxjs-redis:
+        flags:
+          - nestjs-rxjs-redis
+        target: 99.9
+        threshold: 1%
+      nestjs-typed-config:
+        flags:
+          - nestjs-typed-config
+        target: 99.9
+        threshold: 1%
+      object-field-tree:
+        flags:
+          - object-field-tree
+        target: 99.9
+        threshold: 1%
+      platform:
+        flags:
+          - platform
+        target: 99.9
+        threshold: 1%
+      react-native-payments:
+        flags:
+          - react-native-payments
+        target: 100
+        threshold: 0%
+      redux-loadable:
+        flags:
+          - redux-loadable
+        target: 99.9
+        threshold: 1%
+      rxjs-errors:
+        flags:
+          - rxjs-errors
+        target: 99.9
+        threshold: 1%
+      shared:
+        flags:
+          - shared
+        target: 99.9
+        threshold: 1%
+      wdio:
+        flags:
+          - wdio
+        target: 99.9
+        threshold: 1%
 
 flags:
+  decorators-core:
+    carryforward: true
+    paths:
+      - packages/decorators-core/
+  eslint-plugin:
+    carryforward: true
+    paths:
+      - packages/eslint-plugin/
   fast-style:
+    carryforward: true
     paths:
       - packages/fast-style/
-  hoverable:
+  histogram-metric-decorator:
+    carryforward: true
     paths:
-      - packages/hoverable/
+      - packages/histogram-metric-decorator/
+  lock-decorator:
+    carryforward: true
+    paths:
+      - packages/lock-decorator/
+  log-decorator:
+    carryforward: true
+    paths:
+      - packages/log-decorator/
+  nestjs-enterprise:
+    carryforward: true
+    paths:
+      - packages/nestjs-enterprise/
   nestjs-rxjs-lock:
+    carryforward: true
     paths:
       - packages/nestjs-rxjs-lock/
   nestjs-rxjs-logger:
+    carryforward: true
     paths:
       - packages/nestjs-rxjs-logger/
   nestjs-rxjs-metrics:
+    carryforward: true
     paths:
       - packages/nestjs-rxjs-metrics/
   nestjs-rxjs-redis:
+    carryforward: true
     paths:
       - packages/nestjs-rxjs-redis/
   nestjs-typed-config:
+    carryforward: true
     paths:
       - packages/nestjs-typed-config/
-  nestjs-webpack-swc:
-    paths:
-      - packages/nestjs-webpack-swc/
   object-field-tree:
+    carryforward: true
     paths:
       - packages/object-field-tree/
   platform:
+    carryforward: true
     paths:
       - packages/platform/
   react-native-payments:
+    carryforward: true
     paths:
       - packages/react-native-payments/
   redux-loadable:
+    carryforward: true
     paths:
       - packages/redux-loadable/
   rxjs-errors:
+    carryforward: true
     paths:
       - packages/rxjs-errors/
   shared:
+    carryforward: true
     paths:
       - packages/shared/
   wdio:
+    carryforward: true
     paths:
       - packages/wdio/

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,195 +14,195 @@ coverage:
       decorators-core:
         flags:
           - decorators-core
-        target: 99.9
-        threshold: 0.5%
+        target: &target-default 99.9
+        threshold: &threshold-project-default 0.5%
       eslint-plugin:
         flags:
           - eslint-plugin
-        target: 94.1
-        threshold: 0.5%
+        target: &target-eslint-plugin 94.1
+        threshold: *threshold-project-default
       fast-style:
         flags:
           - fast-style
-        target: 99.9
-        threshold: 0.5%
+        target: *target-default
+        threshold: *threshold-project-default
       histogram-metric-decorator:
         flags:
           - histogram-metric-decorator
-        target: 99.9
-        threshold: 0.5%
+        target: *target-default
+        threshold: *threshold-project-default
       lock-decorator:
         flags:
           - lock-decorator
-        target: 99.9
-        threshold: 0.5%
+        target: *target-default
+        threshold: *threshold-project-default
       log-decorator:
         flags:
           - log-decorator
-        target: 99.9
-        threshold: 0.5%
+        target: *target-default
+        threshold: *threshold-project-default
       nestjs-enterprise:
         flags:
           - nestjs-enterprise
-        target: 99.9
-        threshold: 0.5%
+        target: *target-default
+        threshold: *threshold-project-default
       nestjs-rxjs-lock:
         flags:
           - nestjs-rxjs-lock
-        target: 99.9
-        threshold: 0.5%
+        target: *target-default
+        threshold: *threshold-project-default
       nestjs-rxjs-logger:
         flags:
           - nestjs-rxjs-logger
-        target: 99.9
-        threshold: 0.5%
+        target: *target-default
+        threshold: *threshold-project-default
       nestjs-rxjs-metrics:
         flags:
           - nestjs-rxjs-metrics
-        target: 99.9
-        threshold: 0.5%
+        target: *target-default
+        threshold: *threshold-project-default
       nestjs-rxjs-redis:
         flags:
           - nestjs-rxjs-redis
-        target: 99.9
-        threshold: 0.5%
+        target: *target-default
+        threshold: *threshold-project-default
       nestjs-typed-config:
         flags:
           - nestjs-typed-config
-        target: 99.9
-        threshold: 0.5%
+        target: *target-default
+        threshold: *threshold-project-default
       object-field-tree:
         flags:
           - object-field-tree
-        target: 99.9
-        threshold: 0.5%
+        target: *target-default
+        threshold: *threshold-project-default
       platform:
         flags:
           - platform
-        target: 99.9
-        threshold: 0.5%
+        target: *target-default
+        threshold: *threshold-project-default
       react-native-payments:
         flags:
           - react-native-payments
-        target: 100
-        threshold: 0%
+        target: &target-payments 100
+        threshold: &threshold-payments 0%
       redux-loadable:
         flags:
           - redux-loadable
-        target: 99.9
-        threshold: 0.5%
+        target: *target-default
+        threshold: *threshold-project-default
       rxjs-errors:
         flags:
           - rxjs-errors
-        target: 99.9
-        threshold: 0.5%
+        target: *target-default
+        threshold: *threshold-project-default
       shared:
         flags:
           - shared
-        target: 99.9
-        threshold: 0.5%
+        target: *target-default
+        threshold: *threshold-project-default
       wdio:
         flags:
           - wdio
-        target: 99.9
-        threshold: 0.5%
+        target: *target-default
+        threshold: *threshold-project-default
     patch:
       default: off
       decorators-core:
         flags:
           - decorators-core
-        target: 99.9
-        threshold: 1%
+        target: *target-default
+        threshold: &threshold-patch-default 1%
       eslint-plugin:
         flags:
           - eslint-plugin
-        target: 94.1
-        threshold: 1%
+        target: *target-eslint-plugin
+        threshold: *threshold-patch-default
       fast-style:
         flags:
           - fast-style
-        target: 99.9
-        threshold: 1%
+        target: *target-default
+        threshold: *threshold-patch-default
       histogram-metric-decorator:
         flags:
           - histogram-metric-decorator
-        target: 99.9
-        threshold: 1%
+        target: *target-default
+        threshold: *threshold-patch-default
       lock-decorator:
         flags:
           - lock-decorator
-        target: 99.9
-        threshold: 1%
+        target: *target-default
+        threshold: *threshold-patch-default
       log-decorator:
         flags:
           - log-decorator
-        target: 99.9
-        threshold: 1%
+        target: *target-default
+        threshold: *threshold-patch-default
       nestjs-enterprise:
         flags:
           - nestjs-enterprise
-        target: 99.9
-        threshold: 1%
+        target: *target-default
+        threshold: *threshold-patch-default
       nestjs-rxjs-lock:
         flags:
           - nestjs-rxjs-lock
-        target: 99.9
-        threshold: 1%
+        target: *target-default
+        threshold: *threshold-patch-default
       nestjs-rxjs-logger:
         flags:
           - nestjs-rxjs-logger
-        target: 99.9
-        threshold: 1%
+        target: *target-default
+        threshold: *threshold-patch-default
       nestjs-rxjs-metrics:
         flags:
           - nestjs-rxjs-metrics
-        target: 99.9
-        threshold: 1%
+        target: *target-default
+        threshold: *threshold-patch-default
       nestjs-rxjs-redis:
         flags:
           - nestjs-rxjs-redis
-        target: 99.9
-        threshold: 1%
+        target: *target-default
+        threshold: *threshold-patch-default
       nestjs-typed-config:
         flags:
           - nestjs-typed-config
-        target: 99.9
-        threshold: 1%
+        target: *target-default
+        threshold: *threshold-patch-default
       object-field-tree:
         flags:
           - object-field-tree
-        target: 99.9
-        threshold: 1%
+        target: *target-default
+        threshold: *threshold-patch-default
       platform:
         flags:
           - platform
-        target: 99.9
-        threshold: 1%
+        target: *target-default
+        threshold: *threshold-patch-default
       react-native-payments:
         flags:
           - react-native-payments
-        target: 100
-        threshold: 0%
+        target: *target-payments
+        threshold: *threshold-payments
       redux-loadable:
         flags:
           - redux-loadable
-        target: 99.9
-        threshold: 1%
+        target: *target-default
+        threshold: *threshold-patch-default
       rxjs-errors:
         flags:
           - rxjs-errors
-        target: 99.9
-        threshold: 1%
+        target: *target-default
+        threshold: *threshold-patch-default
       shared:
         flags:
           - shared
-        target: 99.9
-        threshold: 1%
+        target: *target-default
+        threshold: *threshold-patch-default
       wdio:
         flags:
           - wdio
-        target: 99.9
-        threshold: 1%
+        target: *target-default
+        threshold: *threshold-patch-default
 
 flags:
   decorators-core:


### PR DESCRIPTION
## Summary

Refs #480

- Rewrote `codecov.yml`: audited every package's flag against which ones actually produce `coverage/lcov.info`. Dropped the stale `hoverable` flag (no such package exists) and `nestjs-webpack-swc` (ships no `.spec.ts` files and has no `test`/`test:coverage` script, so it never uploads). Added the six packages that had tests but no flag: `decorators-core`, `eslint-plugin`, `histogram-metric-decorator`, `lock-decorator`, `log-decorator`, `nestjs-enterprise`. Every flag now has `carryforward: true` so a `turbo --affected` run that skips a package does not zero out its coverage. `project`/`patch` status targets are pinned per package to that package's own jest `coverageThreshold` (99.9% default, 94.1% for `eslint-plugin`, 100% for `react-native-payments`) with a small `threshold` tolerance, instead of codecov's `auto` target, which is the exact "92.30% vs auto-computed 98.32%" noise class called out in #480.
- Wired `.github/workflows/pr.yml`'s existing `code-quality` job (ubuntu-latest, no new job) to actually populate those flags: the prior single `codecov/codecov-action@v5` step passed no `flags` argument at all, so none of the configured flags ever received data — confirmed live: the `react-native-payments` flag badge in its readme currently renders `coverage: unknown`. Replaced it with one upload step per tested package, each guarded by `if: hashFiles('packages/<pkg>/coverage/lcov.info') != ''` so it's a no-op when `turbo --affected` didn't regenerate that package's coverage. Switched to `use_oidc: true` (added `permissions.id-token: write` to the job) and dropped the `CODECOV_TOKEN` secret dependency, since that secret is unavailable to Dependabot/fork PRs (the root cause named in #480).
- The `packages/react-native-payments/readme.md` flag badge already uses the correct shields.io flag query (`?flag=react-native-payments&label=coverage`); it was rendering `unknown` only because CI never tagged an upload with that flag. No readme change needed — it will resolve once this workflow lands and uploads real data.

## Evidence

- `codecov.yml` validated: `curl --data-binary @codecov.yml https://codecov.io/validate` → `Valid!`
- `.github/workflows/pr.yml` validated with `actionlint` (no errors).
- `yarn test:coverage` run from repo root after `yarn build`; every one of the 19 packages with a `test:coverage` script produced `packages/<pkg>/coverage/lcov.info`, matching exactly the 19 flags in `codecov.yml` and the 19 upload steps added to the workflow:
  `decorators-core, eslint-plugin, fast-style, histogram-metric-decorator, lock-decorator, log-decorator, nestjs-enterprise, nestjs-rxjs-lock, nestjs-rxjs-logger, nestjs-rxjs-metrics, nestjs-rxjs-redis, nestjs-typed-config, object-field-tree, platform, react-native-payments, redux-loadable, rxjs-errors, shared, wdio`.
- `yarn ts && yarn lint && yarn test` all pass from repo root (only pre-existing lint warnings, zero errors).

## Test plan

- [ ] CI run on this PR: confirm the guarded upload steps fire for whichever packages `turbo --affected` touches and no step fails on a missing lcov file.
- [ ] After merge to `master`, confirm Codecov shows per-flag coverage and the `react-native-payments` readme badge stops rendering `unknown`.
- [ ] Verify a Dependabot/fork PR can upload via OIDC without `CODECOV_TOKEN` (out of scope for this PR to force-verify; tracked by the parent issue's remaining acceptance criteria).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated code-quality checks with more reliable coverage reporting.
  * Added package-level coverage results and clearer status requirements.
  * Standardized coverage targets, precision, and rounding across supported packages.
  * Coverage results now persist across builds and provide more focused change reports.
  * Pull request coverage summaries are more consistent, with stricter validation and improved handling for external contributions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rewrite codecov.yml flags and wire OIDC upload in CI
> - Replaces a single bulk Codecov upload step in [pr.yml](.github/workflows/pr.yml) with per-package conditional steps, each checking for the package's `lcov.info` before uploading and tagging with the package name as a flag.
> - Adds OIDC support (`use_oidc: true`) and `permissions.id-token: write`; on forked PRs, upload failures do not fail the job.
> - Rewrites [codecov.yml](https://github.com/rnw-community/rnw-community/pull/482/files#diff-3e878d9bdc47f29a0ab909a7db939acf08d2d2f1aaba81e6f897b32361fa40db) to define per-flag project and patch coverage targets/thresholds for each package, enables `carryforward: true` on all flags, and sets a condensed PR comment layout.
> - Removes the `hoverable` and `nestjs-webpack-swc` flag entries and adds new entries including `fast-style` and `react-native-payments` (100% target).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 253ac4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->