### PR TITLE
docs: add codecov flag badges to package readmes

### DIFF
--- a/packages/fast-style/readme.md
+++ b/packages/fast-style/readme.md
@@ -3,6 +3,7 @@
 Utility library for rapid React Native styling.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Ffast-style.svg)](https://badge.fury.io/js/%40rnw-community%2Ffast-style)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=fast-style&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Ffast-style.svg)](https://www.npmjs.com/package/%40rnw-community%2Ffast-style)
 
 Library using [@rnw-community/object-field-tree](https://www.npmjs.com/package/@rnw-community/object-field-tree) package for

--- a/packages/nestjs-rxjs-lock/readme.md
+++ b/packages/nestjs-rxjs-lock/readme.md
@@ -5,6 +5,7 @@ NestJS
 using [Redlock](https://github.com/mike-marcacci/node-redlock)
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Fnestjs-rxjs-lock.svg)](https://badge.fury.io/js/%40rnw-community%2Fnestjs-rxjs-lock)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=nestjs-rxjs-lock&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fnestjs-rxjs-lock.svg)](https://www.npmjs.com/package/%40rnw-community%2Fnestjs-rxjs-lock)
 
 ## TODO

--- a/packages/nestjs-rxjs-logger/readme.md
+++ b/packages/nestjs-rxjs-logger/readme.md
@@ -3,6 +3,7 @@
 NestJS default logger wrapper for using with RxJS streams.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Fnestjs-rxjs-logger.svg)](https://badge.fury.io/js/%40rnw-community%2Fnestjs-rxjs-logger)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=nestjs-rxjs-logger&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fnestjs-rxjs-logger.svg)](https://www.npmjs.com/package/%40rnw-community%2Fnestjs-rxjs-logger)
 
 ## Supported log levels

--- a/packages/nestjs-rxjs-metrics/readme.md
+++ b/packages/nestjs-rxjs-metrics/readme.md
@@ -3,6 +3,7 @@
 NestJS prometheus metrics wrapper for using with RxJS streams with full TypeScript support.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Fnestjs-rxjs-metrics.svg)](https://badge.fury.io/js/%40rnw-community%2Fnestjs-rxjs-metrics)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=nestjs-rxjs-metrics&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fnestjs-rxjs-metrics.svg)](https://www.npmjs.com/package/%40rnw-community%2Fnestjs-rxjs-metrics)
 
 ## Installation

--- a/packages/nestjs-rxjs-redis/readme.md
+++ b/packages/nestjs-rxjs-redis/readme.md
@@ -3,6 +3,7 @@
 NestJS redis wrapper for using with RxJS streams.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Fnestjs-rxjs-redis.svg)](https://badge.fury.io/js/%40rnw-community%2Fnestjs-rxjs-redis)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=nestjs-rxjs-redis&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fnestjs-rxjs-redis.svg)](https://www.npmjs.com/package/%40rnw-community%2Fnestjs-rxjs-redis)
 
 ## TODO

--- a/packages/nestjs-typed-config/readme.md
+++ b/packages/nestjs-typed-config/readme.md
@@ -3,6 +3,7 @@
 NestJS typed configuration with full TypeScript support.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Fnestjs-typed-config.svg)](https://badge.fury.io/js/%40rnw-community%2Fnestjs-typed-config)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=nestjs-typed-config&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fnestjs-typed-config.svg)](https://www.npmjs.com/package/%40rnw-community%2Fnestjs-typed-config)
 
 ## Installation

--- a/packages/nestjs-webpack-swc/readme.md
+++ b/packages/nestjs-webpack-swc/readme.md
@@ -4,6 +4,7 @@ NestJS webpack and SWC configuration helpers, this can speed up your local NestJ
 [10x](https://docs.nestjs.com/recipes/swc).
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Fnestjs-webpack-swc.svg)](https://badge.fury.io/js/%40rnw-community%2Fnestjs-webpack-swc)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=nestjs-webpack-swc&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fnestjs-webpack-swc.svg)](https://www.npmjs.com/package/%40rnw-community%2Fnestjs-webpack-swc)
 
 -   [NestJS](https://docs.nestjs.com) offers [Webpack](https://webpack.js.org) configuration with [HMR](https://docs.nestjs.com/recipes/hot-reload) which significantly

--- a/packages/object-field-tree/readme.md
+++ b/packages/object-field-tree/readme.md
@@ -4,6 +4,7 @@ Utility for generating complex nested objects with data generation callback and 
 with IDE autocompletion.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Fobject-field-tree.svg)](https://badge.fury.io/js/%40rnw-community%2Fobject-field-tree)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=object-field-tree&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fobject-field-tree.svg)](https://www.npmjs.com/package/%40rnw-community%2Fobject-field-tree)
 
 `combine((...keys) => data, ...objects)`

--- a/packages/platform/readme.md
+++ b/packages/platform/readme.md
@@ -3,6 +3,7 @@
 Platform specific helpers and utils for react native web.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Fredux-loadable.svg)](https://badge.fury.io/js/%40rnw-community%2Fredux-loadable)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=platform&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fredux-loadable.svg)](https://www.npmjs.com/package/%40rnw-community%2Fredux-loadable)
 
 ### Platform constants

--- a/packages/redux-loadable/readme.md
+++ b/packages/redux-loadable/readme.md
@@ -4,6 +4,7 @@ Generic redux loading state, selectors and utils for sending requests and handli
 Library supports redux-toolkit and other class redux approaches.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Fredux-loadable.svg)](https://badge.fury.io/js/%40rnw-community%2Fredux-loadable)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=redux-loadable&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fredux-loadable.svg)](https://www.npmjs.com/package/%40rnw-community%2Fredux-loadable)
 
 Supported loading states:

--- a/packages/rxjs-errors/readme.md
+++ b/packages/rxjs-errors/readme.md
@@ -3,6 +3,7 @@
 Utils that help work with errors in rxjs observable's.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Frxjs-errors.svg)](https://badge.fury.io/js/%40rnw-community%2Frxjs-errors)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=rxjs-errors&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Frxjs-errors.svg)](https://www.npmjs.com/package/%40rnw-community%2Frxjs-errors)
 
 ## Classes

--- a/packages/shared/readme.md
+++ b/packages/shared/readme.md
@@ -3,6 +3,7 @@
 Generic types, type guards and utilities commonly used across packages.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Fshared.svg)](https://badge.fury.io/js/%40rnw-community%2Fshared)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=shared&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fshared.svg)](https://www.npmjs.com/package/%40rnw-community%2Fshared)
 
 ## Type guards

--- a/packages/wdio/readme.md
+++ b/packages/wdio/readme.md
@@ -3,6 +3,7 @@
 WDIO commands and utils.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Fwdio.svg)](https://badge.fury.io/js/%40rnw-community%2Fwdio)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=wdio&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fwdio.svg)](https://www.npmjs.com/package/%40rnw-community%2Fwdio)
 
 ## TODO


### PR DESCRIPTION
## Summary
- Adds the `[![coverage](...)]` codecov flag badge to the readme of every package that already has a matching flag defined in `codecov.yml` but was missing the badge, following the exact markup/placement used by `packages/react-native-payments/readme.md` (inserted right after the npm version badge, before npm downloads).
- Touched readmes: `fast-style`, `nestjs-rxjs-lock`, `nestjs-rxjs-logger`, `nestjs-rxjs-metrics`, `nestjs-rxjs-redis`, `nestjs-typed-config`, `nestjs-webpack-swc`, `object-field-tree`, `platform`, `redux-loadable`, `rxjs-errors`, `shared`, `wdio`.
- `react-native-payments/readme.md` was intentionally left untouched (already has the badge; also #499 is open and rewrites that file).

## Notes / scope decisions
- Issue #487's checklist also lists `decorators-core`, `eslint-plugin`, `histogram-metric-decorator`, `lock-decorator`, `log-decorator`, and `nestjs-enterprise`, but none of these have a corresponding flag in `codecov.yml` today — no badge was added for them per the "don't invent flags" rule. Filing a follow-up on #480 to wire flags for these packages is recommended before their badges can be added.
- `codecov.yml` also defines a `hoverable` flag with no corresponding package directory in the monorepo — likely stale/renamed; also worth a follow-up on #480, out of scope here.
- Sampled 4 badge URLs after pushing (`shared`, `platform`, `fast-style`, `react-native-payments` for comparison) — all return HTTP 200 from shields.io, but every one currently renders `coverage: unknown`, including the pre-existing `react-native-payments` badge. This is expected: flags only report real data once the upload workflow runs against `master` with these flags; it is not a defect in this change.

## Test plan
- [x] `yarn lint` passes for all 13 touched packages (0 errors; only pre-existing unrelated warnings in `platform`/`decorators-core`). The one lint failure in the full run is in `react-native-payments` source code, untouched by this PR and pre-existing on `master`.
- [x] Confirmed each added `flag=` value matches its package's flag key in `codecov.yml` exactly.
- [x] Confirmed badge markup/order matches the `react-native-payments` template (npm version → coverage → npm downloads).

Refs #487

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Codecov coverage badges to all package READMEs
> Adds a Codecov flag badge below the npm version badge in each of the 13 package READMEs. Each badge links to the package-specific coverage report on Codecov.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cebc3c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->