### PR TITLE
docs: add codecov flag badges to decorator and nestjs-enterprise readmes

### DIFF
--- a/packages/decorators-core/readme.md
+++ b/packages/decorators-core/readme.md
@@ -3,6 +3,7 @@
 Framework-agnostic middleware primitive for building method decorators (log, metrics, lock, retry, …). Depends only on [`@rnw-community/shared`](https://github.com/rnw-community/rnw-community/tree/master/packages/shared) for its `MethodDecoratorType<K>` primitive. TypeScript `experimentalDecorators`. Dual ESM + CJS.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Fdecorators-core.svg)](https://badge.fury.io/js/%40rnw-community%2Fdecorators-core)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=decorators-core&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fdecorators-core.svg)](https://www.npmjs.com/package/%40rnw-community%2Fdecorators-core)
 
 ## The primitive

--- a/packages/eslint-plugin/readme.md
+++ b/packages/eslint-plugin/readme.md
@@ -3,6 +3,7 @@
 Elevate your React/ReactNative projects with our [ESLint](https://eslint.org) plugin, meticulously crafted to ensure adherence to the best practices in the industry.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Feslint-plugin.svg)](https://badge.fury.io/js/%40rnw-community%2Feslint-plugin)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=eslint-plugin&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Feslint-plugin.svg)](https://www.npmjs.com/package/%40rnw-community%2Feslint-plugin)
 
 ## Notable Rule: no-complex-jsx-logic

--- a/packages/histogram-metric-decorator/readme.md
+++ b/packages/histogram-metric-decorator/readme.md
@@ -3,6 +3,7 @@
 Framework-agnostic method decorator that records call duration into any histogram transport (Prometheus, OpenTelemetry, in-memory, …). Built on [`@rnw-community/decorators-core`](https://github.com/rnw-community/rnw-community/tree/master/packages/decorators-core). Handles sync, `Promise`, and `Observable` return types with a single decorator. TypeScript `experimentalDecorators`.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Fhistogram-metric-decorator.svg)](https://badge.fury.io/js/%40rnw-community%2Fhistogram-metric-decorator)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=histogram-metric-decorator&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fhistogram-metric-decorator.svg)](https://www.npmjs.com/package/%40rnw-community%2Fhistogram-metric-decorator)
 
 ## When the observation fires

--- a/packages/lock-decorator/readme.md
+++ b/packages/lock-decorator/readme.md
@@ -3,6 +3,7 @@
 Framework-agnostic sequential and exclusive method lock decorators. Promise and Observable return shapes both supported. TypeScript `experimentalDecorators`. Dual ESM + CJS. `rxjs` is an optional peer — required only when using the `$`-suffixed Observable factories or `createLockMiddleware$`.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Flock-decorator.svg)](https://badge.fury.io/js/%40rnw-community%2Flock-decorator)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=lock-decorator&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Flock-decorator.svg)](https://www.npmjs.com/package/%40rnw-community/lock-decorator)
 
 ## The four decorator factories

--- a/packages/log-decorator/readme.md
+++ b/packages/log-decorator/readme.md
@@ -3,6 +3,7 @@
 Universal method decorator with pre / post / error logging hooks and a pluggable transport. Built on [`@rnw-community/decorators-core`](https://github.com/rnw-community/rnw-community/tree/master/packages/decorators-core). Handles sync, `Promise`, and `Observable` return types automatically. TypeScript `experimentalDecorators`.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Flog-decorator.svg)](https://badge.fury.io/js/%40rnw-community%2Flog-decorator)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=log-decorator&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Flog-decorator.svg)](https://www.npmjs.com/package/%40rnw-community%2Flog-decorator)
 
 ## When each hook fires

--- a/packages/nestjs-enterprise/readme.md
+++ b/packages/nestjs-enterprise/readme.md
@@ -3,6 +3,7 @@
 NestJS enterprise is a collection of tools and utilities to help you build enterprise-grade applications with NestJS.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Fnestjs-enterprise.svg)](https://badge.fury.io/js/%40rnw-community%2Fnestjs-enterprise)
+[![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=nestjs-enterprise&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fnestjs-enterprise.svg)](https://www.npmjs.com/package/%40rnw-community%2Fnestjs-enterprise)
 
 


### PR DESCRIPTION
## Summary
- Follow-up to #506: PR #482 merged the codecov rewrite to master, adding the six previously-missing flags (`decorators-core`, `eslint-plugin`, `histogram-metric-decorator`, `lock-decorator`, `log-decorator`, `nestjs-enterprise`) to `codecov.yml` and removing the stale `hoverable` flag.
- Adds the `[![coverage](...)]` codecov flag badge to each of those six packages' readmes, using the same markup/placement as #506 (right after the npm version badge, before npm downloads), matching the `packages/react-native-payments/readme.md` template.
- Touched readmes: `decorators-core`, `eslint-plugin`, `histogram-metric-decorator`, `lock-decorator`, `log-decorator`, `nestjs-enterprise`.
- `react-native-payments/readme.md` was not touched (already has the badge; #499 remains open rewriting that file).
- This completes issue #487's checklist — every package with a codecov flag now has the badge in its readme.

## Verification
- Confirmed all six flags exist in `codecov.yml` on `origin/master` (post-#482 merge) before making any edits.
- `yarn lint` (scoped to the six touched packages) passes with 0 errors — only pre-existing, unrelated warnings (`id-length` in `decorators-core`, `promise/no-nesting` in `lock-decorator`).

## Test plan
- [x] Verified each `flag=` value matches its package's flag key in `codecov.yml` exactly.
- [x] Verified badge markup/order matches the `react-native-payments` template.
- [x] `yarn lint` passes for all six touched packages.

Refs #487

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Codecov coverage badges to decorator and nestjs-enterprise READMEs
> Adds shields.io Codecov badges with package-specific flags to the READMEs of `decorators-core`, `eslint-plugin`, `histogram-metric-decorator`, `lock-decorator`, `log-decorator`, and `nestjs-enterprise`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f03270.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added test coverage badges to documentation for several packages.
  * Coverage reports are now easier to discover from each package’s README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->