### PR TITLE
ci: cancel a closed pull request's queued workflow runs

### DIFF
--- a/.github/workflows/pr-closed-cleanup.yml
+++ b/.github/workflows/pr-closed-cleanup.yml
@@ -1,0 +1,50 @@
+name: PR Closed Cleanup
+
+on:
+    pull_request:
+        types: [closed]
+
+jobs:
+    cancel-queued-runs:
+        name: Cancel queued/in-progress runs for the closed PR branch
+        runs-on: ubuntu-latest
+        permissions:
+            actions: write
+
+        steps:
+            -   name: Cancel queued and in-progress runs for this branch
+                env:
+                    GH_TOKEN: ${{ github.token }}
+                    HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+                    CURRENT_RUN_ID: ${{ github.run_id }}
+                run: |
+                    set -euo pipefail
+
+                    for status in queued in_progress; do
+                      page=1
+                      while :; do
+                        response=$(gh api \
+                          "repos/${{ github.repository }}/actions/runs?branch=${HEAD_BRANCH}&status=${status}&per_page=100&page=${page}")
+
+                        run_count=$(echo "$response" | jq '.workflow_runs | length')
+                        if [ "$run_count" -eq 0 ]; then
+                          break
+                        fi
+
+                        echo "$response" | jq -r --arg repo "${{ github.repository }}" --arg current "$CURRENT_RUN_ID" '
+                          .workflow_runs[]
+                          | select(.head_repository.full_name == $repo)
+                          | select((.id | tostring) != $current)
+                          | .id
+                        ' | while read -r run_id; do
+                          echo "Cancelling run ${run_id}"
+                          gh api --method POST \
+                            "repos/${{ github.repository }}/actions/runs/${run_id}/cancel" || true
+                        done
+
+                        if [ "$run_count" -lt 100 ]; then
+                          break
+                        fi
+                        page=$((page + 1))
+                      done
+                    done

--- a/.github/workflows/pr-closed-cleanup.yml
+++ b/.github/workflows/pr-closed-cleanup.yml
@@ -17,6 +17,7 @@ jobs:
                     GH_TOKEN: ${{ github.token }}
                     HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
                     CURRENT_RUN_ID: ${{ github.run_id }}
+                    PR_NUMBER: ${{ github.event.pull_request.number }}
                 run: |
                     set -euo pipefail
 
@@ -38,9 +39,11 @@ jobs:
                           -f "per_page=100" \
                           -f "page=1")
 
-                        cancellable_ids=$(echo "$response" | jq -r --arg repo "${{ github.repository }}" --arg current "$CURRENT_RUN_ID" '
+                        cancellable_ids=$(echo "$response" | jq -r --arg repo "${{ github.repository }}" --arg current "$CURRENT_RUN_ID" --argjson pr_number "$PR_NUMBER" '
                           [.workflow_runs[]
                             | select(.head_repository.full_name == $repo)
+                            | select(.event == "pull_request")
+                            | select([.pull_requests[]?.number] | index($pr_number))
                             | select((.id | tostring) != $current)
                             | .id
                           ] | .[]

--- a/.github/workflows/pr-closed-cleanup.yml
+++ b/.github/workflows/pr-closed-cleanup.yml
@@ -20,31 +20,40 @@ jobs:
                 run: |
                     set -euo pipefail
 
-                    for status in queued in_progress; do
-                      page=1
-                      while :; do
-                        response=$(gh api \
-                          "repos/${{ github.repository }}/actions/runs?branch=${HEAD_BRANCH}&status=${status}&per_page=100&page=${page}")
+                    max_iterations=20
 
-                        run_count=$(echo "$response" | jq '.workflow_runs | length')
-                        if [ "$run_count" -eq 0 ]; then
+                    for status in queued in_progress; do
+                      iteration=0
+                      while :; do
+                        iteration=$((iteration + 1))
+                        if [ "$iteration" -gt "$max_iterations" ]; then
+                          echo "Reached max iterations (${max_iterations}) for status=${status}, stopping."
                           break
                         fi
 
-                        echo "$response" | jq -r --arg repo "${{ github.repository }}" --arg current "$CURRENT_RUN_ID" '
-                          .workflow_runs[]
-                          | select(.head_repository.full_name == $repo)
-                          | select((.id | tostring) != $current)
-                          | .id
-                        ' | while read -r run_id; do
+                        response=$(gh api --method GET \
+                          "repos/${{ github.repository }}/actions/runs" \
+                          -f "branch=${HEAD_BRANCH}" \
+                          -f "status=${status}" \
+                          -f "per_page=100" \
+                          -f "page=1")
+
+                        cancellable_ids=$(echo "$response" | jq -r --arg repo "${{ github.repository }}" --arg current "$CURRENT_RUN_ID" '
+                          [.workflow_runs[]
+                            | select(.head_repository.full_name == $repo)
+                            | select((.id | tostring) != $current)
+                            | .id
+                          ] | .[]
+                        ')
+
+                        if [ -z "$cancellable_ids" ]; then
+                          break
+                        fi
+
+                        echo "$cancellable_ids" | while read -r run_id; do
                           echo "Cancelling run ${run_id}"
                           gh api --method POST \
                             "repos/${{ github.repository }}/actions/runs/${run_id}/cancel" || true
                         done
-
-                        if [ "$run_count" -lt 100 ]; then
-                          break
-                        fi
-                        page=$((page + 1))
                       done
                     done


### PR DESCRIPTION
## Summary

The self-hosted Maestro fleet (Android + iOS e2e) has only 2 serialized runners.
Concurrency groups only cancel superseded runs on the *same* branch — nothing
reacts to a PR closing. When a PR is closed (merged or abandoned), any runs it
had queued or in progress stay in the queue and starve live PRs waiting for a
runner. This was observed directly: roughly 20 zombie runs left behind by
closed dependabot PRs and already-merged branches were clogging the queue.

- Add `.github/workflows/pr-closed-cleanup.yml`, triggered on
  `pull_request: types: [closed]`.
- List queued and in-progress workflow runs for the closed PR's head branch via
  `gh api`, paginated, filtered to runs owned by this repository (never touch
  fork-owned runs) and excluding the current run, then cancel each one.
- No third-party actions and no checkout — everything runs through
  `gh api` with `GH_TOKEN: ${{ github.token }}`, keeping the job's permissions
  to `actions: write` only.
- The head branch name is passed through `env` rather than interpolated
  directly into the script, since branch names are attacker-controlled.

Refs #500

## Test plan

- [x] `actionlint` (with shellcheck) passes on the new workflow
- [ ] Observe the workflow cancel queued runs on the next closed PR

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cancel queued and in-progress workflow runs when a pull request is closed
> Adds a new GitHub Actions workflow ([pr-closed-cleanup.yml](.github/workflows/pr-closed-cleanup.yml)) that triggers on PR close events and cancels any remaining queued or in-progress runs for that PR's head branch. A bash script polls the Actions API (up to 20 iterations per status) filtering by repository, event type, PR number, and branch, then POSTs a cancel request for each matching run excluding the current one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4843c64.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated cleanup for queued or in-progress workflows when a pull request closes.
  * Prevents unnecessary workflow runs from continuing after the associated pull request is closed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->