### PR TITLE
docs: deepen per-package agent architecture notes

### DIFF
--- a/packages/decorators-core/AGENTS.md
+++ b/packages/decorators-core/AGENTS.md
@@ -10,7 +10,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   interface/
     execution-context.interface.ts        — ExecutionContextInterface<TArgs>: { className, methodName, args, logContext }

--- a/packages/decorators-core/AGENTS.md
+++ b/packages/decorators-core/AGENTS.md
@@ -1,15 +1,11 @@
 # @rnw-community/decorators-core
 
-Framework-agnostic interceptor primitive for building method decorators. Ships `createInterceptor` — a factory for `experimentalDecorators` method decorators — plus four built-in result strategies: `syncStrategy`, `promiseStrategy`, `observableStrategy`, and `completionObservableStrategy`.
+Framework-agnostic interceptor primitive: wraps a decorated method's descriptor so every invocation is routed through one consumer-supplied middleware hook.
 
 ## Package Commands
 
 ```bash
-yarn test               # Run tests
-yarn test:coverage      # Tests with coverage
-yarn build              # Build (dual ESM + CJS)
-yarn ts                 # Type check
-yarn lint:fix           # Fix lint issues
+yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 ```
 
 ## Architecture
@@ -17,40 +13,35 @@ yarn lint:fix           # Fix lint issues
 ```
 src/
   interface/
-    execution-context.interface.ts
-    interceptor.interface.ts
-    result-strategy.interface.ts
-    create-interceptor-options.interface.ts
-  strategy/
-    sync-strategy/            — syncStrategy + spec (catch-all, zero deps)
-    promise-strategy/         — promiseStrategy + spec (zero deps)
-    observable-strategy/      — observableStrategy + spec (per-emission; rxjs peer)
-    completion-observable-strategy/ — completionObservableStrategy + spec (completion-latency; rxjs peer)
+    execution-context.interface.ts        — ExecutionContextInterface<TArgs>: { className, methodName, args, logContext }
+    interceptor-middleware.interface.ts    — InterceptorMiddleware<TArgs, TResult> = (context, next: () => TResult) => TResult
+    create-interceptor-options.interface.ts — CreateInterceptorOptionsInterface<TArgs, TResult>: { middleware }
   engine/
-    build-context/            — buildContext + spec
-    run-interception/         — runInterception + spec
-    create-interceptor/       — createInterceptor + spec
+    build-context/       — buildContext(self, fallbackClassName, methodName, args) + spec
+    create-interceptor/  — createInterceptor(options) + spec
+  util/
+    resolve-fallback-class-name/ — resolveFallbackClassName(target) + spec
   index.ts
 ```
 
-`MethodDecoratorType<K>` is owned by `@rnw-community/shared` — not re-exported from this package.
+Public export surface (`index.ts`): `ExecutionContextInterface`, `InterceptorMiddleware`, `CreateInterceptorOptionsInterface` (types) and `createInterceptor` (value). Nothing else — there is no `strategy/` directory and no `runInterception` engine step; the whole contract collapsed to one middleware hook.
 
-## Key Patterns
+### Key Patterns
 
-- One entity per file; folders only to group `source + spec` (+ optional `.md`)
-- `onSuccess` receives `Awaited<TResult>` (the resolved value, not the raw Promise)
-- Per-invocation `ExecutionContext` identity is stable across `onEnter`/`onSuccess`/`onError` — consumers depend on this
-- Hook errors are swallowed inside the engine — transport failures never poison the decorated method
-- Strategies are passed as an immutable factory option (no global mutation registry)
-- **Engine is a strategy coordinator.** `createInterceptor` builds a dispatch chain `[...userStrategies, promiseStrategy, syncStrategy]`; the engine finds the first matching strategy and delegates. `syncStrategy.matches` returns `true` unconditionally (terminal catch-all)
-- Promise and sync handling auto-wired via the built-in strategies; Observable support requires opting into `observableStrategy` or `completionObservableStrategy`
-- `ResultStrategyInterface.handle` MUST NOT throw synchronously — exceptions propagate unguarded past `onError`
+- **The entire interceptor contract is one middleware function**: `(context, next) => TResult`. There are no built-in `onEnter`/`onSuccess`/`onError` hooks and no `syncStrategy`/`promiseStrategy`/`observableStrategy`/`completionObservableStrategy` — those existed in an earlier version of this package and are gone. A middleware that needs to branch on whether `next()` returned a sync value, a `Promise`, or an `Observable` does so itself, typically with `isPromise` from `@rnw-community/shared` and rxjs's `isObservable` (this is exactly what `log-decorator` and `histogram-metric-decorator` do internally).
+- `createInterceptor` wraps `descriptor.value`; if the original property isn't a function, the descriptor is returned unchanged (getters/setters/non-method values pass through untouched).
+- Per-invocation `className` resolution (`buildContext`) is dynamic, not fixed at decoration time: given the `this` value at call time (`self`), it returns `null` for `null`/`undefined`/`globalThis`, the function's own `.name` when `self` is itself a function (static-method call context), otherwise `self.constructor.name`; an empty resolved name is treated the same as no name. Only when none of those apply does it fall back to `fallbackClassName`.
+- `fallbackClassName` is resolved once at decoration time by `resolveFallbackClassName(target)`: the decorated class's own `.name` if `target` is a function with a non-empty name, else `target.constructor.name`, else the literal string `'Object'`.
+- `logContext` is always `` `${className}::${methodName}` ``, recomputed on every call (never memoized), so the same decorated method reports a different `className` when invoked with a different `this` (e.g. via `.call`/`.apply` or a subclass instance).
+- `createInterceptor` never wraps, swallows, or inspects errors — whatever the middleware throws, rejects, or emits propagates unchanged. Resource setup/teardown (e.g. acquire-then-release) is entirely the middleware's responsibility, expressed as a try/finally around `next()` for Promises or an unsubscribe/teardown callback for Observables; this is the composition idiom `lock-decorator`'s `createLockMiddleware`/`createLockMiddleware$` build on directly.
+- A middleware may short-circuit without ever calling `next()` (e.g. a guard that rejects before the method runs).
 
-## Dependencies
+### Dependencies
 
-- `@rnw-community/shared` — `isPromise`, `isDefined`, `EmptyFn`, `emptyFn`, `isNotEmptyString`, `MethodDecoratorType`
-- **Optional peer**: `rxjs` (only needed when importing `observableStrategy` or `completionObservableStrategy`)
+- `@rnw-community/shared` — `isDefined`, `isNotEmptyString` (runtime), `AnyFn`, `MethodDecoratorType` (types)
+- **Optional peer**: `rxjs` — not imported anywhere in `src/`; declared as an optional peer/dev dependency purely because `create-interceptor.spec.ts` exercises Observable-shaped `next()` return values to prove the engine is shape-agnostic
+- **Optional peer**: `typescript` (`>=5.2.0`)
 
-## Coverage
+### Coverage
 
-Default monorepo threshold: **99.9%** on all metrics. Currently **100%**.
+Default monorepo threshold: **99.9%** on all metrics (statements, branches, functions, lines).

--- a/packages/eslint-plugin/AGENTS.md
+++ b/packages/eslint-plugin/AGENTS.md
@@ -1,6 +1,6 @@
 # @rnw-community/eslint-plugin
 
-Custom ESLint plugin with JSX code quality rules. Currently ships one rule: `no-complex-jsx-logic`.
+Custom ESLint plugin with JSX code-quality rules. Currently ships exactly one rule: `no-complex-jsx-logic`.
 
 ## Package Commands
 
@@ -12,33 +12,49 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ```
 src/
-  index.ts       — Plugin definition (export = plugin, CommonJS interop for ESLint)
+  index.ts       — plugin object (meta, configs.recommended, configs['flat/recommended'], rules); `export = plugin`
   rules/
-    index.ts     — Aggregates all rules
+    index.ts     — rules = { 'no-complex-jsx-logic': noComplexJsxLogicRule } satisfies Record<string, TSESLint.RuleModule<...>>
     no-complex-jsx-logic/
-      no-complex-jsx-logic.rule.ts   — AST visitor (JSXExpressionContainer in JSXAttribute context)
-      no-complex-jsx-logic.spec.ts   — RuleTester valid/invalid cases
-      no-complex-jsx-logic.md        — Rule documentation
+      no-complex-jsx-logic.rule.ts   — the AST visitor, built with ESLintUtils.RuleCreator
+      no-complex-jsx-logic.spec.ts   — @typescript-eslint/rule-tester RuleTester valid/invalid cases
+      no-complex-jsx-logic.md        — human-facing rule documentation (overview, rationale, valid/invalid examples)
 ```
 
 ### Key Patterns
 
-- Uses `export = plugin` (CommonJS interop required by ESLint)
-- Ships both legacy (`recommended`) and flat config (`flat/recommended`) presets
-- Namespace derived from package.json name: `@rnw-community`
-- Rule only acts on `JSXAttribute` context (prop values) — JSX children are unaffected
-- Banned in JSX props: arrow functions, ternary, `&&`/`||` (not `??`), binary ops (not `===`/`!==`), inline objects/arrays
-- Tests use `@typescript-eslint/rule-tester`'s `RuleTester`
+- `src/index.ts` ends with `export = plugin` — required CommonJS interop shape for an ESLint plugin object; this is
+  the reason `verbatimModuleSyntax` is disabled for this package (see TypeScript Config below)
+- The plugin's `namespace` is derived at runtime from `pkg.name.split('/')[0]` (falls back to the literal
+  `'@rnw-community'` string if that split ever comes back empty), then used to key both config presets:
+  `configs.recommended` (legacy eslintrc array, `parserOptions.ecmaFeatures.jsx: true`) and
+  `configs['flat/recommended']` (flat-config array, `languageOptions.parserOptions.ecmaFeatures.jsx: true` and a
+  `plugins: { [namespace]: plugin }` self-reference) — both presets exist in source and both enable
+  `${namespace}/no-complex-jsx-logic` as `'error'`
+- `noComplexJsxLogicRule`'s visitor only fires on `JSXExpressionContainer` nodes whose `parent.type` is
+  `JSXAttribute` — i.e. it inspects prop values only; JSX children expressions are never visited
+- Exactly six message IDs, each tied to one AST shape inside a JSX prop: `ArrowFunctionExpression` →
+  `noInlineCallbacks`; `BinaryExpression` whose operator is not `===`/`!==` → `noPropsCalculations`;
+  `ConditionalExpression` → `noPropsTernary`; `LogicalExpression` whose operator is not `??` → `noPropsTernary`;
+  `ObjectExpression` → `noPropsInlineObjects`; `ArrayExpression` → `noPropsInlineArrays`. A `CallExpression` prop is
+  otherwise allowed, but is walked one level into its `arguments`, and any argument that is itself a
+  `ConditionalExpression` reports `noTernaryCallbackArguments`
+- Tests use `@typescript-eslint/rule-tester`'s `RuleTester` (flat-config-shaped constructor: `languageOptions.parserOptions`)
 
 ### TypeScript Config
 
-- Uses `moduleResolution: "nodenext"`, `module: "nodenext"` (overrides root)
-- `verbatimModuleSyntax: false` in tsconfig.json and both build configs (incompatible with `export =`)
+- `tsconfig.json` and both build configs (`tsconfig.build-esm.json`, `tsconfig.build-cjs.json`) override the root with
+  `moduleResolution`/`module` set to `nodenext`/`NodeNext`/`node16` variants and `verbatimModuleSyntax: false` —
+  the latter is required because `export = plugin` cannot coexist with `verbatimModuleSyntax: true`
 
 ### Dependencies
 
-`@typescript-eslint/utils`, `@typescript-eslint/rule-tester`. Peers: `eslint ^9`, `typescript-eslint ^8`.
+- `@typescript-eslint/utils` — `ESLintUtils.RuleCreator` and `TSESLint`/`AST_NODE_TYPES` used by the rule
+- `@typescript-eslint/rule-tester` — `RuleTester` used in the spec (listed as a production dependency, not a
+  devDependency, in this package's package.json)
+- Peers: `eslint` (^9), `typescript-eslint` (^8)
 
 ### Coverage
 
-Custom thresholds: statements **94.4%**, branches **88.8%**, functions **99.9%**, lines **94.1%**.
+This package overrides the monorepo default in its own `jest.config.js`:
+statements **94.4%**, branches **88.8%**, functions **99.9%**, lines **94.1%**.

--- a/packages/eslint-plugin/AGENTS.md
+++ b/packages/eslint-plugin/AGENTS.md
@@ -10,7 +10,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   index.ts       — plugin object (meta, configs.recommended, configs['flat/recommended'], rules); `export = plugin`
   rules/

--- a/packages/fast-style/AGENTS.md
+++ b/packages/fast-style/AGENTS.md
@@ -11,7 +11,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   enum/
     flex-direction.enum.ts         — FlexDirectionEnum (column, columnReverse, row, rowReverse)

--- a/packages/fast-style/AGENTS.md
+++ b/packages/fast-style/AGENTS.md
@@ -1,6 +1,7 @@
 # @rnw-community/fast-style
 
-Pre-computed lookup constants for React Native flex layout and font styling. Index into `Flex.row.center.center` instead of inline style objects.
+Pre-computed lookup constants for React Native flex layout and font styling. Index into `Flex.row.center.center`
+instead of building inline style objects.
 
 ## Package Commands
 
@@ -12,22 +13,34 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ```
 src/
-  enum/    — FlexDirectionEnum, FlexJustifyContentEnum, FlexAlignItemsEnum
-  flex/    — Flex constant (3D combine: direction x justifyContent x alignItems)
-  font/    — getFont<TFamily, TSize, TColor>(families, sizes, colors, additionalStyle?)
+  enum/
+    flex-direction.enum.ts         — FlexDirectionEnum (column, columnReverse, row, rowReverse)
+    flex-justify-content.enum.ts   — FlexJustifyContentEnum (center, flexEnd, flexStart, spaceAround, spaceBetween, spaceEvenly)
+    flex-align-items.enum.ts       — FlexAlignItemsEnum (baseline, center, flexEnd, flexStart, stretch)
+  flex/
+    flex.ts    — Flex constant: combine() over the 3 enums above, each leaf a { flexDirection, justifyContent, alignItems } style
+  font/
+    font.ts    — getFont(fontFamilyObj, fontSizeObj, fontColorObj, additionalStyle?) => nested TextStyle tree
+  index.ts     — re-exports the 3 enums, getFont, Flex
 ```
 
 ### Key Patterns
 
-- `Flex` is a compile-time constant computed once via `combine()` from `object-field-tree`
-- `getFont` returns a 3-level nested object of `TextStyle` values, keyed by user-provided enums
-- Font size values must be strings (not numbers) due to TypeScript enum reverse-mapping issues
+- `Flex` is a module-level constant computed once via `@rnw-community/object-field-tree`'s `combine()`; the data
+  function receives the three enum keys and looks each one up in its own enum to build the `TextStyle`-shaped leaf
+- `getFont` is generic over `TFamily`/`TSize`/`TColor` (each constrained to `Enum<...>`) and also builds its 3-level
+  tree via `combine()`; each leaf spreads a caller-supplied `additionalStyle: TextStyle = {}` after the computed
+  `fontFamily`/`fontSize`/`color`, so caller overrides win when keys collide
+- `getFont` throws `new Error('fontSizeObj must have string values')` before combining if any value in `fontSizeObj`
+  is a `number` — required because font sizes are read back with `parseInt(fontSizeObj[fontSize] as string, 10)`, and
+  a numeric TypeScript enum's reverse-mapping would otherwise silently double-map
 
 ### Dependencies
 
-`@rnw-community/object-field-tree`, `@rnw-community/shared`. Peers: `react`, `react-native`.
+- `@rnw-community/object-field-tree` — `combine()` and `CombineReturn3` powering both `Flex` and `getFont`
+- `@rnw-community/shared` — `Enum` constraint type for `getFont`'s generics
+- Peers: `react` (>=18), `react-native` (>=0.64) — `getFont` types against `react-native`'s `TextStyle`/`ColorValue`
 
 ### Coverage
 
-Default: **99.9%** all metrics.
-```
+Default monorepo threshold: 99.9% on all metrics.

--- a/packages/histogram-metric-decorator/AGENTS.md
+++ b/packages/histogram-metric-decorator/AGENTS.md
@@ -10,7 +10,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   interface/
     create-histogram-metric-options.interface.ts — CreateHistogramMetricOptionsInterface: { transport, onLabelsError? }

--- a/packages/histogram-metric-decorator/AGENTS.md
+++ b/packages/histogram-metric-decorator/AGENTS.md
@@ -1,15 +1,11 @@
 # @rnw-community/histogram-metric-decorator
 
-Framework-agnostic method decorator for recording call durations into any histogram transport. Built on `@rnw-community/decorators-core`. Targets TypeScript's `experimentalDecorators` mode.
+Transport-agnostic histogram/duration method decorator built on `@rnw-community/decorators-core`'s single-middleware interceptor. Targets TypeScript's `experimentalDecorators` mode. Zero opinion on the metrics backend — consumers wire their own `HistogramTransportInterface`.
 
 ## Package Commands
 
 ```bash
-yarn test               # Run tests
-yarn test:coverage      # Tests with coverage
-yarn build              # Build (dual ESM + CJS)
-yarn ts                 # Type check
-yarn lint:fix           # Fix lint issues
+yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 ```
 
 ## Architecture
@@ -17,33 +13,32 @@ yarn lint:fix           # Fix lint issues
 ```
 src/
   interface/
-    create-histogram-metric-options.interface.ts
-    histogram-options.interface.ts
-    histogram-transport.interface.ts
+    create-histogram-metric-options.interface.ts — CreateHistogramMetricOptionsInterface: { transport, onLabelsError? }
+    histogram-options.interface.ts                — HistogramOptionsInterface<TArgs>: { name?, labels? }
+    histogram-transport.interface.ts               — HistogramTransportInterface: observe(name, durationMs, labels?)
   factory/
-    create-histogram-metric-decorator/      — decorator factory + spec
-  transport/
-    in-memory-histogram-transport.mock.ts       — test-only transport (not shipped)
-    in-memory-histogram-transport.mock.spec.ts
+    create-histogram-metric-decorator/ — createHistogramMetricDecorator(options) factory + spec
   index.ts
 ```
 
-The in-memory transport lives as a `*.mock.ts` helper so the dist stays transport-agnostic. Build tsconfigs exclude `**/*.mock.*`, and the monorepo jest config's `coveragePathIgnorePatterns: ['.mock.ts']` keeps it out of coverage reports.
+There is no `transport/` directory and no `*.mock.ts` in-memory transport shipped in `src/`. The spec builds its own throwaway in-memory `HistogramTransportInterface` fixture inline (`createInMemoryTransport`), per the monorepo's rule that test-only fixtures live inside the spec that needs them.
 
-## Key Patterns
+### Key Patterns
 
-- One entity per file; folders only to group `source + spec` (+ optional `.md`)
-- Observation emitted on BOTH success and error paths (via `onSuccess` + `onError` engine hooks)
-- Metric name defaults to `<ClassName>_<methodName>_duration_ms` when omitted; consumer can override via `{ name }`
-- Sync returns emit on return; Promise returns emit on settle (resolve or reject); Observable returns emit one observation on stream `complete` or `error` via `completionObservableStrategy` from `@rnw-community/decorators-core` (wired by default in the factory)
-- `labels` is a function that receives the method's args as a tuple — inferred from the method signature, no annotations required
+- The single middleware (`buildHistogramMiddleware`) measures elapsed time with `performance.now()` at entry and calls `transport.observe(...)` on the terminal event, branching by hand on `next()`'s return shape with `isPromise` (from `@rnw-community/shared`) and `isObservable` (from `rxjs`) — the same one-middleware-covers-every-shape pattern as `log-decorator`; there is no `completionObservableStrategy` import from `decorators-core` (that strategy no longer exists).
+- Default metric name is `` `${className}_${methodName}_duration_ms` ``, read off `ExecutionContextInterface`, unless `config.name` is supplied.
+- Sync and Promise-returning methods emit exactly one observation, on return or on settle (resolve **or** reject) — duration is measured even when the method throws/rejects.
+- Observable-returning methods emit exactly one observation on stream `complete` **or** `error` (via `tap({ complete })` + `catchError`), regardless of how many values were emitted in between — including a stream that completes without ever emitting.
+- `labels` resolution is defensive: `resolveLabelsSafely` wraps the `labels(args)` call in try/catch. A thrown error means the observation is still recorded, just without labels, and the error is forwarded to the optional `onLabelsError(err, args)` hook — which is itself wrapped in try/catch so a broken hook can never block the observation or crash the decorated method.
+- `labels` receives the method's argument tuple as a single array parameter (`(args: TArgs) => ({...})` — array form), the same convention `lock-decorator`'s key resolvers use, distinct from `log-decorator`'s spread form (`(...args) => ...`).
 
-## Dependencies
+### Dependencies
 
-- `@rnw-community/decorators-core` — interceptor engine + `completionObservableStrategy`
-- `@rnw-community/shared` — `MethodDecoratorType`, `AnyFn`
-- **Optional peer**: `rxjs` (only needed when methods return `Observable`)
+- `@rnw-community/decorators-core` — `createInterceptor`, `InterceptorMiddleware`
+- `@rnw-community/shared` — `isPromise`
+- **Optional peer**: `rxjs` — only touched at runtime via `isObservable`
+- **Optional peer**: `typescript` (`>=5.2.0`)
 
-## Coverage
+### Coverage
 
-Default monorepo threshold: **99.9%** on all metrics. Currently **100%**.
+Default monorepo threshold: **99.9%** on all metrics (statements, branches, functions, lines).

--- a/packages/lock-decorator/AGENTS.md
+++ b/packages/lock-decorator/AGENTS.md
@@ -10,7 +10,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   error/
     lock-acquire-timeout-error/  — LockAcquireTimeoutError(key, timeoutMs, { cause? }) + spec

--- a/packages/lock-decorator/AGENTS.md
+++ b/packages/lock-decorator/AGENTS.md
@@ -1,61 +1,61 @@
 # @rnw-community/lock-decorator
 
-Framework-agnostic `@SequentialLock` / `@ExclusiveLock` method decorators with pluggable store, timeout + AbortSignal support, and typed errors. Targets TypeScript's `experimentalDecorators` mode. The package ships only the factories + store contract; consumers wire their own `LockStoreInterface` implementation. A FIFO in-memory store is kept as a test-only helper under `src/store/.../create-in-memory-lock-store.mock.ts` (excluded from the dist by the `**/*.mock.*` pattern in `tsconfig.build-{esm,cjs}.json`).
+Framework-agnostic sequential and exclusive method lock decorators — Promise-returning and Observable-returning variants — with pluggable store, timeout + `AbortSignal` support, and typed errors. Targets TypeScript's `experimentalDecorators` mode. The package ships only the factories + the `LockStoreInterface` contract; consumers wire their own store (Redis/Redlock/in-memory/etc.) — no store implementation, mock, or `*.mock.ts` file ships in `src/`.
 
 ## Package Commands
 
 ```bash
-yarn test               # Run tests
-yarn test:coverage      # Tests with coverage
-yarn build              # Build (dual ESM + CJS)
-yarn ts                 # Type check
-yarn lint:fix           # Fix lint issues
+yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 ```
 
 ## Architecture
 
 ```
 src/
-  type/
-    lock-mode.type.ts
-    lock-argument.type.ts                — union alias: SequentialLockArgumentType | ExclusiveLockArgumentType
-    sequential-lock-argument.type.ts     — string | (args) => string | {key, timeoutMs?, signal?}
-    exclusive-lock-argument.type.ts      — string | (args) => string | {key}  (no waiting, so no timeoutMs/signal)
-  interface/
-    acquire-options.interface.ts         — timeoutMs, signal
-    lock-handle.interface.ts             — key, mode, release()
-    lock-store.interface.ts              — acquire(key, mode, options)
-    create-lock-options.interface.ts     — { store }
   error/
-    lock-busy-error/                     — LockBusyError; thrown when exclusive key is held
-    lock-acquire-timeout-error/          — LockAcquireTimeoutError; thrown when sequential timeoutMs expires
-  store/
-    create-in-memory-lock-store/         — test-only FIFO + exclusive set mock (`*.mock.ts`), excluded from dist
-  util/
-    resolve-lock-key/                    — shared resolver for sequential/exclusive argument shapes
-    run-with-lock/                       — acquire → run → release; rejects non-Promise results at runtime
-    run-with-lock-rxjs/                  — runWithLock$; bridges AbortSignal, releases on complete/error/unsubscribe
+    lock-acquire-timeout-error/  — LockAcquireTimeoutError(key, timeoutMs, { cause? }) + spec
+    lock-busy-error/             — LockBusyError(key, { cause? }) + spec
   factory/
-    create-sequential-lock-decorator/    — returns MethodDecoratorType<K> with K constrained to Promise-returning; runtime-rejects non-Promise methods
-    create-exclusive-lock-decorator/     — returns MethodDecoratorType<K> with K constrained to Promise-returning; runtime-rejects non-Promise methods
+    create-exclusive-lock-decorator/             — createExclusiveLockDecorator(options) + spec
+    create-exclusive-lock-decorator-observable/   — createExclusiveLockDecorator$(options) (no dedicated spec)
+    create-sequential-lock-decorator/             — createSequentialLockDecorator(options) + spec
+    create-sequential-lock-decorator-observable/  — createSequentialLockDecorator$(options) (no dedicated spec)
+  interface/
+    acquire-options.interface.ts     — AcquireOptionsInterface: { timeoutMs?, signal? }
+    create-lock-options.interface.ts — CreateLockOptionsInterface: { store }
+    lock-handle.interface.ts         — LockHandleInterface: { key, mode, release() }
+    lock-store.interface.ts          — LockStoreInterface: acquire(key, mode, options?)
+  type/
+    exclusive-lock-argument.type.ts    — string | (args) => string | { key: string | (args) => string }
+    lock-argument.type.ts              — SequentialLockArgumentType<TArgs> | ExclusiveLockArgumentType<TArgs>
+    lock-mode.type.ts                  — 'sequential' | 'exclusive'
+    sequential-lock-argument.type.ts   — adds optional { timeoutMs?, signal? } to the object form
+  util/
+    assert-valid-timeout-ms/           — assertValidTimeoutMs(value) + spec
+    create-lock-middleware/            — createLockMiddleware(store, mode, arg): Promise-returning InterceptorMiddleware (no dedicated spec — exercised via the factory specs)
+    create-lock-middleware-observable/ — createLockMiddleware$(store, mode, arg): Observable-returning InterceptorMiddleware (no dedicated spec)
+    resolve-lock-key/                  — resolveLockKey(arg, args) + spec
   index.ts
 ```
 
-## Key Patterns
+### Key Patterns
 
-- **Async-only at the type level** — both factories return `MethodDecoratorType<K>` where `K extends (...args) => Promise<unknown>`; applying them to a sync method is a compile-time error and, if bypassed with a cast, a runtime rejection (`Error('Locked method must return a Promise')`)
-- **Exclusive locks don't wait** — argument type does NOT accept `timeoutMs` or `signal`; acquire either succeeds or throws `LockBusyError`
-- **Sequential locks can wait** — accept `timeoutMs` (→ `LockAcquireTimeoutError`) and `signal: AbortSignal` (→ `DOMException('AbortError')`) threaded through the store
-- **Release is idempotent** on both modes — a stale handle's second `release()` is a no-op
-- **Terminal waiters clean up the tail** — on timeout/abort the reject branch schedules `deleteTailIfStillOurs` via `nextTail.then(...)`, so no stale chain entry survives when no later acquirer arrives
-- **`runWithLock$` is leak-free** — a named `forward` listener is registered on the external `AbortSignal` and removed on teardown (complete, error, or unsubscribe)
-- **Thenable support via `isPromise`** (from `@rnw-community/shared`) — catches non-native Promises and cross-realm promises so the lock is held until resolution
+- **No shipped store.** There is no `store/` directory and no `create-in-memory-lock-store.mock.ts` anywhere in this package (this differs from an earlier version of the package, which shipped one). Both `create-*-lock-decorator.spec.ts` files build their own throwaway FIFO/exclusive-set in-memory `LockStoreInterface` fixture inline — duplicated across the two spec files rather than shared, per the monorepo's "test-only code lives in the spec" rule.
+- **The Promise factories do not runtime-check the return shape.** `createLockMiddleware` does `return await Promise.resolve(next())` — a method whose actual runtime behavior returns a non-Promise value is simply wrapped in a resolved Promise, not rejected. The compile-time constraint (`K extends (...args) => Promise<unknown>`) is TypeScript-only; there is no runtime guard here, unlike `@rnw-community/nestjs-enterprise`'s `createPromiseLockDecorators`, which explicitly throws when `originalMethod` doesn't return a thenable.
+- `resolveLockKey` is the single resolver for **both** argument shapes (`SequentialLockArgumentType` and `ExclusiveLockArgumentType`): a plain string, a `(args) => string` function, or an object with `key` (string or function) and, for the sequential shape only, optional `timeoutMs`/`signal`. The waiting semantics themselves (actually delaying on `timeoutMs`, honoring `signal`) live entirely in the consumer's `LockStoreInterface` implementation — this package only resolves the key + options and calls `store.acquire`.
+- `LockBusyError` / `LockAcquireTimeoutError` are types this package **defines** for a consumer's store to throw; the package itself never throws either — both spec files' in-memory store fixtures are the ones raising them.
+- `assertValidTimeoutMs` (used inside `resolveLockKey`) throws `TypeError` for a `timeoutMs` that isn't a positive finite number; `undefined` is always accepted (no timeout).
+- Release is always best-effort: `createLockMiddleware` swallows a rejected `handle.release()` via `.catch(emptyFn)` inside a `finally`, and `createLockMiddleware$` does the same inside `finalize()` — a broken release must never surface to the caller or mask the method's own result/error.
+- The Observable factories (`createSequentialLockDecorator$` / `createExclusiveLockDecorator$`, built on `createLockMiddleware$`) acquire the lock by bridging the store's Promise-based `acquire` into a single-emission `Observable` via a manual `new Observable(...)` constructor (`acquireHandle$`), wired to an internal `AbortController` that also listens to the caller's own `options.signal`. Once acquired, the decorated method's Observable is subscribed through `concatMap`, and release always runs inside `finalize()` regardless of complete / error / unsubscribe. Unsubscribing before acquisition resolves aborts the pending acquire rather than releasing a handle that was never granted.
+- **Coverage gap, verified by grep:** no `.spec.ts` in this package references anything "observable" — `create-lock-middleware-observable.ts` and both `-observable` factories have zero direct test coverage from this package's own suite. Since Jest only instruments files a test run actually imports, these three files simply don't appear in (or count against) this package's coverage report. Their behavior is exercised only where a downstream consumer imports them directly (`@rnw-community/nestjs-enterprise`'s `createObservableLockDecorators` imports `createLockMiddleware$`).
 
-## Dependencies
+### Dependencies
 
-- `@rnw-community/shared` — `isDefined`, `isPromise`
-- **Optional peer**: `rxjs` (only needed for `runWithLock$`)
+- `@rnw-community/decorators-core` — `InterceptorMiddleware` (type only)
+- `@rnw-community/shared` — `isDefined`, `isEmptyString`, `isString`, `emptyFn`
+- **Optional peer**: `rxjs` — needed only for `createLockMiddleware$` / `createSequentialLockDecorator$` / `createExclusiveLockDecorator$`
+- **Optional peer**: `typescript` (`>=5.2.0`)
 
-## Coverage
+### Coverage
 
-Default monorepo threshold: **99.9%** on all metrics. Currently **100%**.
+Default monorepo threshold: **99.9%** on all metrics (statements, branches, functions, lines) — see the coverage-gap note above for the three files this package's own suite never imports.

--- a/packages/log-decorator/AGENTS.md
+++ b/packages/log-decorator/AGENTS.md
@@ -10,7 +10,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   interface/
     create-log-options.interface.ts  — CreateLogOptionsInterface: { transport }

--- a/packages/log-decorator/AGENTS.md
+++ b/packages/log-decorator/AGENTS.md
@@ -14,7 +14,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 src/
   interface/
     create-log-options.interface.ts  — CreateLogOptionsInterface: { transport }
-    log-transport.interface.ts       — LogTransportInterface: log/debug/error(message, logContext[, error])
+    log-transport.interface.ts       — LogTransportInterface: log/debug(message, logContext), error(message, error, logContext)
   type/
     pre-log-input.type.ts    — PreLogInputType<TArgs> = string | ((...args: TArgs) => string)
     post-log-input.type.ts   — PostLogInputType<TArgs, TResult> = string | ((result: TResult, ...args: TArgs) => string)

--- a/packages/log-decorator/AGENTS.md
+++ b/packages/log-decorator/AGENTS.md
@@ -1,15 +1,11 @@
 # @rnw-community/log-decorator
 
-Framework-agnostic `@Log` method decorator with pluggable transport and structured pre/post/error hooks. Built on `@rnw-community/decorators-core`. Targets TypeScript's `experimentalDecorators` mode.
+Framework-agnostic `@Log` method decorator with pluggable transport and structured pre/post/error hooks. Built on `@rnw-community/decorators-core`'s single-middleware interceptor. Targets TypeScript's `experimentalDecorators` mode.
 
 ## Package Commands
 
 ```bash
-yarn test               # Run tests
-yarn test:coverage      # Tests with coverage
-yarn build              # Build (dual ESM + CJS)
-yarn ts                 # Type check
-yarn lint:fix           # Fix lint issues
+yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 ```
 
 ## Architecture
@@ -17,28 +13,35 @@ yarn lint:fix           # Fix lint issues
 ```
 src/
   interface/
-    log-transport.interface.ts
-    create-log-options.interface.ts
+    create-log-options.interface.ts  — CreateLogOptionsInterface: { transport }
+    log-transport.interface.ts       — LogTransportInterface: log/debug/error(message, logContext[, error])
   type/
-    pre-log-input.type.ts
-    post-log-input.type.ts
-    error-log-input.type.ts
-    get-result.type.ts        — unwraps Promise<U> / Observable<U> → U; re-exported because TS2742 forces it into the inferred public type of bound factories
-  console-transport/      — default consoleTransport + spec
-  create-log-decorator/   — decorator factory + spec (middleware body is inlined in the factory file)
+    pre-log-input.type.ts    — PreLogInputType<TArgs> = string | ((...args: TArgs) => string)
+    post-log-input.type.ts   — PostLogInputType<TArgs, TResult> = string | ((result: TResult, ...args: TArgs) => string)
+    error-log-input.type.ts  — ErrorLogInputType<TArgs> = string | ((error: unknown, ...args: TArgs) => string)
+    get-result.type.ts       — GetResultType<T>: unwraps Promise<U> / Observable<U> to U
+  console-transport/     — consoleTransport, the default LogTransportInterface over console.log/debug/error + spec
+  create-log-decorator/  — createLogDecorator(options) factory; the middleware body (buildLogMiddleware) is inlined in this same file + spec
   index.ts
 ```
 
-## Key Patterns
+### Key Patterns
 
-- One entity per file; folders only to group `source + spec` (+ optional `.md`)
-- Observable support: pass `observableStrategy` from `@rnw-community/decorators-core` via the `strategies` factory option
+- `createLogDecorator({ transport })` returns a factory; calling that factory with `(preLog?, postLog?, errorLog?)` builds the actual `@Log(...)` decorator via `createInterceptor` from `@rnw-community/decorators-core`.
+- There is no `observableStrategy` import from `decorators-core` (that strategy no longer exists). The single middleware branches by hand on what `next()` returns, using `isPromise` (from `@rnw-community/shared`) and `isObservable` (from `rxjs`) to pick the sync / Promise / Observable emit path.
+- `preLog` / `postLog` / `errorLog` each accept a literal string or a callback; an empty string — literal or callback-returned — is treated as "log nothing" (checked with `isNotEmptyString` before calling the transport).
+- `errorLog`'s second transport argument is the thrown value only when `isError(error)` is true; non-`Error` throws (e.g. `throw 42`) pass `undefined` instead of being coerced into a synthetic `Error`.
+- Return-shape handling: sync methods run `postLog`/`errorLog` immediately around `next()`; Promise-returning methods fire `postLog`/`errorLog` once on settle (resolve or reject) via `.then(onSuccess, onError)`; Observable-returning methods fire `postLog` per emission via `tap()` and `errorLog` once via `catchError()`, which re-throws through `throwError` so the error still reaches the subscriber.
+- Automatic type narrowing: `preLog`/`postLog`/`errorLog` use the spread form `(...args: TArgs) => string`, inferring parameter types straight from the decorated method's own signature — no explicit factory generics needed, including when `TResult` is unwrapped from a `Promise`/`Observable` via `GetResultType`.
+- A single `@Log(...)` decorator instance works unmodified across sync, Promise, and Observable methods on the same class — verified by the "unification" describe block in the spec.
 
-## Dependencies
+### Dependencies
 
-- `@rnw-community/decorators-core` — interceptor engine
-- `@rnw-community/shared` — `isDefined`
+- `@rnw-community/decorators-core` — `createInterceptor`, `InterceptorMiddleware`
+- `@rnw-community/shared` — `isError`, `isNotEmptyString`, `isPromise`, `isString`
+- **Optional peer**: `rxjs` — only touched at runtime via `isObservable` when a decorated method returns an `Observable`
+- **Optional peer**: `typescript` (`>=5.2.0`)
 
-## Coverage
+### Coverage
 
-Default monorepo threshold: **99.9%** on all metrics. Currently **100%**.
+Default monorepo threshold: **99.9%** on all metrics (statements, branches, functions, lines).

--- a/packages/nestjs-enterprise/AGENTS.md
+++ b/packages/nestjs-enterprise/AGENTS.md
@@ -1,76 +1,78 @@
 # @rnw-community/nestjs-enterprise
 
-Thin-adapter layer exposing NestJS-flavored decorators (`Log`, `HistogramMetric`, `SequentialLock`/`ExclusiveLock`, `SequentialLock$`/`ExclusiveLock$`) built on top of the universal decorator suite: `@rnw-community/decorators-core`, `@rnw-community/log-decorator`, and `@rnw-community/lock-decorator`.
+Thin-adapter layer exposing NestJS-flavored decorators (`Log`, `HistogramMetric`, `SequentialLock`/`ExclusiveLock` via DI, plus deprecated inheritance-based `LockPromise`/`LockObservable`) on top of the universal decorator suite: `@rnw-community/log-decorator`, `@rnw-community/histogram-metric-decorator`, and `@rnw-community/lock-decorator`.
 
 ## Package Commands
 
 ```bash
-yarn test               # Run tests
-yarn test:coverage      # Tests with coverage
-yarn build              # Build (dual ESM + CJS)
-yarn ts                 # Type check
-yarn lint:fix           # Fix lint issues
+yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 ```
 
 ## Architecture
 
-### Directory Layout
-
 ```
 src/
-  pre-decorator-function.type.ts  — PreDecoratorFunction type
+  type/
+    pre-decorator-function.type.ts   — PreDecoratorFunction<TArgs, TResult = string> = (...args: TArgs) => TResult
   decorator/
-    log/                — Log decorator (thin adapter over @rnw-community/log-decorator)
-    histogram-metric/   — HistogramMetric decorator (thin adapter over @rnw-community/histogram-metric-decorator + prom-client transport)
+    log/                 — Log decorator (thin adapter over @rnw-community/log-decorator) + spec + .md
+    histogram-metric/
+      histogram-metric.decorator.ts        — HistogramMetric(metricName, configuration?) + spec + .md
+      histogram-metric-tracking.ts         — per-Registry WeakMap tracking of registered buckets/labelNames
     lock/
-      create-lock-service-store.ts   — createLockServiceStore: bridges LockServiceInterface → LockStoreInterface (NUL-joins multi-resource keys)
-      lockable.service.ts            — DEPRECATED: LockableService base class
-      interface/        — LockServiceInterface, LockHandle
-      create-promise-lock-decorators/    — Modern DI-based promise lock factory (@rnw-community/lock-decorator)
-      create-observable-lock-decorators/ — Modern DI-based observable lock factory
-      lock-promise/     — DEPRECATED: inheritance-based promise lock
-      lock-observable/  — DEPRECATED: inheritance-based observable lock
-      util/             — Deprecated lock utilities (used only by the deprecated inheritance-based decorators)
+      create-lock-service-store.ts          — createLockServiceStore: bridges LockServiceInterface → LockStoreInterface (NUL-joins multi-resource keys)
+      lockable.service.ts                   — DEPRECATED: LockableService base class (wraps a Redlock instance)
+      lock-service-not-injected-message.const.ts — LOCK_SERVICE_NOT_INJECTED_MESSAGE
+      resolve-resources.ts                  — resolveResources: preLock (string[] | fn) → non-empty string[], or throws
+      resource-separator.const.ts            — RESOURCE_SEPARATOR = '\x00'
+      interface/                — LockServiceInterface (acquire/tryAcquire), LockHandle
+      create-promise-lock-decorators/    — createPromiseLockDecorators(serviceToken, defaultDuration) + spec + .md
+      create-observable-lock-decorators/ — createObservableLockDecorators(serviceToken, defaultDuration) + spec + .md
+      lock-promise/      — DEPRECATED: LockPromise (inheritance-based) + spec + .md
+      lock-observable/   — DEPRECATED: LockObservable (inheritance-based) + spec + .md
+      util/              — get-method-name, get-redlock-service, run-pre-lock, validate-redlock, execute-lock-promise.util, execute-lock-observable.util — all used only by the two deprecated decorators
+  index.ts
 ```
 
 ### Subpath Exports
 
-PascalCase convention: `./HistogramMetric`, `./Log`, `./LockPromise`, `./LockObservable`, `./CreatePromiseLockDecorators`, `./CreateObservableLockDecorators`
+PascalCase convention: `./HistogramMetric`, `./Log`, `./LockPromise`, `./LockObservable`, `./CreatePromiseLockDecorators`, `./CreateObservableLockDecorators`.
 
 ### Thin-adapter architecture
 
-All three live decorator families delegate to the universal decorator suite:
+- **Log**: `createLogDecorator({ transport: nestLogTransport })` from `@rnw-community/log-decorator`, bound once to a transport built on `@nestjs/common`'s `Logger`. The exported `Log` is the direct factory return — no further wrapper. Sync/Promise/Observable handling is entirely `log-decorator`'s own internal responsibility now (there is no `observableStrategy` involved anywhere in this package; that concept no longer exists in `decorators-core`).
+- **HistogramMetric**: called directly as `HistogramMetric(metricName, configuration?)` — not a two-step factory like `Log`. It resolves (or lazily creates) a prom-client `Histogram` for `metricName` immediately and returns `createHistogramMetricDecorator({ transport })({ name: metricName, labels })` inline. `histogramMetricTracking` memoizes each registered metric's `{ buckets, labelNames }` per `Registry` in a `WeakMap`; a second `@HistogramMetric` call reusing the same name with **different** `buckets`/`labelNames` on the same registry throws a descriptive mismatch error (`"<name>" already registered with different buckets/labelNames. Existing: ... Requested: ...`); a call with a **matching** config reuses the existing prom-client `Histogram` instance instead of re-instantiating it. The transport converts the engine's milliseconds into prom-client's canonical seconds via `histogram.observe(labelValues, durationMs / 1000)`.
+- **Locks — the two live factory families do NOT wire the same way, and neither goes through `createInterceptor`:**
+  - `createPromiseLockDecorators(serviceToken, defaultDuration)` hand-rolls its own `descriptor.value = async function (...)`, calling `store.acquire` / releasing in a `finally` directly — it reuses `createLockServiceStore` (the `LockServiceInterface` → `LockStoreInterface` bridge) but does **not** reuse `@rnw-community/lock-decorator`'s `createLockMiddleware`; the acquire/invoke/release cycle is reimplemented locally.
+  - `createObservableLockDecorators(serviceToken, defaultDuration)` **does** reuse `createLockMiddleware$` from `@rnw-community/lock-decorator` directly, invoking it by hand inside a `defer(...)` with a manually built `ExecutionContextInterface`-shaped object (`{ className: '', methodName, args, logContext: methodName }`) — since it bypasses `createInterceptor`, it never gets a real `className` from `decorators-core`'s `buildContext`.
+  - Both bridge the multi-resource `LockServiceInterface` to the single-key `LockStoreInterface` via `createLockServiceStore`, which NUL-joins (`RESOURCE_SEPARATOR = '\x00'`) multi-resource keys into one store key.
+  - `createObservableLockDecorators` wraps method-thrown errors in a local `MethodThrownError` marker class so its single `catchError` can tell a method failure apart from a lock-acquire failure and apply the right recovery (`recoverFromMethodError` vs `recoverFromAcquireError`); the Promise version doesn't need a marker since it catches around `store.acquire` and around invoking/awaiting the method in two separate `try` blocks.
+  - `LockBusyError` translation is shared in spirit between both: for `mode === 'exclusive'` with no `catchErrorFn`/`catchErrorFn$` supplied, contention resolves to `undefined` (Promise) / `EMPTY` (Observable); otherwise `LockBusyError` is normalized into a generic `Error("Lock not acquired for keys: …")` (splitting the joined key back on `RESOURCE_SEPARATOR`) before being thrown or handed to the recovery callback.
+  - Setup errors (missing DI binding, empty `preLock` result) bypass `catchErrorFn`/`catchErrorFn$` entirely and always throw.
 
-- **Log**: `createLogDecorator` from `@rnw-community/log-decorator` bound once to a NestJS `Logger` transport and `observableStrategy` from `@rnw-community/decorators-core`. No wrapper — the exported `Log` is the direct factory return. `pre/post/error` hooks use spread-style `(...args) => string` signatures and narrow from the decorated method's parameter types automatically
-- **HistogramMetric**: `createHistogramMetricDecorator` from `@rnw-community/histogram-metric-decorator` + a prom-client `Histogram` transport that converts the engine's milliseconds into prom-client's canonical seconds via `histogram.observe(durationMs / 1000)`. Sync and Promise paths emit one observation on completion or rejection; Observable paths emit one observation on stream `complete` or `error` via `completionObservableStrategy` (wired by default in `createHistogramMetricDecorator`)
-- **Locks**: `createPromiseLockDecorators` / `createObservableLockDecorators` in-package, each driving a NestJS DI binding through `createLockServiceStore` that bridges the multi-resource `LockServiceInterface` to the single-key `LockStoreInterface` from `@rnw-community/lock-decorator` (multi-key resources are NUL-joined into one store key). Setup errors (missing DI, empty key) bypass `catchErrorFn`. `LockBusyError` is translated to the legacy `undefined`/`EMPTY` + `Error("Lock not acquired for keys: …")` shapes
+### Key patterns
 
-### Key patterns preserved from upstream
-
-- **DI-based lock factories** (modern): `createPromiseLockDecorators(LockService, duration)` returns `{ SequentialLock, ExclusiveLock }`
-- Each factory call creates a unique `Symbol('LockService')` for DI isolation — multiple factories can coexist on the same class
-- `@Inject(serviceToken)(target, symbol)` wires NestJS DI at decoration time
-- Lock release errors silently swallowed
-- `preLock` can be static `string[]` or a function `(...args) => string[]`
-- Methods that return a non-Promise/non-Observable throw a descriptive error with the class-qualified method name
-- `ExclusiveLock` (promise form) resolves to `undefined` on contention when no `catchErrorFn` is supplied — see `create-promise-lock-decorators.md`
-- Observable error logging: `{ err: Error }` wrapping only when the error IS an Error instance; non-Error throws use the 2-arg form — applies uniformly across sync/Promise/Observable paths
+- Each `create*LockDecorators(serviceToken, defaultDuration)` call mints its own `Symbol('LockService')` for DI isolation, so multiple factories can coexist on the same class without colliding.
+- `@Inject(serviceToken)(target, symbol)` wires NestJS DI at decoration time (inside the decorator function itself, not in a constructor).
+- `preLock` (or the deprecated decorators' `preLock`) can be a static `string[]` or a function `(...args) => string[]`; an empty resulting array always throws `'Lock key is not defined'`.
+- A decorated method that returns neither a `Promise` (promise family) nor an `Observable` (observable family) throws a descriptive error naming the class-qualified method (`` `${ClassName}::${methodName}` ``).
+- Lock release errors are always silently swallowed on every path (deprecated and modern, Promise and Observable).
+- The deprecated `LockPromise` / `LockObservable` / `LockableService` require class inheritance from `LockableService` (which wraps a `Redlock` instance); the modern `create*LockDecorators` factories use NestJS DI instead and are the documented replacement.
 
 ### Dependencies
 
-- `@rnw-community/shared` — `isDefined`, `isPromise`, `isNotEmptyArray`
-- `@rnw-community/decorators-core` — interceptor engine + `observableStrategy`
+- `@rnw-community/shared` — `isDefined`, `isPromise`, `isNotEmptyArray`, `isError`
 - `@rnw-community/log-decorator` — `createLogDecorator` engine behind `Log`
 - `@rnw-community/histogram-metric-decorator` — `createHistogramMetricDecorator` engine behind `HistogramMetric`
-- `@rnw-community/lock-decorator` — `LockBusyError`, `LockStoreInterface`
-- **Required peers**: `@nestjs/common`, `rxjs`
-- **Optional peers** (`peerDependenciesMeta`): `ioredis`, `redlock`, `prom-client` (feature-specific)
+- `@rnw-community/lock-decorator` — `LockBusyError`, `createLockMiddleware$`, and the `LockStoreInterface`/`LockHandleInterface`/`LockModeType`/`AcquireOptionsInterface` types (`@rnw-community/decorators-core` is **not** a direct dependency of this package — it's only pulled in transitively through `log-decorator`/`histogram-metric-decorator`)
+- **Required peer**: `@nestjs/common`
+- **Optional peers** (`peerDependenciesMeta`): `ioredis`, `redlock`, `prom-client` — each needed only by the feature that uses it (`LockableService`/deprecated lock decorators for `ioredis`+`redlock`, `HistogramMetric` for `prom-client`); `rxjs` is a required peer (used by the Observable lock family and `Log`'s Observable branch)
 
 ### Coverage
 
-Default monorepo threshold: **99.9%** on all metrics. Currently **100%**.
+Default monorepo threshold: **99.9%** on all metrics (statements, branches, functions, lines).
 
 ### Important Notes
 
-- The deprecated `LockPromise`/`LockObservable`/`LockableService` require class inheritance — prefer the `create*LockDecorators` factories
-- `redlock` has a Yarn patch applied (adds `"types"` to its exports for `moduleResolution: "bundler"`)
+- `redlock` has a Yarn patch applied (adds `"types"` to its exports for `moduleResolution: "bundler"` consumers).
+- Prefer `createPromiseLockDecorators` / `createObservableLockDecorators` over the deprecated inheritance-based `LockPromise` / `LockObservable`.

--- a/packages/nestjs-enterprise/AGENTS.md
+++ b/packages/nestjs-enterprise/AGENTS.md
@@ -10,7 +10,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   type/
     pre-decorator-function.type.ts   — PreDecoratorFunction<TArgs, TResult = string> = (...args: TArgs) => TResult

--- a/packages/nestjs-rxjs-lock/AGENTS.md
+++ b/packages/nestjs-rxjs-lock/AGENTS.md
@@ -10,7 +10,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   index.ts                                 — barrel: options, module, service
   nestjs-rxjs-lock-module.options.ts       — NestJSRxJSLockModuleOptions (extends redlock's Settings + defaultExpireMs);

--- a/packages/nestjs-rxjs-lock/AGENTS.md
+++ b/packages/nestjs-rxjs-lock/AGENTS.md
@@ -12,23 +12,45 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ```
 src/
-  nestjs-rxjs-lock-module.options.ts  — NestJSRxJSLockModuleOptions (extends Redlock Settings + defaultExpireMs)
-  nestjs-rxjs-lock-module/            — NestJSRxJSLockModule with registerTypedAsync<E>() factory
-  nestjs-rxjs-lock-service/           — NestJSRxJSLockService<E> abstract base class
+  index.ts                                 — barrel: options, module, service
+  nestjs-rxjs-lock-module.options.ts       — NestJSRxJSLockModuleOptions (extends redlock's Settings + defaultExpireMs);
+                                              defaultNestJSRxJSLockModuleOptions (defaultExpireMs: 10000, retryCount: 0,
+                                              driftFactor: 0.01, retryDelay: 200, retryJitter: 200,
+                                              automaticExtensionThreshold: 500)
+  nestjs-rxjs-lock-module/
+    nestjs-rxjs-lock.module.ts             — NestJSRxJSLockModule.registerTypedAsync<E>()
+  nestjs-rxjs-lock-service/
+    nestjs-rxjs-lock.service.ts            — NestJSRxJSLockService<E> abstract base class
 ```
 
 ### Key Patterns
 
-- `registerTypedAsync<E>()` returns `[DynamicModule, Type<NestJSRxJSLockService<E>>]` — generic enum `E` constrains lock key prefixes
-- `lock$(name, prefix, handler$, expireMs)` → `Observable<T>`: acquires lock, runs handler in `concatMap`, releases in `finalize`
-- Lock key format: `lock:[prefix]:[name]`
-- Release errors are silently swallowed — never pollute the subscriber stream
-- Default `retryCount: 0` (non-blocking/exclusive)
+- `NestJSRxJSLockModule.registerTypedAsync<E = string>(options?)` declares an anonymous `@Injectable()` `LockService
+  extends NestJSRxJSLockService<E>` inline, merges `{ ...defaultNestJSRxJSLockModuleOptions, ...options }` in its
+  constructor, and returns `[DynamicModule, Type<NestJSRxJSLockService<E>>]` (imports `RedisModule` from
+  `@nestjs-modules/ioredis`) — the same tuple pattern used by the other NestJS packages in this repo
+- `NestJSRxJSLockService` constructor splits `options` into `{ defaultExpireMs, ...redlockOptions }`: `defaultExpireMs`
+  becomes the per-instance default lock TTL, `redlockOptions` is passed straight into `new Redlock([redis], ...)`
+- `lock$<T>(name, prefix, handler$, expireInMs = this.expireInMs)`: `from(this.lock.acquire([lockName], expireInMs))`
+  piped through `concatMap(lock => handler$().pipe(finalize(() => void lock.release().catch(() => void 0))))` — the
+  handler only runs after acquisition succeeds, and the lock is always released on completion/error/unsubscribe
+  because `finalize` runs regardless of how the inner observable terminates
+- Lock key is built by the private static `generateName(name, prefix)`: `['lock', prefix, name].filter(isNotEmptyString).join(':')`
+  — a falsy/empty `prefix` collapses to `lock:name` instead of `lock::name`
+- An error thrown while **acquiring** the lock propagates to the subscriber and neither `handler$` nor `release` ever run
+  (nothing was acquired to release)
+- An error thrown by `lock.release()` is swallowed by `.catch(() => void 0)` inside `finalize` — it never reaches the
+  subscriber, so a Redis hiccup during release cannot fail an otherwise-successful `handler$` result
+- Default `retryCount: 0` — lock acquisition is non-blocking/exclusive: a contended lock rejects immediately instead of
+  retrying
 
 ### Dependencies
 
-`@nestjs-modules/ioredis`, `@nestjs/common`, `@nestjs/core`, `@rnw-community/shared`, `ioredis`, `redlock`, `rxjs`
+`@nestjs-modules/ioredis`, `@nestjs/common`, `@nestjs/core`, `@rnw-community/shared` (`isNotEmptyString`), `ioredis`,
+`redlock` (patched via yarn — `redlock@npm:5.0.0-beta2` with a local patch), `rxjs`. No `peerDependencies` — all of these
+ship as direct `dependencies`.
 
 ### Coverage
 
-Default: **99.9%** all metrics.
+Default monorepo threshold: **99.9%** on all metrics (statements, branches, functions, lines) — no package-level
+`coverageThreshold` override in `jest.config.js`.

--- a/packages/nestjs-rxjs-lock/AGENTS.md
+++ b/packages/nestjs-rxjs-lock/AGENTS.md
@@ -33,8 +33,10 @@ src/
   becomes the per-instance default lock TTL, `redlockOptions` is passed straight into `new Redlock([redis], ...)`
 - `lock$<T>(name, prefix, handler$, expireInMs = this.expireInMs)`: `from(this.lock.acquire([lockName], expireInMs))`
   piped through `concatMap(lock => handler$().pipe(finalize(() => void lock.release().catch(() => void 0))))` — the
-  handler only runs after acquisition succeeds, and the lock is always released on completion/error/unsubscribe
-  because `finalize` runs regardless of how the inner observable terminates
+  handler only runs after acquisition succeeds, and release is always attempted on completion/error/unsubscribe
+  because `finalize` runs regardless of how the inner observable terminates — release is only attempted, not
+  guaranteed: if Redis rejects the release call, the swallowed error (see below) means the lock stays held until
+  its TTL expires rather than being freed immediately
 - Lock key is built by the private static `generateName(name, prefix)`: `['lock', prefix, name].filter(isNotEmptyString).join(':')`
   — a falsy/empty `prefix` collapses to `lock:name` instead of `lock::name`
 - An error thrown while **acquiring** the lock propagates to the subscriber and neither `handler$` nor `release` ever run

--- a/packages/nestjs-rxjs-logger/AGENTS.md
+++ b/packages/nestjs-rxjs-logger/AGENTS.md
@@ -11,7 +11,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   index.ts                         — barrel: enum, service, module
   enum/

--- a/packages/nestjs-rxjs-logger/AGENTS.md
+++ b/packages/nestjs-rxjs-logger/AGENTS.md
@@ -1,6 +1,7 @@
 # @rnw-community/nestjs-rxjs-logger
 
-RxJS-native logging operators for NestJS. Provides pipeable operators (`debug$`, `info$`, `warn$`, `error$`, `verbose$`) that log side-effects inside Observable streams.
+RxJS-native logging operators for NestJS. Provides pipeable operators (`debug`, `info`, `warn`, `error`, `verbose`,
+plus `create$` and `catch`) that log side-effects inside Observable streams.
 
 ## Package Commands
 
@@ -12,24 +13,48 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ```
 src/
-  enum/                         — AppLogLevelEnum (debug, error, info, verbose, warn)
-  nestjs-rxjs-logger-module/    — NestJSRxJSLoggerModule (static, provides Logger as 'LOGGER' token)
-  nestjs-rxjs-logger-service/   — NestJSRxJSLoggerService (TRANSIENT scope)
+  index.ts                         — barrel: enum, service, module
+  enum/
+    app-log-level.enum.ts          — AppLogLevelEnum (debug, error, info, verbose, warn)
+  nestjs-rxjs-logger-module/
+    nestjs-rxjs-logger.module.ts   — NestJSRxJSLoggerModule (static @Module, provides `Logger` under 'LOGGER' token)
+  nestjs-rxjs-logger-service/
+    nestjs-rxjs-logger.service.ts  — NestJSRxJSLoggerService (TRANSIENT scope)
 ```
 
 ### Key Patterns
 
-- Service is `TRANSIENT`-scoped — each consumer gets its own instance with its own context
-- All log methods return `MonoTypeOperatorFunction<T>` — pass-through the stream value while logging
-- Message can be a string or `(input: T) => string` function receiving the stream value
-- `.catch(errorMsgFn)` catches errors, logs, and re-throws
-- `.create$(message)` creates an `Observable<boolean>` that emits `true` and logs
-- Internal `print$` uses `concatMap` pattern for side-effect logging
+- The five level methods (`debug`, `info`, `warn`, `error`, `verbose`) are **not** `$`-suffixed despite being RxJS
+  operators — only `create$` carries the `$` convention (it starts a new stream rather than piping an existing one)
+- Every level method delegates to the private `print$<T>(message, context, level)`, which returns a
+  `MonoTypeOperatorFunction<T>` built from `concatMap(input => { this.print(...); return [input]; })` — the stream
+  value passes through unchanged while the log side-effect runs
+- `message` is either a plain `string` or `(input: T) => string` — `print$` calls the function form with the stream's
+  emitted value only when `typeof message === 'function'`
+- `context` defaults to `this.context` (set once via `setContext(context)`) on every method, so a service can log
+  without repeating its context on each call site
+- `.catch(errorMsgFn, context?)` wraps `catchError`: logs at `AppLogLevelEnum.error` via the synchronous `print()`
+  (not `print$`) using the error-derived message, then re-throws the original error with `throwError(() => error)` —
+  it never swallows the error
+- `.create$(message, context?, level = AppLogLevelEnum.info)` builds `of(true).pipe(tap(() => this.print(...)))` — the
+  only method that starts a stream from scratch rather than piping through one
+- `print(message, context, level)` is a synchronous dispatcher: an `if`/`else if` chain maps `AppLogLevelEnum.debug`
+  →`logger.debug`, `.error`→`logger.error`, `.warn`→`logger.warn`, `.info`→`logger.log`, and the `else` branch (only
+  reachable for `.verbose`) →`logger.verbose`
+- The service is `@Injectable({ scope: Scope.TRANSIENT })` — each consumer gets its own instance, so `setContext` on
+  one consumer's injected instance never leaks into another's
+- `NestJSRxJSLoggerModule`'s only provider wiring is `{ provide: 'LOGGER', useValue: Logger }` — it binds the **class**
+  `Logger` itself (from `@nestjs/common`), not an instance created with `new Logger()`. This works because
+  `@nestjs/common`'s `Logger` exposes matching static methods (`Logger.debug`, `.error`, `.warn`, `.log`, `.verbose`)
+  alongside its instance API, so `this.logger.debug(...)` inside the service resolves to the static call
 
 ### Dependencies
 
-Peers: `@nestjs/common`, `rxjs`. Internal: `@rnw-community/shared`.
+Peers: `@nestjs/common`, `rxjs` (both `devDependencies` + `peerDependencies`, not bundled). Direct dependency:
+`@rnw-community/shared` — used only by the test specs (`getErrorMessage`, `isNotEmptyString`), not by production `src`
+code.
 
 ### Coverage
 
-Default: **99.9%** all metrics.
+Default monorepo threshold: **99.9%** on all metrics (statements, branches, functions, lines) — no package-level
+`coverageThreshold` override in `jest.config.js`.

--- a/packages/nestjs-rxjs-metrics/AGENTS.md
+++ b/packages/nestjs-rxjs-metrics/AGENTS.md
@@ -12,25 +12,52 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ```
 src/
-  interface/                    — MetricsModuleOptionsInterface
-  nestjs-rxjs-metrics-service/  — NestJSRxJSMetricsService (generic base class)
-  type/                         — HistogramRecord, SummaryRecord, LabelsConfig, MetricConfig
-  util/                         — createMetricsRecord, rxjsOperator (shared concatMap pass-through)
-  nestjs-rxjs-metrics.module.ts — NestJSRxJSMetricsModule with create() factory
+  index.ts                                — barrel: module, service
+  nestjs-rxjs-metrics.module.ts           — NestJSRxJSMetricsModule.create<C,G,H,S,HL,SL>()
+  interface/
+    metrics-module-options.interface.ts   — MetricsModuleOptionsInterface<C,G,H,S,HL,SL> extends PrometheusOptions
+  nestjs-rxjs-metrics-service/
+    nestjs-rxjs-metrics.service.ts        — NestJSRxJSMetricsService<C,G,H,S,HL,SL> (generic base class)
+  type/
+    metrics-config.type.ts                — MetricConfig = Record<string, string>
+    labels-config.type.ts                 — LabelsConfig<M, E extends string = string> = Record<keyof M, readonly E[]>
+    histogram-record.type.ts              — HistogramRecord<H> = Record<keyof H, ReturnType<Histogram['startTimer']>[]>
+    summary-record.type.ts                — SummaryRecord<S> = Record<keyof S, ReturnType<Summary['startTimer']>[]>
+  util/
+    create-metrics-record.util.ts         — createMetricsRecord(type, enumObj, labelNames?) via getOrCreateMetric
+    rxjs-operator.util.ts                 — rxjsOperator(handlerFn) shared concatMap pass-through
 ```
 
 ### Key Patterns
 
-- `NestJSRxJSMetricsModule.create<C,G,H,S,...>(options)` returns `[DynamicModule, Type<MetricsService>]`
-- `MetricConfig = Record<string, string>` where keys are metric names, values are help descriptions
-- Timer-based metrics (histogram/summary) use internal stacks to pair `startTimer`/`endTimer` across operators
-- All operator methods use shared `rxjsOperator` utility: `concatMap` pass-through with void side-effect
-- Built on `@willsoto/nestjs-prometheus` (`getOrCreateMetric`)
+- `NestJSRxJSMetricsModule.create<C,G,H,S,HL,SL>(options)` destructures `options` into the four `*Metrics` /
+  `*Labels` config objects plus the remaining `nestjsPrometheusOptions`, declares an inline `class MetricsService
+  extends NestJSRxJSMetricsService<...>` whose constructor calls `createMetricsRecord('Counter'|'Gauge'|'Histogram'|
+  'Summary', ...)` for each kind, imports `PrometheusModule.register(nestjsPrometheusOptions)`, and returns
+  `[DynamicModule, Type<NestJSRxJSMetricsService<C,G,H,S,HL,SL>>]`
+- `MetricConfig = Record<string, string>` — keys are metric names, values are the Prometheus `help` text
+- `createMetricsRecord` calls `getOrCreateMetric` from `@willsoto/nestjs-prometheus` per metric key, passing
+  `labelNames: Object.keys(labelNames[metric])` only when a `LabelsConfig` was supplied for that metric kind
+  (histogram/summary only — counters and gauges never receive label names this way)
+- `histogramStart`/`summaryStart` push the `startTimer(labels)` end-function onto a per-metric array
+  (`startedHistogramMetrics[metric]` / `startedSummaryMetrics[metric]`) acting as a **LIFO stack**;
+  `histogramEnd`/`summaryEnd` `pop()` the most recently pushed end-function and invoke it with the end-time labels —
+  nested `start`/`end` pairs on the same metric+label combination unwind innermost-first
+- If `end*` is called with nothing left to pop (`isDefined(metricEndFn)` is false), the timer end is silently
+  skipped and `Logger.error('Cannot end histogram/summary for metric "<metric>" - It was not started', ...)` is
+  logged instead of throwing — a mismatched start/end never crashes the stream
+- All operator methods (`counter`, `gauge`, `gaugeInc`, `gaugeDec`, `histogramStart`, `histogramEnd`, `summaryStart`,
+  `summaryEnd`) are built on the shared `rxjsOperator(handlerFn)` utility: `concatMap` pass-through that runs
+  `handlerFn()` for its side effect and re-emits the untouched input
+- `gaugeInc`/`gaugeDec` are thin wrappers over `gauge(metric, g => g.inc(value))` / `g.dec(value)`
 
 ### Dependencies
 
-Peers: `@nestjs/common`, `@willsoto/nestjs-prometheus`, `prom-client`, `rxjs`. Internal: `@rnw-community/shared`.
+Peers: `@nestjs/common`, `@willsoto/nestjs-prometheus`, `prom-client`, `rxjs` (all three declared in both
+`devDependencies` and `peerDependencies`). Direct dependency: `@rnw-community/shared` (`isDefined`, used in
+production `src` for the missing-start-timer check).
 
 ### Coverage
 
-Default: **99.9%** all metrics.
+Default monorepo threshold: **99.9%** on all metrics (statements, branches, functions, lines) — no package-level
+`coverageThreshold` override in `jest.config.js`.

--- a/packages/nestjs-rxjs-metrics/AGENTS.md
+++ b/packages/nestjs-rxjs-metrics/AGENTS.md
@@ -53,7 +53,7 @@ src/
 
 ### Dependencies
 
-Peers: `@nestjs/common`, `@willsoto/nestjs-prometheus`, `prom-client`, `rxjs` (all three declared in both
+Peers: `@nestjs/common`, `@willsoto/nestjs-prometheus`, `prom-client`, `rxjs` (all four declared in both
 `devDependencies` and `peerDependencies`). Direct dependency: `@rnw-community/shared` (`isDefined`, used in
 production `src` for the missing-start-timer check).
 

--- a/packages/nestjs-rxjs-metrics/AGENTS.md
+++ b/packages/nestjs-rxjs-metrics/AGENTS.md
@@ -10,7 +10,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   index.ts                                — barrel: module, service
   nestjs-rxjs-metrics.module.ts           — NestJSRxJSMetricsModule.create<C,G,H,S,HL,SL>()

--- a/packages/nestjs-rxjs-redis/AGENTS.md
+++ b/packages/nestjs-rxjs-redis/AGENTS.md
@@ -12,24 +12,45 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ```
 src/
-  nestjs-rxjs-redis-service/    — NestJSRxJSRedisService (injectable)
-  nestjs-rxjs-redis-core.module.ts — @Global() core module (wires RedisModule + service)
-  nestjs-rxjs-redis.module.ts   — NestJSRxJSRedisModule with forRootAsync(options)
+  index.ts                            — barrel: service, module (named exports, not `export *`)
+  nestjs-rxjs-redis-core.module.ts    — @Global() NestJSRxJSRedisCoreModule.forRootAsync(options)
+  nestjs-rxjs-redis.module.ts         — NestJSRxJSRedisModule.forRootAsync(options) (thin wrapper over CoreModule)
+  nestjs-rxjs-redis-service/
+    nestjs-rxjs-redis.service.ts      — NestJSRxJSRedisService (@Injectable)
 ```
 
 ### Key Patterns
 
-- Two-module architecture: `CoreModule` (@Global, handles DI) + `PublicModule` (consumer API)
-- Observable methods end in `$`: `set$`, `get$`, `del$`, `ttl$`, `expire$`, `incr$`, `mget$`
-- Operator methods: `save`, `load`, `remove`, `cache` (pipeable `OperatorFunction`s)
-- `cache` operator: tries `get$` first, falls back to `prepareFn$` observable + `set$`
-- `get$` throws if Redis returns null — use `mget$` for nullable multi-key lookups
-- All `$` methods wrap Redis promise errors with `catchError`
+- Two-module architecture: `NestJSRxJSRedisCoreModule` (`@Global()`, declares `NestJSRxJSRedisService` as a provider,
+  its static `forRootAsync` imports `RedisModule.forRootAsync(options)`) + `NestJSRxJSRedisModule` (the consumer-facing
+  module whose `forRootAsync` just imports `NestJSRxJSRedisCoreModule.forRootAsync(options)`) — consumers only ever
+  import the public module, the core module only exists to make the service globally injectable exactly once
+- Observable methods end in `$`: `set$(key, value, ttlInSeconds, error?)`, `get$(key, error?)`, `del$(key, error?)`,
+  `ttl$(key, error?)`, `expire$(key, seconds, error?)`, `incr$(key, error?)`, `mget$(keys)`
+- `set$`, `del$`, `ttl$`, `expire$`, `incr$` and `get$` all wrap the underlying Redis promise with
+  `catchError(() => throwError(() => new Error(error)))` — a rejected/erroring Redis call always surfaces as a plain
+  `Error` with the caller-supplied (or default, key-interpolated) message; **`mget$` is the one exception** — it has no
+  `catchError` and lets a rejected `mget` promise propagate unmodified
+- `get$` additionally treats a resolved `null` (key not found) as an error via `concatMap` before its `catchError`
+  runs — both "not found" and "Redis threw" surface identically as `Error(error)`; use `mget$` when a `null` value per
+  key must be observable instead of thrown
+- `mget$<K extends string>(keys)` zips the resolved value array back onto the input `keys` via `reduce`, returning
+  `Record<K, string | null>` — the only method that turns a positional array result into a keyed object
+- Operator methods (`save`, `load`, `remove`, `cache`) are pipeable `MonoTypeOperatorFunction`/`OperatorFunction`s that
+  wrap the `$` methods; all default their `keyFn`/`errorFn`/`toValueFn`/`fromValueFn` params (`String(input)` for keys,
+  `JSON.stringify`/`JSON.parse` for (de)serialization)
+- `cache(ttlInSeconds, prepareFn$, keyFn?, fromValueFn?, toValueFn?)`: on each input, tries `get$(key)` + `fromValueFn`
+  first; if that observable errors (cache miss or Redis error, indistinguishable), falls back to
+  `prepareFn$(key)` and pipes its result into `set$` before re-emitting the freshly prepared value — a cache miss and
+  a Redis outage take the same fallback path
 
 ### Dependencies
 
-Peers: `@nestjs-modules/ioredis`, `@nestjs/common`, `ioredis`, `rxjs`. Internal: `@rnw-community/shared`.
+Peers: `@nestjs-modules/ioredis`, `@nestjs/common`, `ioredis`, `rxjs` (all declared in both `devDependencies` and
+`peerDependencies`). Direct dependency: `@rnw-community/shared` (`isDefined`, used in production `src` for the `get$`
+null check).
 
 ### Coverage
 
-Default: **99.9%** all metrics.
+Default monorepo threshold: **99.9%** on all metrics (statements, branches, functions, lines) — no package-level
+`coverageThreshold` override in `jest.config.js`.

--- a/packages/nestjs-rxjs-redis/AGENTS.md
+++ b/packages/nestjs-rxjs-redis/AGENTS.md
@@ -10,7 +10,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   index.ts                            — barrel: service, module (named exports, not `export *`)
   nestjs-rxjs-redis-core.module.ts    — @Global() NestJSRxJSRedisCoreModule.forRootAsync(options)

--- a/packages/nestjs-rxjs-redis/AGENTS.md
+++ b/packages/nestjs-rxjs-redis/AGENTS.md
@@ -37,8 +37,9 @@ src/
 - `mget$<K extends string>(keys)` zips the resolved value array back onto the input `keys` via `reduce`, returning
   `Record<K, string | null>` — the only method that turns a positional array result into a keyed object
 - Operator methods (`save`, `load`, `remove`, `cache`) are pipeable `MonoTypeOperatorFunction`/`OperatorFunction`s that
-  wrap the `$` methods; all default their `keyFn`/`errorFn`/`toValueFn`/`fromValueFn` params (`String(input)` for keys,
-  `JSON.stringify`/`JSON.parse` for (de)serialization)
+  wrap the `$` methods; `load`, `remove`, and `cache` default their `keyFn`/`errorFn`/`toValueFn`/`fromValueFn` params
+  (`String(input)` for keys, `JSON.stringify`/`JSON.parse` for (de)serialization) — `save` takes `keyFn` as its first,
+  required parameter (no default), since the caller must say how to derive a Redis key from the value being saved
 - `cache(ttlInSeconds, prepareFn$, keyFn?, fromValueFn?, toValueFn?)`: on each input, tries `get$(key)` + `fromValueFn`
   first; if that observable errors (cache miss or Redis error, indistinguishable), falls back to
   `prepareFn$(key)` and pipes its result into `set$` before re-emitting the freshly prepared value — a cache miss and

--- a/packages/nestjs-typed-config/AGENTS.md
+++ b/packages/nestjs-typed-config/AGENTS.md
@@ -10,7 +10,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   index.ts                          — barrel: module, service
   env.type.ts                       — EnvType<T, K extends keyof T> = T[K] (indexed access utility type)

--- a/packages/nestjs-typed-config/AGENTS.md
+++ b/packages/nestjs-typed-config/AGENTS.md
@@ -12,23 +12,44 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ```
 src/
-  env.type.ts                        — EnvType<T, K> utility type (indexed access)
-  nest-js-typed-config.module.ts     — NestJSTypedConfigModule with create() factory
-  nest-js-typed-config.service.ts    — NestJSTypedConfigService<EnvEnum, EnvTypes, EnvKeys>
+  index.ts                          — barrel: module, service
+  env.type.ts                       — EnvType<T, K extends keyof T> = T[K] (indexed access utility type)
+  nest-js-typed-config.module.ts    — NestJSTypedConfigModule.create<Enum, C>(joiSchema)
+  nest-js-typed-config.service.ts   — NestJSTypedConfigService<EnvEnum, EnvTypes, EnvKeys>
 ```
 
 ### Key Patterns
 
-- `NestJSTypedConfigModule.create<Enum, Config>(joiSchema)` returns `[DynamicModule, Type<Service>]` — same tuple pattern as other NestJS packages
-- Module is `global: true` with `ConfigModule.forRoot({ cache: true, validationOptions: { abortEarly: false } })`
-- `_FILE` env variables: if key ends in `_FILE`, reads filesystem path and returns file content (trimmed)
-- Values cached in `private readonly envCache = new Map()` to avoid repeated lookups/file reads
-- Falls back from `_FILE` to non-`_FILE` env var if file var is unset
+- `NestJSTypedConfigModule.create<Enum extends string, C extends Record<Enum, boolean | number | string>>(joiSchema:
+  Joi.ObjectSchema<C>)` declares an inline `class Service extends NestJSTypedConfigService<Enum, C, Extract<keyof C,
+  string>>` with no constructor override, wires `ConfigModule.forRoot({ cache: true, validationSchema: joiSchema,
+  validationOptions: { abortEarly: false }, isGlobal: true })`, and returns `[DynamicModule, Type<Service>]` — the
+  returned `DynamicModule` itself also sets `global: true`, so the module is global on two levels: NestJS's own
+  `ConfigModule` and this module's own `providers`/`exports`
+- `abortEarly: false` means Joi validation reports every failing env var at once instead of stopping at the first
+  failure
+- `NestJSTypedConfigService.get<T extends EnvKeys>(envVariable)` checks `envCache` (a `Map`) first; a cache hit
+  short-circuits straight to the stored value plus a debug log, so file reads and `ConfigService.get` calls only ever
+  happen once per key for the lifetime of the service instance
+- On a cache miss, `get` reads `ConfigService.get(envVariable)` and branches on `envVariable.endsWith('_FILE')`:
+  - **matches**: delegates to `handleFileEnvVariable`, which reads the `_FILE` key's own value as a candidate
+    filesystem path (`isNotEmptyString(filePath)`); if that path is set, `readFileEnvFromFS` requires
+    `existsSync(path)` (throwing `Error('Could not read file "<envVariable>"')` if it's missing) and returns
+    `readFileSync(path).toString().trim()`; if the `_FILE` variable itself is unset, `readFileEnvFromEnvironment`
+    falls back to `ConfigService.get` on the same key with the `_FILE` suffix stripped
+  - **no match**: the raw `ConfigService.get` result is cached and returned directly
+- Every branch writes its result into `envCache` before returning — including the file-path branch — so `_FILE`-backed
+  values are only ever read from disk once
+- `EnvType<T, K extends keyof T> = T[K]` exists purely to give `get()` a return type that narrows per the specific
+  `envVariable` key passed in, rather than the union of all possible config value types
 
 ### Dependencies
 
-Peers: `@nestjs/common`, `@nestjs/config`, `joi`. Internal: `@rnw-community/shared`.
+Peers: `@nestjs/common`, `@nestjs/config`, `joi` (all declared in both `devDependencies` and `peerDependencies`, plus
+`@types/hapi__joi` as a type-only devDependency). Direct dependency: `@rnw-community/shared` (`isNotEmptyString`, used
+in production `src`).
 
 ### Coverage
 
-Default: **99.9%** all metrics.
+Default monorepo threshold: **99.9%** on all metrics (statements, branches, functions, lines) — no package-level
+`coverageThreshold` override in `jest.config.js`.

--- a/packages/nestjs-webpack-swc/AGENTS.md
+++ b/packages/nestjs-webpack-swc/AGENTS.md
@@ -8,36 +8,72 @@ Pre-configured Webpack + SWC build configs for NestJS — dev (HMR) and prod (Te
 yarn build && yarn ts && yarn lint:fix
 ```
 
-Note: This package has **no unit tests** — it is a configuration/utility library.
+This package has **no `test` or `test:coverage` script** in `package.json` — only `ts`, `build:esm`, `build:cjs`,
+`build`, `lint`, `lint:fix`, `format`, `clear`, `clear:deps`. A `jest.config.js` exists (delegating to the shared
+`get-jest.config.js` like every other package) but nothing invokes it — no script runs `jest` and no `.spec.ts` files
+exist under `src/`. Treat the config as orphaned scaffolding, not a live coverage gate: there is no unit-test coverage
+percentage to report for this package, and none should be assumed or backfilled without first adding a `test` script.
 
 ## Architecture
 
 ```
 src/
+  index.ts                                     — barrel: `export * from './typeorm'` + `export * from './hmr'`
+                                                  (does NOT re-export config/ — see Subpath Exports)
   config/
-    swc.config.ts                       — Base SWC options (es2020, decorators, keepClassNames)
-    get-nestjs-webpack-generic.config.ts — Shared base Webpack config factory (internal)
-    get-nestjs-webpack-dev.config.ts     — Dev config (HMR via polling, WatchIgnorePlugin, RunScriptWebpackPlugin)
-    get-nestjs-webpack-prod.config.ts    — Prod config (TerserPlugin, no mangle, keep_classnames)
+    swc.config.ts                               — swcConfig: es2020 target, TS parser with decorators,
+                                                    legacyDecorator + decoratorMetadata transforms, keepClassNames
+    get-nestjs-webpack-generic.config.ts         — getNestJSWebpackGenericConfig(options, swcOptions?, allowList?):
+                                                    shared base (never exported, internal-only)
+    get-nestjs-webpack-dev.config.ts             — getNestJSWebpackDevConfig(options, webpack)
+    get-nestjs-webpack-prod.config.ts            — getNestJSWebpackProdConfig(options, _webpack)
   hmr/
-    handle-nestjs-webpack-hmr.ts         — Wires HMR accept/dispose on NestJS app
-    hmr-module.interface.ts              — HmrModuleInterface type
+    index.ts                                     — barrel: HmrModuleInterface (type), handleNestJSWebpackHmr
+    handle-nestjs-webpack-hmr.ts                  — handleNestJSWebpackHmr(app, webpackModule)
+    hmr-module.interface.ts                       — HmrModuleInterface ({ hot?: { accept, dispose } })
   typeorm/
-    import-typeorm-webpack-migrations.util.ts — Loads TypeORM migrations from webpack require.context
+    index.ts                                      — barrel: importTypeormWebpackMigrations
+    import-typeorm-webpack-migrations.util.ts     — importTypeormWebpackMigrations(requireContext)
 ```
 
 ### Subpath Exports
 
-`./get-nestjs-webpack-dev.config`, `./get-nestjs-webpack-prod.config` — config factories are NOT in the root barrel (intended as targeted imports).
+`./get-nestjs-webpack-dev.config`, `./get-nestjs-webpack-prod.config` — the two config factories are reached only via
+these subpaths; the root `index.ts` barrel exports just `typeorm` and `hmr` (`HmrModuleInterface`,
+`handleNestJSWebpackHmr`, `importTypeormWebpackMigrations`). `get-nestjs-webpack-generic.config.ts` and
+`swc.config.ts` are never exported at all, from either the root or a subpath — they exist purely to be composed by
+the dev/prod factories.
 
 ### Key Patterns
 
-- Layered factory: `generic` → `dev` or `prod` (generic is internal, never exported)
-- NestJS-safe Terser: `mangle: false`, `keep_classnames: true` (NestJS DI depends on class names)
-- HMR via `webpack/hot/poll?100` (polling, robust in Docker/VM environments)
-- `webpack-node-externals` with `modulesFromFile: true` (reads from package.json)
-- Filesystem cache at `.build_cache/` for faster rebuilds
+- Layered factory: `getNestJSWebpackGenericConfig(options, swcOptions?, allowList?)` is spread into by both
+  `getNestJSWebpackDevConfig` and `getNestJSWebpackProdConfig`; it is never exported itself
+- The generic config always injects `'webpack/hot/poll?100'` into the `webpack-node-externals` `allowlist` — even for
+  the prod config — in addition to whatever `allowList` the caller passes (normalized via
+  `Array.isArray(allowList) ? allowList : [allowList]`)
+- `getNestJSWebpackProdConfig(options, _webpack)` calls the generic factory with `swcOptions = { minify: true }` and
+  `allowList = '@rnw-community/nestjs-webpack-swc'` — the package allowlists **itself** by name in
+  `webpack-node-externals` so its own runtime helpers aren't externalized out of the prod bundle; its second
+  parameter (`_webpack`) is accepted for signature symmetry with the dev factory but is otherwise unused
+- NestJS-safe Terser in prod: `mangle: false`, `keep_classnames: true` — NestJS's DI/reflection depends on
+  constructor names surviving minification
+- Dev config prepends `'webpack/hot/poll?100'` to `entry`, adds `HotModuleReplacementPlugin`,
+  `WatchIgnorePlugin({ paths: [/\.js$/, /\.d\.ts$/] })`, and `RunScriptWebpackPlugin({ autoRestart: false })` — polling
+  HMR is chosen over native filesystem watchers because it stays reliable in Docker/VM dev environments where inotify
+  events don't propagate from bind mounts
+- `webpack-node-externals` is configured with `modulesFromFile: true` (reads externals from `package.json` rather than
+  scanning `node_modules`) on top of the allowlist described above
+- Filesystem build cache lives at `path.resolve(process.cwd(), '.build_cache')` with `allowCollectingMemory: true`
+- `handleNestJSWebpackHmr(app, webpackModule)` is a no-op unless `isDefined(webpackModule.hot)`; when present it calls
+  `hot.accept()` and registers `hot.dispose(() => app.close())` so a hot-swapped module cleanly tears down the running
+  Nest application before the replacement takes over
+- `importTypeormWebpackMigrations(requireContext)` sorts `requireContext.keys()`, requires each module, and keeps only
+  the exports whose value is a `function` — this is how TypeORM migration classes are collected from a Webpack
+  `require.context` bundle without relying on filesystem globbing at runtime
 
 ### Dependencies
 
-Peers: `webpack`, `swc-loader`, `@swc/core`, `@swc/cli`, `@swc/helpers`, `run-script-webpack-plugin`, `terser-webpack-plugin`, `webpack-node-externals`, `@nestjs/common`. Internal: `@rnw-community/shared`.
+Peers: `@nestjs/common`, `@swc/cli`, `@swc/core`, `@swc/helpers`, `run-script-webpack-plugin`, `swc-loader`,
+`terser-webpack-plugin`, `webpack`, `webpack-node-externals` (all consumer-supplied at their own compatible
+versions — declared as `peerDependencies`, with matching `devDependencies` pins for building/type-checking this
+package itself). Direct dependency: `@rnw-community/shared` (`isDefined`, used in `handleNestJSWebpackHmr`).

--- a/packages/nestjs-webpack-swc/AGENTS.md
+++ b/packages/nestjs-webpack-swc/AGENTS.md
@@ -16,7 +16,7 @@ percentage to report for this package, and none should be assumed or backfilled 
 
 ## Architecture
 
-```
+```text
 src/
   index.ts                                     — barrel: `export * from './typeorm'` + `export * from './hmr'`
                                                   (does NOT re-export config/ — see Subpath Exports)

--- a/packages/nestjs-webpack-swc/AGENTS.md
+++ b/packages/nestjs-webpack-swc/AGENTS.md
@@ -75,5 +75,8 @@ the dev/prod factories.
 
 Peers: `@nestjs/common`, `@swc/cli`, `@swc/core`, `@swc/helpers`, `run-script-webpack-plugin`, `swc-loader`,
 `terser-webpack-plugin`, `webpack`, `webpack-node-externals` (all consumer-supplied at their own compatible
-versions — declared as `peerDependencies`, with matching `devDependencies` pins for building/type-checking this
-package itself). Direct dependency: `@rnw-community/shared` (`isDefined`, used in `handleNestJSWebpackHmr`).
+versions — declared as `peerDependencies`). Only `@nestjs/common`, `run-script-webpack-plugin`,
+`terser-webpack-plugin`, `webpack`, and `webpack-node-externals` also have a matching `devDependencies` pin for
+building/type-checking this package itself; `@swc/cli`, `@swc/core`, `@swc/helpers`, and `swc-loader` have no
+devDependency entry in this package's own `package.json`. Direct dependency: `@rnw-community/shared` (`isDefined`,
+used in `handleNestJSWebpackHmr`).

--- a/packages/object-field-tree/AGENTS.md
+++ b/packages/object-field-tree/AGENTS.md
@@ -1,6 +1,6 @@
 # @rnw-community/object-field-tree
 
-Generates fully-typed nested lookup objects from combinations of enum-like objects using a data generator function. Type-safe Cartesian product of enum keys.
+Generates a fully-typed nested lookup object from 1-5 enum-like collections, calling a data generator function once per leaf combination. Type-safe Cartesian product of enum keys.
 
 ## Package Commands
 
@@ -13,24 +13,30 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 ```
 src/
   type/
-    data-fn.type.ts    — DataFn1..DataFn5 (typed generator function signatures)
-    return.type.type.ts     — CombineReturn1..CombineReturn5 (nested Record return types)
-  index.ts             — exports combine() + types
-  index.spec.ts        — tests (co-located with index, unusual for this repo — package is small)
+    data-fn.type.ts    — DataFn1..DataFn5: (t1: keyof T1, ..., tN: keyof TN) => D
+    return.type.ts     — CombineReturn1..CombineReturn5: nested Record<keyof T1, Record<keyof T2, ...>>
+  index.ts             — combine() overloads (arity 1-5) + runtime implementation, re-exports Enum
+  index.spec.ts        — tests (co-located with index — the only file in the package with a spec)
 ```
 
 ### Key Patterns
 
-- `combine(dataFn, ...enums)` — overloaded for 1-5 enum args, builds nested object where each leaf is `dataFn(key1, key2, ...)`
-- Runtime implementation is recursive: shifts first object, recurses with partial-application of `dataFn`
-- Used by `fast-style` to build the `Flex` constant (3D: direction x justifyContent x alignItems)
-- Re-exports `Enum` type from `@rnw-community/shared`
+- `combine(dataFn, collection1, ..., collectionN)` is overloaded for exactly **1 through 5** collections
+  (`DataFn1`/`CombineReturn1` … `DataFn5`/`CombineReturn5`); there is no 6-collection overload, though the untyped
+  implementation signature (`dataFn, ...objects: any[]`) would run with any count at runtime
+- The runtime implementation in `index.ts` is genuinely recursive: it `shift()`s the first collection off `objects`,
+  and for each of its keys recurses with `combine((...args) => dataFn(key, ...args), ...objects)` (partial
+  application), terminating with `dataFn(key)` once `objects` is empty
+- `Object.keys()` enumerates collection keys, so both string and numeric TypeScript enums work — a numeric enum's
+  reverse-mapping entries (`'0': 'Key'`) are walked like any other key, which is why the spec covers a 2-numeric-enum
+  case explicitly
+- Consumed by `fast-style` to build the `Flex` 3D lookup constant (direction x justifyContent x alignItems)
+- Re-exports `Enum` type from `@rnw-community/shared` — the constraint every `T1..T5` collection type must satisfy
 
 ### Dependencies
 
-`@rnw-community/shared` (for `Enum` type).
+- `@rnw-community/shared` — supplies the `Enum` constraint type used by every `combine()` overload
 
 ### Coverage
 
-Default: **99.9%** all metrics.
-```
+Default monorepo threshold: 99.9% on all metrics.

--- a/packages/object-field-tree/AGENTS.md
+++ b/packages/object-field-tree/AGENTS.md
@@ -10,7 +10,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   type/
     data-fn.type.ts    — DataFn1..DataFn5: (t1: keyof T1, ..., tN: keyof TN) => D

--- a/packages/platform/AGENTS.md
+++ b/packages/platform/AGENTS.md
@@ -10,7 +10,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   platform/
     platform.ts       — isWeb, isIOS, isAndroid, isMobile: booleans derived once from react-native's Platform.OS

--- a/packages/platform/AGENTS.md
+++ b/packages/platform/AGENTS.md
@@ -1,6 +1,6 @@
 # @rnw-community/platform
 
-React Native/Web platform detection utilities, conditional styling helpers, and cross-platform env abstraction.
+React Native/Web platform detection constants, conditional styling helpers, and a cross-platform env-variable getter.
 
 ## Package Commands
 
@@ -12,24 +12,39 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ```
 src/
-  platform/        — isWeb, isIOS, isAndroid, isMobile boolean constants + platform.mock.ts
-  platform-style/  — webStyles, mobileStyles, iosStyles, androidStyles helpers
-  get-env/         — getEnv (RN: react-native-config) / get-env.web.ts (Web: process.env)
+  platform/
+    platform.ts       — isWeb, isIOS, isAndroid, isMobile: booleans derived once from react-native's Platform.OS
+    platform.mock.ts   — jest.mock('react-native', ...) stub forcing Platform.OS to the sentinel 'no'
+  platform-style/
+    platform-style.ts  — webStyles, mobileStyles, iosStyles, androidStyles (all built on one internal platformStyles helper)
+  get-env/
+    get-env.ts         — getEnv(key): reads react-native-config's Config[key] (native/RN target)
+    get-env.web.ts      — getEnv(key): reads process.env[`REACT_APP_${key}`] (web target, resolved via the .web.ts suffix)
+  index.ts             — re-exports the platform booleans, the 4 style helpers, and getEnv
 ```
 
 ### Key Patterns
 
-- `.web.ts` suffix pattern for Metro/webpack platform resolution
-- `platform.mock.ts` provides test overrides for platform booleans
-- `platformStyles(condition)(style)` returns style only if platform matches, else `{}`
-- `getEnv(key)` on web returns `process.env['REACT_APP_' + key]`
-- Jest uses `'react-native'` preset
+- `.web.ts` suffix on `get-env.web.ts` is the Metro/webpack platform-resolution convention: bundlers pick it over
+  `get-env.ts` when building for web, so `getEnv` has one call-site contract with two source implementations
+- `platformStyles(isPlatform: boolean, style: T): R | object` is **not curried** — it takes both the platform flag and
+  the style object as plain arguments and returns `style` if `isPlatform` is true, else `{}`; each exported helper
+  (`webStyles`, `mobileStyles`, `iosStyles`, `androidStyles`) is a thin single-arg wrapper that closes over one of the
+  imported `is*` booleans
+- `platform.mock.ts` sets `Platform.OS` to the non-standard string `'no'` (not `'ios'`/`'android'`/`'web'`), so every
+  boolean is `false` by default when a spec imports the mock; specs that need a specific platform then reassign the
+  exported `const` directly (`constants.isWeb = true`) via `@ts-expect-error`, since the module has no setter API
+- `getEnv` has no shared implementation between targets: the RN version delegates entirely to `react-native-config`'s
+  default export indexed by `key`; the web version indexes `process.env` with a hardcoded `REACT_APP_` prefix
+- Jest preset is `'react-native'` (second arg to `get-jest.config.js('platform', 'react-native')`), unlike the other
+  packages in this document which pass no preset
 
 ### Dependencies
 
-Peers: `react`, `react-native`, `react-native-config`. No internal deps.
+- No runtime `dependencies` — this package has none
+- Peers: `react` (>=18), `react-native` (>=0.72), `react-native-config` (>=1.4) — all three are also devDependencies
+  for local type-checking and the `platform.mock.ts` jest mock
 
 ### Coverage
 
-Default: **99.9%** all metrics.
-```
+Default monorepo threshold: 99.9% on all metrics.

--- a/packages/react-native-payments-example/AGENTS.md
+++ b/packages/react-native-payments-example/AGENTS.md
@@ -28,6 +28,17 @@ apps/
     index.js, app.json, babel.config.js, metro.config.js, ios/, android/
   expo/                          — @rnw-community/react-native-payments-example-expo (Expo)
     index.js, app.json, babel.config.js, metro.config.js, assets/
+e2e/
+  flows/                         — one Maestro scenario per file (app_launch, can_make_payment_probe,
+                                   sheet_opens_on_show, dismiss_abort_reject_state,
+                                   shipping_listener_wiring_enabled/disabled, async_update_toggle_state,
+                                   reset_new_request_state_transitions), run directly by `maestro test`
+  subflows/                      — shared steps included via `runFlow` (dismiss_ios_sheet, show_request,
+                                   launch_and_wait_for_probe), never run standalone
+  readme.md                      — flow inventory, APP_ID table per target/platform, and the two documented
+                                   E2E coverage gaps (iOS PassKit sheet sandboxes the app's own accessibility
+                                   tree while presented; native-sheet-driven completion is out of reach on a
+                                   simulator/emulator)
 ```
 
 `apps/bare` and `apps/expo` are nested Yarn workspaces (root glob `packages/react-native-payments-example/apps/*`). They are
@@ -62,14 +73,30 @@ excluded from Lerna (`lerna.json` keeps `packages/*`), so they are never version
 - Change-event listeners are attached per request in `attach-change-listeners.ts`: `paymentmethodchange` always,
   the shipping pair when `requestShipping` is on, `couponcodechange` only on iOS with the coupon toggle on. On Android the
   log records the documented no-op instead of staying silent.
+- The Maestro suite is one shared, parameterized flow set per scenario, not one per app target/platform: only the `APP_ID`
+  env value and the connected device change between `apps/bare`/`apps/expo` and iOS/Android, and in-flow platform branching
+  uses Maestro's `when: platform:` condition. Flows assert against the on-screen event log and flow-state/can-make-status
+  labels, never native dialogs directly — except five iOS flows, which briefly assert against the PassKit sheet's own
+  accessibility tree (via `subflows/dismiss_ios_sheet.yaml`) purely to dismiss it, since iOS blocks UI-test tooling from
+  querying the app's own tree while that sheet is presented.
+- `.github/workflows/ios-maestro.yml` and `android-maestro.yml` at the repo root run this suite per matrix target
+  (`bare`/`expo`) on `[self-hosted, macOS, ARM64, macos-maestro]` / an equivalent Android runner, gated by a
+  turbo-`--affected` check against this package and its two app workspaces. As of this writing the workflows are wired but
+  queue rather than execute — the self-hosted fleet label is not yet registered (tracked separately) — so treat CI as
+  configured, not as a currently green signal. The `maestro-e2e` agent skill (`.claude/skills/maestro-e2e`) documents how to
+  drive and extend the suite locally.
 
 ## Commands
 
 Target scripts live on this package and delegate to the nested workspaces: `ios:bare`, `android:bare`, `start:bare`,
 `ios:expo`, `android:expo`, `start:expo`, `prebuild:expo`. `ts`, `lint`, `lint:fix` and `format` cover `src` only.
+`e2e:ios:bare`, `e2e:ios:expo`, `e2e:android:bare`, `e2e:android:expo` each run `maestro test -e APP_ID=<target appId>
+e2e/flows` against whichever simulator/emulator is currently booted — the app under test must already be built and
+installed (`ios:bare`/`android:bare`/`ios:expo`/`android:expo`, or `prebuild:expo` first for the Expo native projects).
 
 ## Dependencies
 
 `@rnw-community/react-native-payments` (workspace), `@rnw-community/shared` (workspace), `react`, `react-native`.
 
-This is an example/demo package — no tests, no build, no publish.
+This is an example/demo package — no unit tests, no build, no publish. It does carry a real, runnable Maestro e2e suite
+(`e2e/`) exercising the JS-observable half of the demo flow; see `e2e/readme.md` for the coverage boundary.

--- a/packages/react-native-payments-example/AGENTS.md
+++ b/packages/react-native-payments-example/AGENTS.md
@@ -4,7 +4,7 @@ Private. Single example package for the Payment Request API library, with one sh
 
 ## Layout
 
-```
+```text
 src/
   index.ts                       — exports `App`
   component/                     — app.tsx, demo-status.tsx, request-builder-form.tsx, demo-actions.tsx,

--- a/packages/react-native-payments-example/AGENTS.md
+++ b/packages/react-native-payments-example/AGENTS.md
@@ -76,7 +76,7 @@ excluded from Lerna (`lerna.json` keeps `packages/*`), so they are never version
 - The Maestro suite is one shared, parameterized flow set per scenario, not one per app target/platform: only the `APP_ID`
   env value and the connected device change between `apps/bare`/`apps/expo` and iOS/Android, and in-flow platform branching
   uses Maestro's `when: platform:` condition. Flows assert against the on-screen event log and flow-state/can-make-status
-  labels, never native dialogs directly — except five iOS flows, which briefly assert against the PassKit sheet's own
+  labels, never native dialogs directly — except six iOS flows, which briefly assert against the PassKit sheet's own
   accessibility tree (via `subflows/dismiss_ios_sheet.yaml`) purely to dismiss it, since iOS blocks UI-test tooling from
   querying the app's own tree while that sheet is presented.
 - `.github/workflows/ios-maestro.yml` and `android-maestro.yml` at the repo root run this suite per matrix target

--- a/packages/redux-loadable/AGENTS.md
+++ b/packages/redux-loadable/AGENTS.md
@@ -11,7 +11,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   interface/
     loading-state.interface.ts    — LoadingStateInterface { error: string; isLoading: boolean; isPristine: boolean } + initialLoadingState

--- a/packages/redux-loadable/AGENTS.md
+++ b/packages/redux-loadable/AGENTS.md
@@ -1,6 +1,7 @@
 # @rnw-community/redux-loadable
 
-Minimal Redux Toolkit-compatible loading state pattern — interface, initial state, state-mutation utilities, and curried selector.
+Minimal Redux Toolkit-compatible loading-state pattern — an interface, an initial state, state-mutation utilities, and
+a curried selector.
 
 ## Package Commands
 
@@ -12,20 +13,35 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ```
 src/
-  interface/  — LoadingStateInterface { error, isLoading, isPristine } + initialLoadingState
-  selectors/  — loadingStateSelector (curried: (slice) => (state) => [isLoading, isFailed, isPristine, error])
-  utils/      — loadingStarted, loadingFinished, loadingFailed, loadingReset
+  interface/
+    loading-state.interface.ts    — LoadingStateInterface { error: string; isLoading: boolean; isPristine: boolean } + initialLoadingState
+  selectors/
+    loading-state-slice-selector.type.ts   — LoadingStateSliceSelector<R>: <S>(slice: keyof S) => (state: S) => R
+    loading-state.selector.ts               — loadingStateSelector: curried (slice) => (state) => [isLoading, isFailed, isPristine, error]
+  utils/
+    loading-started.util.ts    — loadingStarted(state): isLoading=true, isPristine=false, error reset
+    loading-finished.util.ts   — loadingFinished(state): isLoading=false, isPristine=false, error reset
+    loading-failed.util.ts     — loadingFailed(state, errorReason): isLoading=false, isPristine=false, error=errorReason
+    loading-reset.util.ts      — loadingReset(state): all three fields back to initialLoadingState's values
+  index.ts   — re-exports LoadingStateInterface, initialLoadingState, loadingStateSelector, and the 4 utils
 ```
 
 ### Key Patterns
 
-- State utils mutate then return `{ ...state }` — designed for RTK createSlice (Immer)
-- `isPristine` tracks "never loaded yet" — changes only once on first `loadingStarted`
-- `isFailed` derived as `error !== ''` (no separate boolean stored)
-- Curried selector: `loadingStateSelector('mySlice')(state)` returns 4-element tuple
-- Zero dependencies — framework-agnostic state helpers
+- Every util is generic over `T extends LoadingStateInterface`, mutates the three fields on `state` directly, then
+  returns `{ ...state }` — the mutate-then-spread shape matches Redux Toolkit's Immer-drafted `createSlice` reducers
+- `isPristine` means "this slice has never finished a loading cycle" — it starts `true` in `initialLoadingState` and
+  every one of `loadingStarted`/`loadingFinished`/`loadingFailed` sets it to `false`; only `loadingReset` can restore
+  it to `true`
+- There is no separate `isFailed` field stored on state. `loadingFailed` only sets `error` to the given reason;
+  "failed" is derived downstream — `loadingStateSelector`'s tuple computes it inline as `state[slice].error !== ''`
+- `loadingStateSelector` is curried: `LoadingStateSliceSelector<R> = <S>(slice: keyof S) => (state: S) => R`, called as
+  `loadingStateSelector('mySlice')(state)`, returning the 4-tuple
+  `[isLoading, isFailed, isPristine, errorText]` — `isFailed` at index 1 is the same `error !== ''` derivation, not
+  reading a stored boolean
+- No production `dependencies` in package.json — the utilities are framework-agnostic and only assume the
+  `LoadingStateInterface` shape
 
 ### Coverage
 
-Default: **99.9%** all metrics.
-```
+Default monorepo threshold: 99.9% on all metrics.

--- a/packages/redux-loadable/AGENTS.md
+++ b/packages/redux-loadable/AGENTS.md
@@ -30,7 +30,7 @@ src/
 
 - Every util is generic over `T extends LoadingStateInterface`, mutates the three fields on `state` directly, then
   returns `{ ...state }` — the mutate-then-spread shape matches Redux Toolkit's Immer-drafted `createSlice` reducers
-- `isPristine` means "this slice has never finished a loading cycle" — it starts `true` in `initialLoadingState` and
+- `isPristine` means "this slice has never started a loading cycle" — it starts `true` in `initialLoadingState` and
   every one of `loadingStarted`/`loadingFinished`/`loadingFailed` sets it to `false`; only `loadingReset` can restore
   it to `true`
 - There is no separate `isFailed` field stored on state. `loadingFailed` only sets `error` to the given reason;

--- a/packages/rxjs-errors/AGENTS.md
+++ b/packages/rxjs-errors/AGENTS.md
@@ -1,6 +1,7 @@
 # @rnw-community/rxjs-errors
 
-RxJS pipeable operators for typed error handling — `filterWithException` (type-guard-aware filter) and `rethrowException` (catch, log, rethrow/wrap).
+RxJS pipeable operators for typed error handling — `filterWithException` (type-guard-aware filter that throws instead
+of silently dropping) and `rethrowException` (catch, log, then rethrow or wrap).
 
 ## Package Commands
 
@@ -13,28 +14,44 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 ```
 src/
   operator/
-    filter-with-exception-operator/  — filterWithException (concatMap + throwError, supports type guards)
-    rethrow-exception-operator/      — rethrowException (catchError, log, rethrow or wrap)
+    filter-with-exception-operator/
+      filter-with-exception.operator.ts   — filterWithException(passingCondition, errorCodeOrMsgFn, createError?)
+    rethrow-exception-operator/
+      rethrow-exception.operator.ts       — rethrowException(errStringOrMessageFn, logFn, ErrorCtor?, createError?)
   type/
-    create-error-fn.type.ts          — CreateErrorFn + defaultCreateError factory
-    error-code-or-msg-fn.type.ts     — ErrorCodeOrMsgFn<TInput> = string | ((val) => string)
-    error-ctor.type.ts               — ErrorCtor type
-  rxjs-filter-error.ts              — RxJSFilterError extends Error (default error type)
+    create-error-fn.type.ts      — CreateErrorFn = (msg: string) => Error, + defaultCreateError(ErrorCtor) factory
+    error-code-or-msg-fn.type.ts — ErrorCodeOrMsgFn<TInput> = string | ((val: TInput) => string)
+    error-ctor.type.ts           — ErrorCtor = new (msg: string, ...args: never[]) => Error
+  rxjs-filter-error.ts           — RxJSFilterError extends Error (the default error class for both operators)
+  index.ts                      — re-exports RxJSFilterError, filterWithException, rethrowException
 ```
 
 ### Key Patterns
 
-- `filterWithException` uses `concatMap` (not `filter`) to replace passing items with `of(val)` and failing items with `throwError()`
-- Supports type narrowing: `passingCondition` can be a type guard `(val: TInput) => val is TOutput`
-- `rethrowException` avoids double-wrapping: `err instanceof ErrorCtor ? err : createError(message)`
-- `ErrorCodeOrMsgFn<TInput>` union: string or `(val: TInput) => string` for dynamic error messages
-- `defaultCreateError(ErrorCtor)` factory creates a `CreateErrorFn` from a constructor
+- `filterWithException(passingCondition, errorCodeOrMsgFn, createError = defaultCreateError(RxJSFilterError))` uses
+  `concatMap` (not `filter`) so it can replace a passing value with `of(val)` and a failing one with
+  `throwError(() => createError(...))` in the same operator — a plain `filter` cannot throw
+- `passingCondition` accepts either a plain predicate or a type guard (`(val: TInput) => val is TOutput`), so the
+  observable's emitted type narrows to `TOutput` on the happy path without an extra cast
+- `rethrowException(errStringOrMessageFn, logFn, ErrorCtor = RxJSFilterError, createError = defaultCreateError(ErrorCtor))`
+  wraps `catchError`: it always resolves the message (string or `(err: unknown) => string`), always calls
+  `logFn(`${message}: ${getErrorMessage(err)}`)`, then rethrows the original error unchanged if it is already an
+  `instanceof ErrorCtor`, otherwise rethrows `createError(message)` — this avoids double-wrapping an error that was
+  already produced by an earlier `rethrowException`/`filterWithException` in the same pipe
+- `ErrorCodeOrMsgFn<TInput>` is the shared union (`string | ((val: TInput) => string)`) both operators use for their
+  message argument, letting callers pass a dynamic, value-dependent message
+- `defaultCreateError(ErrorCtor)` is the shared factory (`msg => new ErrorCtor(msg)`) both operators fall back to when
+  no explicit `createError` is supplied
+- `ErrorCtor`'s constructor signature is `new (msg: string, ...args: never[]) => Error` — the `never[]` rest
+  deliberately blocks constructors that require more than a message
 
 ### Dependencies
 
-`@rnw-community/shared` (for `getErrorMessage`). Peer: `rxjs`.
+- `@rnw-community/shared` — `getErrorMessage` extracts a safe `.message` string inside `rethrowException`'s log line
+- Peer: `rxjs` (^7.8.1)
+- DevDependency `expect-type` is used only in `filter-with-exception.operator.spec.ts` to assert compile-time type
+  narrowing on the type-guard overload
 
 ### Coverage
 
-Default: **99.9%** all metrics.
-```
+Default monorepo threshold: 99.9% on all metrics.

--- a/packages/rxjs-errors/AGENTS.md
+++ b/packages/rxjs-errors/AGENTS.md
@@ -11,7 +11,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   operator/
     filter-with-exception-operator/

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -10,7 +10,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   type/                             — TypeScript utility types, one folder per entity
     maybe-type/                     — Maybe<T> = T | null

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -1,58 +1,67 @@
 # @rnw-community/shared
 
-Core utility hub — type guards, helper functions, and TypeScript utility types. Zero dependencies. Many packages in the monorepo depend on this package.
+Core utility hub — type guards, helper functions, and TypeScript utility types. Zero runtime dependencies; the most-depended-on package in the monorepo.
 
 ## Package Commands
 
 ```bash
-yarn test               # Run tests
-yarn test --watch       # Watch mode
-yarn test:coverage      # Tests with coverage
-yarn build              # Build (dual ESM + CJS)
-yarn ts                 # Type check
-yarn lint:fix           # Fix lint issues
+yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 ```
 
 ## Architecture
 
-### Directory Layout
-
 ```
 src/
-  type/           — TypeScript utility types (Maybe, AnyFn, ClassType, EmptyFn, Enum, MethodDecoratorType, etc.)
-  type-guard/     — Runtime type narrowing functions
-    generic/      — isDefined, isError, isObject, isPromise, isRecord
-    array/        — isArray, isEmptyArray, isNotEmptyArray, isNotEmptyArrayOf
-    boolean/      — isBoolean
-    number/       — isNumber, isPositiveNumber
-    string/       — isString, isEmptyString, isNotEmptyString
-  util/           — Runtime utilities (cs, emptyFn, getDefined, getErrorMessage, wait)
+  type/                             — TypeScript utility types, one folder per entity
+    maybe-type/                     — Maybe<T> = T | null
+    empty-fn-type/                  — EmptyFn = (...args: any[]) => void
+    any-fn-type/                    — AnyFn = (...args: any) => any
+    class-type/                     — ClassType<T> = new (...args: any[]) => T
+    abstract-constructor-type/      — AbstractConstructor<T> = abstract new (...args: any[]) => T
+    method-decorator-type/          — MethodDecoratorType<K> (typed method-decorator factory result)
+    on-event-fn-type/               — OnEventFn<T, R> = (event: T) => R
+    enum-type/                      — Enum<D> = Record<string, D>
+    is-not-empty-array-type/        — IsNotEmptyArray<T> = [T, ...T[]]
+    readonly-is-not-empty-array-type/ — ReadonlyIsNotEmptyArray<T> = readonly [T, ...T[]]
+  type-guard/                       — Runtime type narrowing functions, one folder per entity
+    generic/    — isDefined, isError, isObject, isPromise, isRecord
+    array/      — isArray, isEmptyArray, isNotEmptyArray, isNotEmptyArrayOf (+ is-never.spec-type.ts, a
+                  compile-time-only IsNever<T> helper used by the array specs, never exported)
+    boolean/    — isBoolean
+    number/     — isNumber, isPositiveNumber
+    string/     — isString, isEmptyString, isNotEmptyString, isDecimalMonetaryValue
+  util/                             — Runtime utilities, one folder per entity
+    cs/              — conditional style-object picker for RN/RNW `style` props
+    empty-fn/        — emptyFn, the canonical no-op
+    get-defined/     — getDefined(value, defaultFn) — sync lazy default when nullish
+    get-defined-async/ — getDefinedAsync(value, defaultFn) — async counterpart; on disk, NOT in index.ts
+    get-error-message/ — getErrorMessage(err, fallback?)
+    wait/            — Promise-based sleep
 ```
 
-Source for `getDefinedAsync` exists on disk but is intentionally NOT re-exported from `src/index.ts` — treat it as internal.
+### Key Patterns
 
-### Key Conventions
+- **One exported entity per folder, including single-file types.** This package predates the root-level rule that a lone
+  file (no spec, no `.md`) stays flat at the category level — every entity here, even a one-line `.type.ts`, still gets its
+  own folder with `<entity>.ts` + `<entity>.md` (and a `.spec.ts` for guards/utils). New packages follow the root convention
+  (flat single-file types); this package's existing layout is intentionally left alone rather than restructured piecemeal.
+- `getDefinedAsync` is fully implemented and tested on disk (`src/util/get-defined-async/`) but is deliberately **not**
+  re-exported from `src/index.ts` — verified directly against the barrel, which lists `getDefined` but not
+  `getDefinedAsync`. Treat it as internal until a consumer need promotes it to the public surface.
+- `isObject` is a public guard (`isDefined(value) && typeof value === 'object' && !isArray(value)`) and `isRecord` composes
+  it directly (`isRecord = (value) => isObject(value)`) rather than re-implementing the same narrowing — the guard chain is
+  the pattern to follow for any new object-shaped guard.
+- Composition over re-implementation elsewhere too: `isNotEmptyArray` builds on `isArray`, `isNotEmptyString`/`isEmptyString`
+  build on `isString`, `isDecimalMonetaryValue` builds on `isString` plus a regexp test — `isDefined` is the guard every
+  other guard ultimately bottoms out on.
+- Types are always `export type` — never import a type from this package as a value.
 
-- **One entity per file.** This package predates the monorepo-wide flat-layout-for-single-file-entities rule codified in the root `AGENTS.md`; the shared package's existing layout places every entity (including single-file interfaces) in its own folder. Root convention now prefers flat `src/<category>/<entity>.<suffix>.ts` for lone files — new packages should follow root convention; do not restructure existing shared folders without a separate refactor.
-- Each entity directory contains: implementation `.ts`, test `.spec.ts`, documentation `.md`
-- Types are always `export type` — never import types as values from this package
-- `isDefined` is the foundation guard — most other guards compose with it
-- `getDefinedAsync` exists but is intentionally **not exported** (internal use only)
-- Composition over re-implementation: guards chain (`isString` → `isDefined`, `isNotEmptyArray` → `isArray`)
+### Dependencies
+
+None at runtime (`package.json` has no `dependencies` field). This is deliberate: `shared` is the dependency floor every
+other package in the monorepo builds on, so it must not itself depend on anything workspace-local or third-party.
 
 ### Coverage
 
-Default monorepo threshold: **99.9%** for statements, branches, functions, and lines.
-
-### Key Types
-
-| Type | Definition | Purpose |
-|------|-----------|---------|
-| `Maybe<T>` | `T \| null` | Nullable values |
-| `EmptyFn` | `(...args: any[]) => void` | Default event handlers, no-op slots, abort-listener cleanup |
-| `AnyFn` | `(...args: any) => any` | Generic function constraint for decorator factories |
-| `ClassType<T>` | `new (...args: any[]) => T` | Concrete constructor (DI, reflection) |
-| `AbstractConstructor<T>` | `abstract new (...args: any[]) => T` | Abstract class mixins |
-| `MethodDecoratorType<K>` | Typed method-decorator factory result | Used across every decorator package in the monorepo (not just NestJS) — the canonical home for the decorator-return type |
-| `IsNotEmptyArray<T>` | `[T, ...T[]]` | Non-empty array assertion |
-| `Enum<D>` | `Record<string, D>` | Enum-like object |
+Default monorepo threshold: **99.9%** for statements, branches, functions, and lines (`get-jest.config.js`, no
+per-package override in `packages/shared/jest.config.js`).

--- a/packages/wdio/AGENTS.md
+++ b/packages/wdio/AGENTS.md
@@ -10,7 +10,7 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ## Architecture
 
-```
+```text
 src/
   add-wdio-commands.ts — addWdioCommands(browser) entry point, registers every command below
   wdio.d.ts         — ambient `WebdriverIO` namespace augmentation (Element/Browser/MultiRemoteBrowser

--- a/packages/wdio/AGENTS.md
+++ b/packages/wdio/AGENTS.md
@@ -12,28 +12,44 @@ yarn test && yarn test:coverage && yarn build && yarn ts && yarn lint:fix
 
 ```
 src/
-  capability/       — isAndroid, isBrowser, isIOS detection
-  command/          — Custom WDIO commands: testID$, testID$$, testID$$Index, el, els, swipe, clearInput, slowInput
-    mobile/         — openDeepLink, relativeClick
-  component/        — Component<T> base class (Proxy-based selector resolution)
-  component$/       — Promise-returning component factory variants
-  rooted-component/ — RootedComponent<T> (scoped child lookups to root element)
-  rooted-component$/ — Promise-returning rooted component variants
-  config/           — Default component configs, web selector constant ('data-test-id')
-  selector/         — Platform-aware testID selectors (web: [data-test-id="x"], mobile: ~x)
+  add-wdio-commands.ts — addWdioCommands(browser) entry point, registers every command below
+  wdio.d.ts         — ambient `WebdriverIO` namespace augmentation (Element/Browser/MultiRemoteBrowser
+                       command signatures) so `browser.testID$(...)` etc. type-check for consumers
+  capability/       — isAndroidCapability, isBrowserCapability, isIOSCapability detection
+  command/          — testID$, testID$$, el$, els$ (command/index.ts barrel); testID$$Index, byIndex$$ and
+                       swipeCommand are imported by path (not re-exported from the barrel); clearInputCommand,
+                       slowInputCommand
+    mobile/         — openDeepLinkCommand, relativeClickCommand
+  component/        — Component<T> base class (Proxy-based selector resolution); createComponent, getComponent,
+                       getExtendedComponent factories
+    mocks/          — *.mock.ts fixtures consumed by componnet.spec.ts and sibling specs (legacy scaffolding,
+                       predates the "test-only code lives inside the spec" rule — see root AGENTS.md exception)
+  component$/       — Promise-returning component factory variants (createComponent$, getComponent$,
+                       getExtendedComponent$) + their own mocks/
+  rooted-component/ — RootedComponent<T> extends Component<T>, scopes child lookups to a `RootEl` getter;
+                       createRootedComponent, getRootedComponent, getExtendedRootedComponent + mocks/
+  rooted-component$/ — Promise-returning rooted component variants + mocks/
+  config/           — defaultComponentConfig (testID$/testID$$/testID$$Index-backed) and default$ComponentConfig
+                       (el$/els$/byIndex$$-backed, for raw-selector component variants); web-selector.config.ts
+                       exports the 'data-test-id' constant
+  selector/         — Platform-aware testID selectors: testIDSelector picks web vs. mobile via
+                       isBrowserCapability(); mobileTestIDSelector picks android vs. ios via isAndroidCapability()
+                       (both mobile selectors currently render identical `~id` strings)
   selector-element/ — SelectorElement Proxy (chains .el()/.els()/.byIdx() calls)
   interface/        — TestIDProps, AndroidTestIDProps, WebTestIDProps
-  type/             — ElSelectorFn, ElsSelectorFn, ComponentConfigInterface, etc.
+  type/             — ElSelectorFn, ElsSelectorFn, ElsIndexSelectorFn, ComponentConfigInterface, SwipeDirectionType, etc.
   util/             — getTestID, setTestID, setPropTestID
 ```
 
 ### Key Patterns
 
-- **Proxy-based page objects**: `Component` constructor returns `new Proxy(this, ...)` — property access on selectors is intercepted and wrapped in `SelectorElement`
+- **Proxy-based page objects**: `Component`'s constructor returns `new Proxy(this, { get: (client, field) => client.proxyGet(field, receiver) })` — a field found on `this` passes through via `Reflect.get`, a field found in `selectors` is wrapped in a `SelectorElement`, and anything unresolved falls back through `parentComponents` before an optional `notFoundFn`
+- **`RootedComponent` extends `Component`**: it overrides `getChildEl`/`getChildEls`/`getChildElByIdx` to resolve against its own `RootEl` getter (`config.elSelectorFn(parentElInput)`) instead of the global `browser`, and its Proxy `get` trap falls back to `Reflect.get(client.RootEl, field, receiver)` for anything not found on the instance — that's what lets `rootedComponent.someRawElementMethod()` work without an explicit `.el()`
 - **SelectorElement proxy chain**: `page.submitBtn.click()` works without `.el()` — property access is forwarded to the underlying `ChainablePromiseElement`
-- **Platform-aware selectors**: `testIDSelector` checks `isBrowserCapability()` at runtime → `[data-test-id="id"]` (web) or `~id` (mobile)
-- **`addWdioCommands(browser)`** must be called once (typically in `wdio.conf.ts` `before` hook) — registers commands at both browser and element level
-- Import `ElementReference` from `@wdio/protocols` (not from deep `build/types` path)
+- **Platform-aware selectors**: `testIDSelector` checks `isBrowserCapability()` at runtime → `[data-test-id="id"]` (web) or `~id` (mobile, via `mobileTestIDSelector`)
+- **`addWdioCommands(browser)`** must be called once (typically in `wdio.conf.ts` `before` hook) — registers `testID$`/`testID$$`/`openDeepLink` at the browser level and `testID$`/`testID$$`/`slowInput`/`clearInput`/`relativeClick`/`swipe` at the element level
+- Import `ElementReference` from `@wdio/protocols` (used by `ElSelectorFn`/`ElsSelectorFn` in `src/type`), not from a deep `build/types` path
+- **Legacy mock scaffolding**: every `component*`/`rooted-component*` folder keeps its fixtures in a colocated `mocks/*.mock.ts` rather than inlined in the spec — this predates the monorepo's "test-only code lives inside the spec" rule and is the documented exception in the root `AGENTS.md`; `.mock.ts` files are excluded from coverage via `coveragePathIgnorePatterns: ['.mock.ts']` in `get-jest.config.js`
 
 ### Dependencies
 
@@ -41,4 +57,5 @@ src/
 
 ### Coverage
 
-Default: **99.9%** all metrics.
+Default monorepo threshold: **99.9%** for statements, branches, functions, and lines (`get-jest.config.js`, no
+per-package override in `packages/wdio/jest.config.js`).


### PR DESCRIPTION
## Summary

- Brings all 20 non-reference packages' `AGENTS.md` to the depth/parity of `packages/react-native-payments/AGENTS.md`: verified source layout, key implementation invariants, dependencies, and enforced coverage thresholds against each package's actual `jest.config.js` and current `src/` tree.
- Corrected real drift found during verification, most notably across the decorator family: `decorators-core`'s engine was previously documented as a multi-strategy design (`syncStrategy`/`promiseStrategy`/`observableStrategy`/`completionObservableStrategy`) that no longer exists in source — it's now a single `InterceptorMiddleware = (context, next) => TResult` hook. `log-decorator`, `histogram-metric-decorator`, `lock-decorator`, and `nestjs-enterprise` were updated to match, including `lock-decorator`'s new Observable-returning factories (`createSequentialLockDecorator$`/`createExclusiveLockDecorator$`) which weren't documented at all before.
- `nestjs-webpack-swc` and `react-native-payments-example` state their actual test posture honestly (no `test`/`test:coverage` script; orphaned `jest.config.js` for the former, a real Maestro e2e suite discovered under `e2e/` for the latter) instead of an invented coverage number.
- `packages/react-native-payments` is unchanged (reference file).

## Test plan

- [x] `yarn build` — all 20 packages build clean
- [x] `yarn ts` — type-checks clean across all 21 packages in scope
- [x] `yarn lint` — no errors (pre-existing warnings only, unrelated to this change)

Refs #489

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expand per-package AGENTS.md architecture notes across the monorepo
> Updates `AGENTS.md` files in 18 packages to add concrete implementation details that were previously missing or vague.
>
> - Decorator packages (`log-decorator`, `histogram-metric-decorator`, `decorators-core`, `lock-decorator`, `nestjs-enterprise`) now document middleware wiring, Promise vs Observable branching, error normalization, and resource key construction.
> - NestJS service packages (`nestjs-rxjs-lock`, `nestjs-rxjs-metrics`, `nestjs-rxjs-logger`, `nestjs-rxjs-redis`, `nestjs-typed-config`) document constructor behavior, operator semantics, module patterns, and default option values.
> - Utility and config packages (`shared`, `platform`, `redux-loadable`, `fast-style`, `object-field-tree`, `nestjs-webpack-swc`, `eslint-plugin`, `rxjs-errors`) add file-level architecture trees, key pattern explanations, and explicit dependency roles.
> - `react-native-payments-example` documents the Maestro e2e suite structure and CI matrix wiring.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0bc5562.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated package documentation across the repository to reflect current APIs, architecture, behavior, configuration, dependencies, testing, and coverage guidance.
  * Clarified usage and runtime behavior for decorators, logging, metrics, locking, Redis, configuration, platform utilities, and state management.
  * Added detailed end-to-end testing guidance for the React Native payments example.
  * Removed outdated references and documented current exports, commands, error handling, and integration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->