### PR TITLE
docs: bring package readmes to per-export parity

### DIFF
--- a/packages/decorators-core/readme.md
+++ b/packages/decorators-core/readme.md
@@ -8,13 +8,23 @@ Framework-agnostic middleware primitive for building method decorators (log, met
 
 ## The primitive
 
-`createInterceptor({ middleware })` wraps a method descriptor with a single middleware function:
+### `createInterceptor`
+
+`createInterceptor({ middleware }: CreateInterceptorOptionsInterface)` wraps a method descriptor with a single middleware function and returns a `MethodDecoratorType<AnyFn>`:
 
 ```ts
-type InterceptorMiddleware<TArgs, TResult> = (
-    context: ExecutionContextInterface<TArgs>,
-    next: () => TResult
-) => TResult;
+import { createInterceptor } from '@rnw-community/decorators-core';
+
+import type { InterceptorMiddleware } from '@rnw-community/decorators-core';
+
+const passthrough: InterceptorMiddleware = (_context, next) => next();
+
+const Passthrough = createInterceptor({ middleware: passthrough });
+
+class Service {
+    @Passthrough
+    run(): void { /* ... */ }
+}
 ```
 
 `next()` invokes the original method. The middleware decides what to do before, after, around, or instead of that call — observe timings, retry, short-circuit, log, acquire a lock — and returns whatever shape the method returns (sync value, `Promise<T>`, `Observable<T>`, or anything else). The engine is transport-agnostic and result-shape-agnostic; the middleware owns both.
@@ -32,12 +42,44 @@ class OrderService {
 
 ## Exports
 
-| Export | Purpose |
-|---|---|
-| `createInterceptor` | Method-decorator factory; takes `{ middleware }`, returns a `MethodDecoratorType<AnyFn>` |
-| `InterceptorMiddleware<TArgs, TResult>` | Function type: `(context, next) => TResult` |
-| `ExecutionContextInterface<TArgs>` | `{ className, methodName, args, logContext }` — stable identity per invocation |
-| `CreateInterceptorOptionsInterface<TArgs, TResult>` | `{ middleware }` — the sole option |
+### `InterceptorMiddleware<TArgs, TResult>`
+
+Function type: `(context: ExecutionContextInterface<TArgs>, next: () => TResult) => TResult`. See "Build your own decorator" above for a full implementation.
+
+```ts
+import type { InterceptorMiddleware } from '@rnw-community/decorators-core';
+
+const timingMiddleware: InterceptorMiddleware<[id: string]> = (context, next) => {
+    const start = performance.now();
+
+    return next();
+};
+```
+
+### `ExecutionContextInterface<TArgs>`
+
+`{ className, methodName, args, logContext }` — stable identity per invocation, passed as the first argument to every `InterceptorMiddleware`. See "Execution context" below for field semantics.
+
+```ts
+import type { ExecutionContextInterface } from '@rnw-community/decorators-core';
+
+const describe = (context: ExecutionContextInterface): string => context.logContext;
+```
+
+### `CreateInterceptorOptionsInterface<TArgs, TResult>`
+
+`{ middleware: InterceptorMiddleware<TArgs, TResult> }` — the sole option accepted by `createInterceptor`.
+
+```ts
+import { createInterceptor } from '@rnw-community/decorators-core';
+
+import type { CreateInterceptorOptionsInterface, InterceptorMiddleware } from '@rnw-community/decorators-core';
+
+declare const middleware: InterceptorMiddleware;
+
+const options: CreateInterceptorOptionsInterface<readonly unknown[], unknown> = { middleware };
+const withMiddleware = createInterceptor(options);
+```
 
 `MethodDecoratorType<K>` comes from [`@rnw-community/shared`](https://github.com/rnw-community/rnw-community/tree/master/packages/shared) — import it directly, not through this package.
 

--- a/packages/fast-style/readme.md
+++ b/packages/fast-style/readme.md
@@ -13,6 +13,20 @@ generating complex object field structure.
 
 Special object `Flex` for rapid React native FlexBox styles generation with IDE autocomplete(IntelliSense).
 
+### Enums backing `Flex`'s keys
+
+`Flex` is built via `combine()` from [`@rnw-community/object-field-tree`](https://github.com/rnw-community/rnw-community/tree/master/packages/object-field-tree) over these three enums — their member names are exactly the property chain used above (`Flex.row.flexEnd.stretch`):
+
+-   `FlexDirectionEnum` - `column` | `columnReverse` | `row` | `rowReverse`
+-   `FlexJustifyContentEnum` - `center` | `flexEnd` | `flexStart` | `spaceAround` | `spaceBetween` | `spaceEvenly`
+-   `FlexAlignItemsEnum` - `baseline` | `center` | `flexEnd` | `flexStart` | `stretch`
+
+```ts
+import { FlexDirectionEnum } from '@rnw-community/fast-style';
+
+const direction: FlexDirectionEnum = FlexDirectionEnum.row;
+```
+
 ### Usage in Style object
 
 Styles usage example with spreading styles:

--- a/packages/histogram-metric-decorator/readme.md
+++ b/packages/histogram-metric-decorator/readme.md
@@ -61,10 +61,59 @@ The `onLabelsError` hook itself is crash-safe — exceptions inside it are swall
 
 ## Public API
 
-- [`createHistogramMetricDecorator`](src/factory/create-histogram-metric-decorator/create-histogram-metric-decorator.ts) — factory; takes `{ transport, onLabelsError? }` and returns `<K extends AnyFn>(config?) => MethodDecoratorType<K>`
-- [`HistogramTransportInterface`](src/interface/histogram-transport.interface.ts) — `observe(name, durationMs, labels?)`; implement for any backend
-- [`HistogramOptionsInterface<TArgs>`](src/interface/histogram-options.interface.ts) — per-decoration `{ name?, labels? }`
-- [`CreateHistogramMetricOptionsInterface`](src/interface/create-histogram-metric-options.interface.ts) — `{ transport, onLabelsError? }`
+### `createHistogramMetricDecorator`
+
+Factory; takes `{ transport, onLabelsError? }: CreateHistogramMetricOptionsInterface` and returns `<K extends AnyFn>(config?: HistogramOptionsInterface) => MethodDecoratorType<K>` — see the usage example above.
+
+```ts
+import { createHistogramMetricDecorator } from '@rnw-community/histogram-metric-decorator';
+
+import type { HistogramTransportInterface } from '@rnw-community/histogram-metric-decorator';
+
+declare const transport: HistogramTransportInterface;
+
+const HistogramMetric = createHistogramMetricDecorator({ transport });
+```
+
+### `HistogramTransportInterface`
+
+`observe(name, durationMs, labels?)`; implement for any backend (Prometheus, OpenTelemetry, in-memory, …).
+
+```ts
+import type { HistogramTransportInterface } from '@rnw-community/histogram-metric-decorator';
+
+const inMemoryTransport: HistogramTransportInterface = {
+    observe: (name, durationMs, labels) => console.log(name, durationMs, labels),
+};
+```
+
+### `HistogramOptionsInterface<TArgs>`
+
+Per-decoration `{ name?, labels? }` — the optional argument to `@HistogramMetric(...)`.
+
+```ts
+import type { HistogramOptionsInterface } from '@rnw-community/histogram-metric-decorator';
+
+const config: HistogramOptionsInterface<[id: string]> = {
+    name: 'order_fetch_ms',
+    labels: ([id]) => ({ orderId: id }),
+};
+```
+
+### `CreateHistogramMetricOptionsInterface`
+
+`{ transport, onLabelsError? }` — the sole argument to `createHistogramMetricDecorator`.
+
+```ts
+import { createHistogramMetricDecorator } from '@rnw-community/histogram-metric-decorator';
+
+import type { CreateHistogramMetricOptionsInterface, HistogramTransportInterface } from '@rnw-community/histogram-metric-decorator';
+
+declare const transport: HistogramTransportInterface;
+
+const options: CreateHistogramMetricOptionsInterface = { transport, onLabelsError: (err, args) => console.warn(err, args) };
+const HistogramMetric = createHistogramMetricDecorator(options);
+```
 
 ## License
 

--- a/packages/lock-decorator/readme.md
+++ b/packages/lock-decorator/readme.md
@@ -17,6 +17,8 @@ Each factory takes `{ store }: CreateLockOptionsInterface` and returns a decorat
 
 ## Sequential (Promise)
 
+### `createSequentialLockDecorator`
+
 FIFO queue on the key. Supports `timeoutMs` (→ `LockAcquireTimeoutError`) and `AbortSignal` (→ `DOMException('AbortError')`).
 
 ```ts
@@ -44,6 +46,8 @@ Key-fn `args` is inferred from the method signature — no annotations needed. T
 
 ## Exclusive (Promise)
 
+### `createExclusiveLockDecorator`
+
 Rejects immediately with `LockBusyError` if the key is held. No waiting, no timeout, no signal.
 
 ```ts
@@ -65,6 +69,8 @@ class Cache {
 
 For methods that return `Observable<T>`, use `createSequentialLockDecorator$` / `createExclusiveLockDecorator$`. Same store contract, same key-argument shapes. The acquired handle is released on the inner Observable's `complete`, `error`, or `unsubscribe` — the lock tracks the subscription lifecycle.
 
+### `createSequentialLockDecorator$`
+
 ```ts
 import { createSequentialLockDecorator$ } from '@rnw-community/lock-decorator';
 
@@ -81,48 +87,186 @@ class StreamService {
 }
 ```
 
-## Raw middleware (`createLockMiddleware` / `createLockMiddleware$`)
+### `createExclusiveLockDecorator$`
 
-If you are building a custom decorator (for example a DI-aware NestJS adapter), consume the raw middleware directly and feed it into your own `createInterceptor({ middleware })` call:
+```ts
+import { createExclusiveLockDecorator$ } from '@rnw-community/lock-decorator';
+
+import type { LockStoreInterface } from '@rnw-community/lock-decorator';
+import type { Observable } from 'rxjs';
+
+declare const store: LockStoreInterface;
+
+const ExclusiveLock$ = createExclusiveLockDecorator$({ store });
+
+class StreamService {
+    @ExclusiveLock$({ key: 'feed' })
+    subscribe$(symbol: string): Observable<number> { /* ... */ }
+}
+```
+
+## Raw middleware
+
+If you are building a custom decorator (for example a DI-aware NestJS adapter), consume the raw middleware directly and feed it into your own `createInterceptor({ middleware })` call. Both are used internally by the four factories above.
+
+### `createLockMiddleware`
+
+Returns an `InterceptorMiddleware<TArgs>` for Promise-returning methods:
+
+```ts
+import { createInterceptor } from '@rnw-community/decorators-core';
+import { createLockMiddleware } from '@rnw-community/lock-decorator';
+
+import type { LockStoreInterface } from '@rnw-community/lock-decorator';
+
+declare const store: LockStoreInterface;
+
+const withSequentialLock = createInterceptor({ middleware: createLockMiddleware(store, 'sequential', 'my-key') });
+```
+
+### `createLockMiddleware$`
+
+Returns an `InterceptorMiddleware<TArgs, Observable<unknown>>` for Observable-returning methods, and additionally bridges an external `AbortSignal` through to the store:
 
 ```ts
 import { createInterceptor } from '@rnw-community/decorators-core';
 import { createLockMiddleware$ } from '@rnw-community/lock-decorator';
-```
 
-`createLockMiddleware(store, mode, arg)` returns an `InterceptorMiddleware<TArgs>` for Promise methods; `createLockMiddleware$` returns one for Observable methods and additionally bridges an external `AbortSignal` through to the store. Both are used internally by the four factories above.
+import type { LockStoreInterface } from '@rnw-community/lock-decorator';
+
+declare const store: LockStoreInterface;
+
+const withSequentialLock$ = createInterceptor({ middleware: createLockMiddleware$(store, 'sequential', 'my-key') });
+```
 
 ## Store contract
 
-Bring your own [`LockStoreInterface`](src/interface/lock-store.interface.ts) implementation — Redis, in-process, cluster-aware, whatever fits the deployment target. The contract is a single method:
+Bring your own `LockStoreInterface` implementation — Redis, in-process, cluster-aware, whatever fits the deployment target. The store returns a handle; the handle releases itself. A minimal adapter is typically a few dozen lines.
+
+### `LockStoreInterface`
 
 ```ts
-interface LockStoreInterface {
-    acquire: (key: string, mode: LockModeType, options?: AcquireOptionsInterface) => Promise<LockHandleInterface>;
-}
+import type { LockStoreInterface } from '@rnw-community/lock-decorator';
 
-interface LockHandleInterface {
-    readonly key: string;
-    readonly mode: LockModeType;
-    release: () => void | Promise<void>;
-}
+const store: LockStoreInterface = {
+    acquire: async (key, mode, options) => ({
+        key,
+        mode,
+        release: async () => { /* ... */ },
+    }),
+};
 ```
 
-The store returns a handle; the handle releases itself. A minimal adapter is typically a few dozen lines.
+### `LockHandleInterface`
+
+The handle returned by `LockStoreInterface.acquire`; the four factories call `release()` for you.
+
+```ts
+import type { LockHandleInterface } from '@rnw-community/lock-decorator';
+
+const handle: LockHandleInterface = { key: 'my-key', mode: 'sequential', release: () => undefined };
+```
+
+### `AcquireOptionsInterface`
+
+`{ timeoutMs?: number; signal?: AbortSignal }` — the third argument to `LockStoreInterface.acquire`.
+
+```ts
+import type { AcquireOptionsInterface } from '@rnw-community/lock-decorator';
+
+const options: AcquireOptionsInterface = { timeoutMs: 5000 };
+```
+
+### `LockModeType`
+
+`'sequential' | 'exclusive'` — passed to `LockStoreInterface.acquire` so the store knows which semantics to apply.
+
+```ts
+import type { LockModeType } from '@rnw-community/lock-decorator';
+
+const mode: LockModeType = 'sequential';
+```
+
+### `CreateLockOptionsInterface`
+
+`{ store: LockStoreInterface }` — the sole argument to all four factories.
+
+```ts
+import { createSequentialLockDecorator } from '@rnw-community/lock-decorator';
+
+import type { CreateLockOptionsInterface, LockStoreInterface } from '@rnw-community/lock-decorator';
+
+declare const store: LockStoreInterface;
+
+const options: CreateLockOptionsInterface = { store };
+const SequentialLock = createSequentialLockDecorator(options);
+```
 
 ## Errors
 
-- [`LockBusyError`](src/error/lock-busy-error/lock-busy.error.ts) — exclusive key already held
-- [`LockAcquireTimeoutError`](src/error/lock-acquire-timeout-error/lock-acquire-timeout.error.ts) — sequential `timeoutMs` expired
+### `LockBusyError`
 
-## Types & interfaces
+Thrown by `createExclusiveLockDecorator` / `createExclusiveLockDecorator$` when the key is already held.
 
-- [`SequentialLockArgumentType<TArgs>`](src/type/sequential-lock-argument.type.ts) — `string | ((args: TArgs) => string) | { key, timeoutMs?, signal? }`
-- [`ExclusiveLockArgumentType<TArgs>`](src/type/exclusive-lock-argument.type.ts) — `string | ((args: TArgs) => string) | { key }`
-- [`LockArgumentType<TArgs>`](src/type/lock-argument.type.ts) — union of the two above
-- [`LockModeType`](src/type/lock-mode.type.ts) — `'sequential' | 'exclusive'`
-- [`AcquireOptionsInterface`](src/interface/acquire-options.interface.ts) — `{ timeoutMs?, signal? }`
-- [`CreateLockOptionsInterface`](src/interface/create-lock-options.interface.ts) — `{ store }`
+```ts
+import { LockBusyError } from '@rnw-community/lock-decorator';
+
+try {
+    await cache.write(value);
+} catch (error) {
+    if (error instanceof LockBusyError) {
+        console.warn(`busy: ${error.key}`);
+    }
+}
+```
+
+### `LockAcquireTimeoutError`
+
+Thrown by `createSequentialLockDecorator` / `createSequentialLockDecorator$` when `timeoutMs` elapses before the key becomes free.
+
+```ts
+import { LockAcquireTimeoutError } from '@rnw-community/lock-decorator';
+
+try {
+    await service.charge(amount);
+} catch (error) {
+    if (error instanceof LockAcquireTimeoutError) {
+        console.warn(`timed out after ${error.timeoutMs}ms for ${error.key}`);
+    }
+}
+```
+
+## Key-argument types
+
+### `SequentialLockArgumentType<TArgs>`
+
+Accepted key shapes for `createSequentialLockDecorator` / `createSequentialLockDecorator$`:
+
+```ts
+import type { SequentialLockArgumentType } from '@rnw-community/lock-decorator';
+
+const byId: SequentialLockArgumentType<[id: string]> = ([id]) => `order:${id}`;
+```
+
+### `ExclusiveLockArgumentType<TArgs>`
+
+Accepted key shapes for `createExclusiveLockDecorator` / `createExclusiveLockDecorator$` — no `timeoutMs`/`signal`, exclusive locks never wait:
+
+```ts
+import type { ExclusiveLockArgumentType } from '@rnw-community/lock-decorator';
+
+const byId: ExclusiveLockArgumentType<[id: string]> = ([id]) => ({ key: `cache:${id}` });
+```
+
+### `LockArgumentType<TArgs>`
+
+`SequentialLockArgumentType<TArgs> | ExclusiveLockArgumentType<TArgs>` — the union accepted internally by `createLockMiddleware` / `createLockMiddleware$`.
+
+```ts
+import type { LockArgumentType } from '@rnw-community/lock-decorator';
+
+const arg: LockArgumentType<[id: string]> = 'static-key';
+```
 
 ## License
 

--- a/packages/lock-decorator/readme.md
+++ b/packages/lock-decorator/readme.md
@@ -15,11 +15,13 @@ Framework-agnostic sequential and exclusive method lock decorators. Promise and 
 
 Each factory takes `{ store }: CreateLockOptionsInterface` and returns a decorator factory that accepts the same key argument shape (string, `(args) => string`, or `{ key, timeoutMs?, signal? }` for sequential; `{ key }` only for exclusive — exclusive does not wait, so timeout/signal make no sense).
 
+"FIFO queue" and "skip-on-busy" are the semantics a `LockStoreInterface` implementation is expected to provide — the decorators/middleware only resolve the key and forward `mode`, `key`, and `options` (`timeoutMs`/`signal`) to `store.acquire()`, then propagate whatever it resolves or rejects with. See "Store contract" and "Errors" below for exactly what the library itself does vs. what the store owns.
+
 ## Sequential (Promise)
 
 ### `createSequentialLockDecorator`
 
-FIFO queue on the key. Supports `timeoutMs` (→ `LockAcquireTimeoutError`) and `AbortSignal` (→ `DOMException('AbortError')`).
+Forwards `timeoutMs` and `signal` to `store.acquire()` as part of `AcquireOptionsInterface` — a compliant store queues on the key (FIFO) and rejects with `LockAcquireTimeoutError` if `timeoutMs` elapses, or honors the `AbortSignal` itself. The decorator does not enforce either behavior; it only awaits `store.acquire()` and propagates whatever it resolves or rejects with.
 
 ```ts
 import { createSequentialLockDecorator } from '@rnw-community/lock-decorator';
@@ -48,7 +50,7 @@ Key-fn `args` is inferred from the method signature — no annotations needed. T
 
 ### `createExclusiveLockDecorator`
 
-Rejects immediately with `LockBusyError` if the key is held. No waiting, no timeout, no signal.
+No `timeoutMs`/`signal` — `ExclusiveLockArgumentType` only accepts `string | ((args) => string) | { key }`, so there is nothing to wait on. A compliant store's `acquire()` is expected to reject immediately (no queueing) with `LockBusyError` when the key is already held; the decorator itself just propagates that rejection.
 
 ```ts
 import { createExclusiveLockDecorator } from '@rnw-community/lock-decorator';
@@ -67,7 +69,7 @@ class Cache {
 
 ## Observable variants — `$` factories
 
-For methods that return `Observable<T>`, use `createSequentialLockDecorator$` / `createExclusiveLockDecorator$`. Same store contract, same key-argument shapes. The acquired handle is released on the inner Observable's `complete`, `error`, or `unsubscribe` — the lock tracks the subscription lifecycle.
+For methods that return `Observable<T>`, use `createSequentialLockDecorator$` / `createExclusiveLockDecorator$`. Same store contract, same key-argument shapes. The acquired handle is released on the inner Observable's `complete`, `error`, or `unsubscribe` — the lock tracks the subscription lifecycle. Unlike the Promise variants above, the `$` factories bridge an external `AbortSignal` themselves: aborting it errors the subscriber with `DOMException('The operation was aborted.', 'AbortError')` directly, independent of what the store does.
 
 ### `createSequentialLockDecorator$`
 
@@ -204,9 +206,11 @@ const SequentialLock = createSequentialLockDecorator(options);
 
 ## Errors
 
+Neither of these is thrown by the decorators or `createLockMiddleware`/`createLockMiddleware$` themselves — both are exported as the conventional error classes a `LockStoreInterface.acquire()` implementation is expected to throw/reject with, so callers get a stable `instanceof` check no matter which store is plugged in. The library only awaits `store.acquire()` and propagates whatever it resolves or rejects with.
+
 ### `LockBusyError`
 
-Thrown by `createExclusiveLockDecorator` / `createExclusiveLockDecorator$` when the key is already held.
+Convention: a store's `acquire()` should reject with this when `mode: 'exclusive'` and the key is already held.
 
 ```ts
 import { LockBusyError } from '@rnw-community/lock-decorator';
@@ -222,7 +226,7 @@ try {
 
 ### `LockAcquireTimeoutError`
 
-Thrown by `createSequentialLockDecorator` / `createSequentialLockDecorator$` when `timeoutMs` elapses before the key becomes free.
+Convention: a store's `acquire()` should reject with this when `mode: 'sequential'` and `options.timeoutMs` elapses before the key becomes free.
 
 ```ts
 import { LockAcquireTimeoutError } from '@rnw-community/lock-decorator';

--- a/packages/lock-decorator/readme.md
+++ b/packages/lock-decorator/readme.md
@@ -143,7 +143,7 @@ const withSequentialLock$ = createInterceptor({ middleware: createLockMiddleware
 
 ## Store contract
 
-Bring your own `LockStoreInterface` implementation — Redis, in-process, cluster-aware, whatever fits the deployment target. The store returns a handle; the handle releases itself. A minimal adapter is typically a few dozen lines.
+Bring your own `LockStoreInterface` implementation — Redis, in-process, cluster-aware, whatever fits the deployment target. The store returns a handle; the lock decorators/middleware call the handle's `release()` for you — when the protected Promise settles for the Promise variants, or when the Observable completes, errors, or unsubscribes for the `$` variants. A minimal adapter is typically a few dozen lines.
 
 ### `LockStoreInterface`
 
@@ -215,8 +215,10 @@ Convention: a store's `acquire()` should reject with this when `mode: 'exclusive
 ```ts
 import { LockBusyError } from '@rnw-community/lock-decorator';
 
+declare const cache: { write: (value: string) => Promise<void> };
+
 try {
-    await cache.write(value);
+    await cache.write('value');
 } catch (error) {
     if (error instanceof LockBusyError) {
         console.warn(`busy: ${error.key}`);
@@ -231,8 +233,10 @@ Convention: a store's `acquire()` should reject with this when `mode: 'sequentia
 ```ts
 import { LockAcquireTimeoutError } from '@rnw-community/lock-decorator';
 
+declare const service: { charge: (amount: number) => Promise<string> };
+
 try {
-    await service.charge(amount);
+    await service.charge(100);
 } catch (error) {
     if (error instanceof LockAcquireTimeoutError) {
         console.warn(`timed out after ${error.timeoutMs}ms for ${error.key}`);

--- a/packages/log-decorator/readme.md
+++ b/packages/log-decorator/readme.md
@@ -43,12 +43,95 @@ Omit any hook to skip that lifecycle event. Hook results that are empty strings 
 
 ## Public API
 
-- [`createLogDecorator`](src/create-log-decorator/create-log-decorator.ts) — factory; takes `{ transport }` and returns the `@Log(preLog?, postLog?, errorLog?)` decorator factory
-- [`consoleTransport`](src/console-transport/console-transport.ts) — default `LogTransportInterface` forwarding to `console.log` / `console.debug` / `console.error`
-- [`LogTransportInterface`](src/interface/log-transport.interface.ts) — three methods (`log`, `debug`, `error`); plug in Pino, Winston, NestJS `Logger`, anything
-- [`CreateLogOptionsInterface`](src/interface/create-log-options.interface.ts) — `{ transport }`
-- [`PreLogInputType`](src/type/pre-log-input.type.ts) / [`PostLogInputType`](src/type/post-log-input.type.ts) / [`ErrorLogInputType`](src/type/error-log-input.type.ts) — string or spread-args function
-- [`GetResultType<T>`](src/type/get-result.type.ts) — unwraps `Promise<U>` / `Observable<U>` → `U`; used by the factory's generic constraint and re-exported so consumer-bound factories (for example `nestjs-enterprise`'s `Log`) stay portable under legacy CJS module resolution
+### `createLogDecorator`
+
+Factory; takes `{ transport }: CreateLogOptionsInterface` and returns the `@Log(preLog?, postLog?, errorLog?)` decorator factory used in the examples above.
+
+```ts
+import { createLogDecorator, consoleTransport } from '@rnw-community/log-decorator';
+
+const Log = createLogDecorator({ transport: consoleTransport });
+```
+
+### `consoleTransport`
+
+Default `LogTransportInterface` forwarding to `console.log` / `console.debug` / `console.error`.
+
+```ts
+import { consoleTransport } from '@rnw-community/log-decorator';
+
+consoleTransport.log('placing order 1', 'OrderService::placeOrder');
+```
+
+### `LogTransportInterface`
+
+Three methods (`log`, `debug`, `error`); implement it to plug in Pino, Winston, NestJS `Logger`, or anything else.
+
+```ts
+import type { LogTransportInterface } from '@rnw-community/log-decorator';
+
+const pinoTransport: LogTransportInterface = {
+    log: (message, logContext) => logger.info({ logContext }, message),
+    debug: (message, logContext) => logger.debug({ logContext }, message),
+    error: (message, error, logContext) => logger.error({ logContext, error }, message),
+};
+```
+
+### `CreateLogOptionsInterface`
+
+`{ transport: LogTransportInterface }` — the sole argument to `createLogDecorator`.
+
+```ts
+import { createLogDecorator } from '@rnw-community/log-decorator';
+
+import type { CreateLogOptionsInterface, LogTransportInterface } from '@rnw-community/log-decorator';
+
+declare const transport: LogTransportInterface;
+
+const options: CreateLogOptionsInterface = { transport };
+const Log = createLogDecorator(options);
+```
+
+### `PreLogInputType<TArgs>`
+
+`string | ((...args: TArgs) => string)` — the shape accepted by `@Log`'s first (`preLog`) hook.
+
+```ts
+import type { PreLogInputType } from '@rnw-community/log-decorator';
+
+const preLog: PreLogInputType<[orderId: string]> = orderId => `placing order ${orderId}`;
+```
+
+### `PostLogInputType<TArgs, TResult>`
+
+`string | ((result: TResult, ...args: TArgs) => string)` — the shape accepted by `@Log`'s second (`postLog`) hook.
+
+```ts
+import type { PostLogInputType } from '@rnw-community/log-decorator';
+
+const postLog: PostLogInputType<[orderId: string], { id: string }> = (result, orderId) =>
+    `order ${orderId} placed: ${result.id}`;
+```
+
+### `ErrorLogInputType<TArgs>`
+
+`string | ((error: unknown, ...args: TArgs) => string)` — the shape accepted by `@Log`'s third (`errorLog`) hook.
+
+```ts
+import type { ErrorLogInputType } from '@rnw-community/log-decorator';
+
+const errorLog: ErrorLogInputType<[orderId: string]> = (error, orderId) => `order ${orderId} failed: ${String(error)}`;
+```
+
+### `GetResultType<T>`
+
+Unwraps `Promise<U>` / `Observable<U>` → `U` (passes any other `T` through unchanged). Used by the factory's generic constraint and re-exported so consumer-bound factories (for example `nestjs-enterprise`'s `Log`) stay portable under legacy CJS module resolution.
+
+```ts
+import type { GetResultType } from '@rnw-community/log-decorator';
+
+type Unwrapped = GetResultType<Promise<{ id: string }>>; // { id: string }
+```
 
 ## Observable support
 

--- a/packages/log-decorator/readme.md
+++ b/packages/log-decorator/readme.md
@@ -70,6 +70,12 @@ Three methods (`log`, `debug`, `error`); implement it to plug in Pino, Winston, 
 ```ts
 import type { LogTransportInterface } from '@rnw-community/log-decorator';
 
+declare const logger: {
+    info: (meta: Readonly<Record<string, unknown>>, message: string) => void;
+    debug: (meta: Readonly<Record<string, unknown>>, message: string) => void;
+    error: (meta: Readonly<Record<string, unknown>>, message: string) => void;
+};
+
 const pinoTransport: LogTransportInterface = {
     log: (message, logContext) => logger.info({ logContext }, message),
     debug: (message, logContext) => logger.debug({ logContext }, message),
@@ -139,6 +145,8 @@ Observable returns are handled internally — no opt-in, no strategy wiring. `rx
 
 ```ts
 import { createLogDecorator, consoleTransport } from '@rnw-community/log-decorator';
+
+import type { Observable } from 'rxjs';
 
 const Log = createLogDecorator({ transport: consoleTransport });
 

--- a/packages/nestjs-enterprise/readme.md
+++ b/packages/nestjs-enterprise/readme.md
@@ -45,7 +45,7 @@ const { SequentialLock$, ExclusiveLock$ } = createObservableLockDecorators(MyLoc
     const preLock: PreDecoratorFunction<[orderId: string], string[]> = orderId => [`order:${orderId}`];
     ```
 
-- `LockServiceInterface` - the contract `createPromiseLockDecorators` / `createObservableLockDecorators` expect from an injectable NestJS provider: `acquire(resources, duration)` and `tryAcquire(resources, duration)`, both resolving a `LockHandle`.
+- `LockServiceInterface` - the contract `createPromiseLockDecorators` / `createObservableLockDecorators` expect from an injectable NestJS provider: `acquire(resources, duration)` resolves a `LockHandle`; `tryAcquire(resources, duration)` resolves `LockHandle | undefined`, returning `undefined` on contention instead of waiting or throwing.
 
     ```ts
     import type { LockServiceInterface } from '@rnw-community/nestjs-enterprise';

--- a/packages/nestjs-enterprise/readme.md
+++ b/packages/nestjs-enterprise/readme.md
@@ -35,6 +35,39 @@ const { SequentialLock$, ExclusiveLock$ } = createObservableLockDecorators(MyLoc
 - [createPromiseLockDecorators](./src/decorator/lock/create-promise-lock-decorators/create-promise-lock-decorators.md) - `SequentialLock` + `ExclusiveLock` for async methods
 - [createObservableLockDecorators](./src/decorator/lock/create-observable-lock-decorators/create-observable-lock-decorators.md) - `SequentialLock$` + `ExclusiveLock$` for Observable methods
 
+### Types
+
+- `PreDecoratorFunction<TArgs, TResult>` - `(...args: TArgs) => TResult`; the spread-form callback shape used by `Log`'s `preLog`/`postLog`/`errorLog` hooks and `HistogramMetric`'s `labels` hook.
+
+    ```ts
+    import type { PreDecoratorFunction } from '@rnw-community/nestjs-enterprise';
+
+    const preLog: PreDecoratorFunction<[orderId: string]> = orderId => `placing order ${orderId}`;
+    ```
+
+- `LockServiceInterface` - the contract `createPromiseLockDecorators` / `createObservableLockDecorators` expect from an injectable NestJS provider: `acquire(resources, duration)` and `tryAcquire(resources, duration)`, both resolving a `LockHandle`.
+
+    ```ts
+    import type { LockServiceInterface } from '@rnw-community/nestjs-enterprise';
+
+    class RedlockService implements LockServiceInterface {
+        async acquire(resources: string[], duration: number) {
+            return { release: async () => undefined };
+        }
+        async tryAcquire(resources: string[], duration: number) {
+            return { release: async () => undefined };
+        }
+    }
+    ```
+
+- `LockHandle` - `{ release(): Promise<void> }`; returned by `LockServiceInterface.acquire` / `tryAcquire` and released automatically once the decorated method settles.
+
+    ```ts
+    import type { LockHandle } from '@rnw-community/nestjs-enterprise';
+
+    const handle: LockHandle = { release: async () => undefined };
+    ```
+
 ### Deprecated
 
 - [LockPromise](./src/decorator/lock/lock-promise/lock-promise-decorator.md) - use `createPromiseLockDecorators` instead

--- a/packages/nestjs-enterprise/readme.md
+++ b/packages/nestjs-enterprise/readme.md
@@ -37,12 +37,12 @@ const { SequentialLock$, ExclusiveLock$ } = createObservableLockDecorators(MyLoc
 
 ### Types
 
-- `PreDecoratorFunction<TArgs, TResult>` - `(...args: TArgs) => TResult`; the spread-form callback shape used by `Log`'s `preLog`/`postLog`/`errorLog` hooks and `HistogramMetric`'s `labels` hook.
+- `PreDecoratorFunction<TArgs, TResult>` - `(...args: TArgs) => TResult`; the spread-form callback shape accepted as the `preLock` argument to `SequentialLock`/`ExclusiveLock`/`SequentialLock$`/`ExclusiveLock$` (and the deprecated `LockPromise`/`LockObservable`) — computes the lock resource key(s) from the decorated method's own arguments.
 
     ```ts
     import type { PreDecoratorFunction } from '@rnw-community/nestjs-enterprise';
 
-    const preLog: PreDecoratorFunction<[orderId: string]> = orderId => `placing order ${orderId}`;
+    const preLock: PreDecoratorFunction<[orderId: string], string[]> = orderId => [`order:${orderId}`];
     ```
 
 - `LockServiceInterface` - the contract `createPromiseLockDecorators` / `createObservableLockDecorators` expect from an injectable NestJS provider: `acquire(resources, duration)` and `tryAcquire(resources, duration)`, both resolving a `LockHandle`.

--- a/packages/nestjs-rxjs-lock/readme.md
+++ b/packages/nestjs-rxjs-lock/readme.md
@@ -8,11 +8,6 @@ using [Redlock](https://github.com/mike-marcacci/node-redlock)
 [![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=nestjs-rxjs-lock&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fnestjs-rxjs-lock.svg)](https://www.npmjs.com/package/%40rnw-community%2Fnestjs-rxjs-lock)
 
-## TODO
-
--   [ ] Add module tests
--   [ ] Add `lock$` docs usage example
-
 ## Installation
 
 Add `@rnw-community/nestjs-rxjs-lock` to your project using you package manager of choice.

--- a/packages/nestjs-rxjs-logger/readme.md
+++ b/packages/nestjs-rxjs-logger/readme.md
@@ -6,40 +6,47 @@ NestJS default logger wrapper for using with RxJS streams.
 [![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=nestjs-rxjs-logger&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fnestjs-rxjs-logger.svg)](https://www.npmjs.com/package/%40rnw-community%2Fnestjs-rxjs-logger)
 
-## Supported log levels
+## Exports
 
--   `error` - `error$` RxJS operator
--   `info` - `info$` RxJS operator
--   `warn` - `warn$` RxJS operator
--   `debug` - `debug$` RxJS operator
--   `verbose` - `verbose$` RxJS operator
+### `AppLogLevelEnum`
 
-## Configuration
-
-Import `NestJsRxJsLoggerModule` into your module:
+`'debug' | 'error' | 'info' | 'verbose' | 'warn'` — the level argument accepted by `NestJSRxJSLoggerService.print` / `create$`; each level also has its own same-named pipeable method (`debug`, `error`, `info`, `verbose`, `warn`) shown below.
 
 ```ts
-import { Logger, Module } from '@nestjs/common';
-import { NestJsRxjsLoggerService } from '@rnw-community/nestjs-rxjs-logger';
+import { AppLogLevelEnum } from '@rnw-community/nestjs-rxjs-logger';
+
+const level: AppLogLevelEnum = AppLogLevelEnum.warn;
+```
+
+### `NestJSRxJSLoggerModule`
+
+Provides `NestJSRxJSLoggerService` (bound to NestJS's own `Logger` under the `'LOGGER'` DI token) for your module to import.
+
+```ts
+import { Module } from '@nestjs/common';
+
+import { NestJSRxJSLoggerModule } from '@rnw-community/nestjs-rxjs-logger';
 
 @Module({
-    imports: [NestJsRxJsLoggerModule],
+    imports: [NestJSRxJSLoggerModule],
     providers: [],
     exports: [],
 })
 export class MyModule {}
 ```
 
-Inject `NestJsRxjsLoggerService` into your service:
+### `NestJSRxJSLoggerService`
+
+`TRANSIENT`-scoped injectable with one pipeable method per log level (`debug`, `error`, `info`, `verbose`, `warn`), plus `create$` (starts a logged `Observable<boolean>`), `catch` (logs and rethrows), `setContext`, and `print` (imperative logging, no stream involved).
 
 ```ts
 import { Injectable } from '@nestjs/common';
-import { NestJsRxjsLoggerService } from '@rnw-community/nestjs-rxjs-logger';
-import { mapTo } from 'rxjs';
+
+import { NestJSRxJSLoggerService } from '@rnw-community/nestjs-rxjs-logger';
 
 @Injectable()
 export class MyService {
-    constructor(private readonly logger: NestJsRxjsLoggerService) {}
+    constructor(private readonly logger: NestJSRxJSLoggerService) {}
 }
 ```
 
@@ -49,15 +56,18 @@ export class MyService {
 
 ```ts
 import { Injectable } from '@nestjs/common';
-import { NestJsRxjsLoggerService } from '@rnw-community/nestjs-rxjs-logger';
-import { mapTo } from 'rxjs';
+
+import { NestJSRxJSLoggerService } from '@rnw-community/nestjs-rxjs-logger';
+import { of } from 'rxjs';
+
+import type { Observable } from 'rxjs';
 
 @Injectable()
 export class MyService {
-    constructor(private readonly logger: NestJsRxjsLoggerService) {}
+    constructor(private readonly logger: NestJSRxJSLoggerService) {}
 
     loggerOperatorExample$(): Observable<true> {
-        return of(true).pipe(this.logger.info$('My message', 'OtherContext'));
+        return of(true).pipe(this.logger.info('My message', 'OtherContext'));
     }
 }
 ```
@@ -66,15 +76,37 @@ export class MyService {
 
 ```ts
 import { Injectable } from '@nestjs/common';
-import { NestJsRxjsLoggerService } from '@rnw-community/nestjs-rxjs-logger';
-import { mapTo } from 'rxjs';
+
+import { NestJSRxJSLoggerService } from '@rnw-community/nestjs-rxjs-logger';
+import { map } from 'rxjs';
+
+import type { Observable } from 'rxjs';
 
 @Injectable()
 export class MyService {
-    constructor(private readonly logger: NestJsRxjsLoggerService) {}
+    constructor(private readonly logger: NestJSRxJSLoggerService) {}
 
     loggerCreateStreamExample$(): Observable<number> {
-        return this.logger.create$('My message', MyService.name).pipe(mapTo(1));
+        return this.logger.create$('My message', MyService.name).pipe(map(() => 1));
+    }
+}
+```
+
+### Catch and rethrow example
+
+```ts
+import { Injectable } from '@nestjs/common';
+
+import { NestJSRxJSLoggerService } from '@rnw-community/nestjs-rxjs-logger';
+
+import type { Observable } from 'rxjs';
+
+@Injectable()
+export class MyService {
+    constructor(private readonly logger: NestJSRxJSLoggerService) {}
+
+    loggerCatchExample$(source$: Observable<number>): Observable<number> {
+        return source$.pipe(this.logger.catch((error: unknown) => `failed: ${String(error)}`));
     }
 }
 ```
@@ -83,21 +115,24 @@ export class MyService {
 
 ```ts
 import { Injectable } from '@nestjs/common';
-import { NestJsRxjsLoggerService } from '@rnw-community/nestjs-rxjs-logger';
-import { mapTo } from 'rxjs';
+
+import { NestJSRxJSLoggerService } from '@rnw-community/nestjs-rxjs-logger';
+import { map, of } from 'rxjs';
+
+import type { Observable } from 'rxjs';
 
 @Injectable()
 export class MyService {
-    constructor(private readonly logger: NestJsRxjsLoggerService) {
+    constructor(private readonly logger: NestJSRxJSLoggerService) {
         this.logger.setContext(MyService.name);
     }
 
     loggerOperatorExample$(): Observable<true> {
-        return of(true).pipe(this.logger.info$('My message'));
+        return of(true).pipe(this.logger.info('My message'));
     }
 
     loggerCreateStreamExample$(): Observable<number> {
-        return this.logger.create$('My message').pipe(mapTo(1));
+        return this.logger.create$('My message').pipe(map(() => 1));
     }
 }
 ```

--- a/packages/nestjs-rxjs-metrics/readme.md
+++ b/packages/nestjs-rxjs-metrics/readme.md
@@ -41,7 +41,7 @@ const summaryLabels = {
 -   Create metrics module and service for NestJS DI, this module and service should be used in the project:
 
 ```ts
-import { Injectable } from '@nestjs/common';
+import { Injectable, Module } from '@nestjs/common';
 
 import { NestJSRxJSMetricsModule } from '@rnw-community/nestjs-rxjs-metrics';
 
@@ -97,8 +97,8 @@ export class MyService {
 [Gauge](https://prometheus.io/docs/concepts/metric_types/#gauge) supports next operators:
 
 -   `gauge(GaugeMetric, handler: (gauge: Gauge<string>) => void)` operator - observe Gauge metric and perform callback on it
--   `gaugeInc(GaugeMetric, value = 1) => void)` operator - increment Gauge metric by `value`
--   `gaugeDec(GaugeMetric, value = 1) => void)` operator - decrement Gauge metric by `value`
+-   `gaugeInc(GaugeMetric, value = 1)` operator - increment Gauge metric by `value`
+-   `gaugeDec(GaugeMetric, value = 1)` operator - decrement Gauge metric by `value`
 
 ```ts
 const gaugeMetrics = { my_gauge_metric: 'Text gauge metric' };
@@ -128,7 +128,7 @@ export class MyService {
 [Histogram](https://prometheus.io/docs/concepts/metric_types/#histogram) supports next operators:
 
 -   `histogramStart(HistogramMetric, labels?: LabelValues<L>)` operator - start observing Histogram metric with labels
--   `histogramEnd(HistogramMetric, labels?: LabelValues<L>))` operator - finish observing Histogram metric with labels
+-   `histogramEnd(HistogramMetric, labels?: LabelValues<L>)` operator - finish observing Histogram metric with labels
 
 ```ts
 const histogramMetrics = { my_histogram_metric: 'Text histogram metric' };
@@ -153,7 +153,7 @@ export class MyService {
 [Summary](https://prometheus.io/docs/concepts/metric_types/#summary) supports next operators:
 
 -   `summaryStart(SummaryMetric, labels?: LabelValues<L>)` operator - start observing Summary metric with labels
--   `summaryEnd(SummaryMetric, labels?: LabelValues<L>))` operator - finish observing Summary metric with labels
+-   `summaryEnd(SummaryMetric, labels?: LabelValues<L>)` operator - finish observing Summary metric with labels
 
 ```ts
 const summaryMetrics = { my_summary_metric: 'Text summary metric' };

--- a/packages/nestjs-rxjs-metrics/readme.md
+++ b/packages/nestjs-rxjs-metrics/readme.md
@@ -41,14 +41,9 @@ const summaryLabels = {
 -   Create metrics module and service for NestJS DI, this module and service should be used in the project:
 
 ```ts
-import { Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 
-import { MetricsServiceMixin } from '@rnw-community/nestjs-rxjs-metrics';
-
-import type { counterMetrics } from './counter.metrics';
-import type { gaugeMetrics } from './gauge.metrics';
-import type { histogramMetrics } from './histogram.metrics';
-import type { summaryMetrics } from './summary.metrics';
+import { NestJSRxJSMetricsModule } from '@rnw-community/nestjs-rxjs-metrics';
 
 export const [BaseMetricsModule, BaseMetricsService] = NestJSRxJSMetricsModule.create({
     counterMetrics,
@@ -57,7 +52,6 @@ export const [BaseMetricsModule, BaseMetricsService] = NestJSRxJSMetricsModule.c
     summaryMetrics,
     summaryLabels,
     histogramLabels,
-    controller: PrometheusController,
 });
 
 @Injectable()
@@ -158,8 +152,8 @@ export class MyService {
 
 [Summary](https://prometheus.io/docs/concepts/metric_types/#summary) supports next operators:
 
--   `histogramStart(SumaryMetric, labels?: LabelValues<L>)` operator - start observing Summary metric with labels
--   `histogramEnd(SummaryMetric, labels?: LabelValues<L>))` operator - finish observing Summary metric with labels
+-   `summaryStart(SummaryMetric, labels?: LabelValues<L>)` operator - start observing Summary metric with labels
+-   `summaryEnd(SummaryMetric, labels?: LabelValues<L>))` operator - finish observing Summary metric with labels
 
 ```ts
 const summaryMetrics = { my_summary_metric: 'Text summary metric' };
@@ -171,9 +165,9 @@ export class MyService {
 
     exampleAction$() {
         return of(true).pipe(
-            this.metrics.histogramStart('my_summary_metric', { my_summary_metric_label1: 1 }),
+            this.metrics.summaryStart('my_summary_metric', { my_summary_metric_label1: 1 }),
             // perform actions
-            this.metrics.histogramEnd('my_summary_metric', { my_summary_metric_label1: 2 })
+            this.metrics.summaryEnd('my_summary_metric', { my_summary_metric_label1: 2 })
         );
     }
 }

--- a/packages/nestjs-rxjs-redis/readme.md
+++ b/packages/nestjs-rxjs-redis/readme.md
@@ -6,9 +6,6 @@ NestJS redis wrapper for using with RxJS streams.
 [![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=nestjs-rxjs-redis&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
 [![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fnestjs-rxjs-redis.svg)](https://www.npmjs.com/package/%40rnw-community%2Fnestjs-rxjs-redis)
 
-## TODO
-- [ ] Merge and refactor `@nestjs-modules/ioredis` into this repo, as it has not been updated for 3+ years.
-
 ## Configuration
 
 Import `NestJSRxJSRedisModule` into your module:

--- a/packages/nestjs-typed-config/readme.md
+++ b/packages/nestjs-typed-config/readme.md
@@ -53,7 +53,7 @@ export const environmentVariablesValidationSchema = Joi.object({
 -   Create config module and service for NestJS DI, this module and service should be used in the project:
 
 ```ts
-import { Inject, Injectable } from '@nestjs/common';
+import { Injectable, Module } from '@nestjs/common';
 
 import { NestJSTypedConfigModule } from '@rnw-community/nestjs-typed-config';
 

--- a/packages/nestjs-typed-config/readme.md
+++ b/packages/nestjs-typed-config/readme.md
@@ -13,6 +13,16 @@ Install additional peer dependencies:
 -   [@nestjs/config](https://github.com/nestjs/config)
 -   [joi](https://github.com/sideway/joi)
 
+## Exports
+
+### `NestJSTypedConfigModule`
+
+`NestJSTypedConfigModule.create<Enum, Config>(validationSchema)` returns a `[DynamicModule, Type<NestJSTypedConfigService<Enum, Config>>]` tuple — extend the returned service class and wire the module into your own `@Module({ imports: [BaseConfigModule] })`. See "Configuration" below for the full setup.
+
+### `NestJSTypedConfigService`
+
+Injectable service with a single `get<K extends keyof Config>(envVariable: K): Config[K]` method; caches lookups and transparently reads `_FILE`-suffixed variables from disk. See "Usage" below.
+
 ## Configuration
 
 -   Create enum with names for all the required environment variable names, interface with type for every environment variable

--- a/packages/object-field-tree/readme.md
+++ b/packages/object-field-tree/readme.md
@@ -12,6 +12,57 @@ with IDE autocompletion.
 Real world usage examples:
 [@rnw-community/fast-style](https://github.com/rnw-community/rnw-community/tree/master/packages/fast-style)
 
+## Exports
+
+### `combine`
+
+Overloaded for 1–5 enum-like collection arguments; builds a nested lookup object where each leaf is `dataFn(key1, key2, ...)`. See the two full examples below.
+
+### `Enum`
+
+Re-exported from [`@rnw-community/shared`](https://github.com/rnw-community/rnw-community/tree/master/packages/shared) — the constraint every `combine` collection argument must satisfy (a plain string/number enum-like object).
+
+```ts
+import type { Enum } from '@rnw-community/object-field-tree';
+
+const isValidCollection = <T extends Enum>(collection: T): T => collection;
+```
+
+### `CombineReturn1<T, D>`
+
+Return type of `combine` called with 1 collection: `Record<keyof T, D>`.
+
+```ts
+import type { CombineReturn1 } from '@rnw-community/object-field-tree';
+
+type Sizes = CombineReturn1<{ Small: 'Small'; Large: 'Large' }, string>; // Record<'Small' | 'Large', string>
+```
+
+### `CombineReturn2<D, T1, T2>`
+
+Return type of `combine` called with 2 collections — nests one more level of `Record`: `Record<keyof T1, CombineReturn1<T2, D>>`.
+
+```ts
+import type { CombineReturn2 } from '@rnw-community/object-field-tree';
+
+type Sizes = { Small: 'Small'; Large: 'Large' };
+type Colors = { Red: 'Red'; Blue: 'Blue' };
+
+type SizeColor = CombineReturn2<string, Sizes, Colors>; // Record<'Small' | 'Large', Record<'Red' | 'Blue', string>>
+```
+
+### `CombineReturn3<D, T1, T2, T3>`
+
+Return type of `combine` called with 3 collections: `Record<keyof T1, CombineReturn2<D, T2, T3>>` — one more nesting level than `CombineReturn2`.
+
+### `CombineReturn4<D, T1, T2, T3, T4>`
+
+Return type of `combine` called with 4 collections: `Record<keyof T1, CombineReturn3<D, T2, T3, T4>>`.
+
+### `CombineReturn5<D, T1, T2, T3, T4, T5>`
+
+Return type of `combine` called with 5 collections: `Record<keyof T1, CombineReturn4<D, T2, T3, T4, T5>>` — the deepest arity `combine` supports.
+
 ## Example
 
 ### Typescript enum and object usage example

--- a/packages/platform/readme.md
+++ b/packages/platform/readme.md
@@ -2,9 +2,9 @@
 
 Platform specific helpers and utils for react native web.
 
-[![npm version](https://badge.fury.io/js/%40rnw-community%2Fredux-loadable.svg)](https://badge.fury.io/js/%40rnw-community%2Fredux-loadable)
+[![npm version](https://badge.fury.io/js/%40rnw-community%2Fplatform.svg)](https://badge.fury.io/js/%40rnw-community%2Fplatform)
 [![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=platform&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
-[![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fredux-loadable.svg)](https://www.npmjs.com/package/%40rnw-community%2Fredux-loadable)
+[![npm downloads](https://img.shields.io/npm/dm/%40rnw-community%2Fplatform.svg)](https://www.npmjs.com/package/%40rnw-community%2Fplatform)
 
 ### Platform constants
 
@@ -21,7 +21,6 @@ Simple platform-specific styling helpers:
 
 -   `webStyles(style)`
 -   `androidStyles(style)`
--   `iosStyles(style)`
 -   `iosStyles(style)`
 -   `mobileStyles(style)`
 

--- a/packages/redux-loadable/readme.md
+++ b/packages/redux-loadable/readme.md
@@ -49,7 +49,11 @@ Helper reducer functions that mutate then return `{ ...state }` — designed to 
 Sets `isLoading: true`, clears `error`, and flips `isPristine` to `false`.
 
 ```ts
+import { createSlice } from '@reduxjs/toolkit';
+
 import { loadingStarted } from '@rnw-community/redux-loadable';
+
+declare const initialState: UserState;
 
 const userSlice = createSlice({
     name: 'user',
@@ -65,7 +69,13 @@ const userSlice = createSlice({
 Sets `isLoading: false` and clears `error` on a successful load.
 
 ```ts
+import { createSlice } from '@reduxjs/toolkit';
+
 import { loadingFinished } from '@rnw-community/redux-loadable';
+
+import type { PayloadAction } from '@reduxjs/toolkit';
+
+declare const initialState: UserState;
 
 const userSlice = createSlice({
     name: 'user',
@@ -85,7 +95,13 @@ const userSlice = createSlice({
 Sets `isLoading: false` and stores `errorReason` in `error`.
 
 ```ts
+import { createSlice } from '@reduxjs/toolkit';
+
 import { loadingFailed } from '@rnw-community/redux-loadable';
+
+import type { PayloadAction } from '@reduxjs/toolkit';
+
+declare const initialState: UserState;
 
 const userSlice = createSlice({
     name: 'user',
@@ -101,7 +117,11 @@ const userSlice = createSlice({
 Resets the slice back to `initialLoadingState`'s values.
 
 ```ts
+import { createSlice } from '@reduxjs/toolkit';
+
 import { loadingReset } from '@rnw-community/redux-loadable';
+
+declare const initialState: UserState;
 
 const userSlice = createSlice({
     name: 'user',
@@ -123,7 +143,11 @@ interface RootState {
     user: UserState;
 }
 
-const [isLoading, isFailed, isPristine, error] = loadingStateSelector<RootState>('user')(state);
+declare const rootState: RootState;
+
+const selectUserLoadingState = (state: RootState) => loadingStateSelector<RootState>('user')(state);
+
+const [isLoading, isFailed, isPristine, error] = selectUserLoadingState(rootState);
 ```
 
 ## License

--- a/packages/redux-loadable/readme.md
+++ b/packages/redux-loadable/readme.md
@@ -14,29 +14,117 @@ Supported loading states:
 -   `failed` - loading failed
 -   `success` - loading was successful
 
-## Utils
+## Exports
 
-Helper reducer functions that will change loading state.
-
-### `loadingStarted(state: LoadingStateInterface)`
-
-### `loadingFinished(state: LoadingStateInterface)`
-
-### `loadingFailed(state: LoadingStateInterface, error: string)`
-
-### `loadingReset(state: LoadingStateInterface)`
-
-## LoadingStateInterface
+### `LoadingStateInterface`
 
 -   `isPristine` - flag showing that slice is in initial state and no requests were made.
 -   `isLoading` - flag showing that request is ongoing.
--   `error` - string, storing last request error message
+-   `error` - string, storing last request error message (empty string when there is no error)
 
-## Examples
+```ts
+import type { LoadingStateInterface } from '@rnw-community/redux-loadable';
 
-### Redux-toolkit example
+interface UserState extends LoadingStateInterface {
+    name: string;
+}
+```
 
-### ts-action example
+### `initialLoadingState`
+
+`{ isPristine: true, isLoading: false, error: '' }` — the starting value for any state slice implementing `LoadingStateInterface`.
+
+```ts
+import { initialLoadingState } from '@rnw-community/redux-loadable';
+
+const initialState: UserState = { ...initialLoadingState, name: '' };
+```
+
+## Utils
+
+Helper reducer functions that mutate then return `{ ...state }` — designed to be called from inside a Redux Toolkit `createSlice` reducer (Immer draft in, plain object out).
+
+### `loadingStarted(state)`
+
+Sets `isLoading: true`, clears `error`, and flips `isPristine` to `false`.
+
+```ts
+import { loadingStarted } from '@rnw-community/redux-loadable';
+
+const userSlice = createSlice({
+    name: 'user',
+    initialState,
+    reducers: {
+        fetchUser: state => loadingStarted(state),
+    },
+});
+```
+
+### `loadingFinished(state)`
+
+Sets `isLoading: false` and clears `error` on a successful load.
+
+```ts
+import { loadingFinished } from '@rnw-community/redux-loadable';
+
+const userSlice = createSlice({
+    name: 'user',
+    initialState,
+    reducers: {
+        fetchUserSuccess: (state, action: PayloadAction<string>) => {
+            state.name = action.payload;
+
+            return loadingFinished(state);
+        },
+    },
+});
+```
+
+### `loadingFailed(state, errorReason)`
+
+Sets `isLoading: false` and stores `errorReason` in `error`.
+
+```ts
+import { loadingFailed } from '@rnw-community/redux-loadable';
+
+const userSlice = createSlice({
+    name: 'user',
+    initialState,
+    reducers: {
+        fetchUserFailure: (state, action: PayloadAction<string>) => loadingFailed(state, action.payload),
+    },
+});
+```
+
+### `loadingReset(state)`
+
+Resets the slice back to `initialLoadingState`'s values.
+
+```ts
+import { loadingReset } from '@rnw-community/redux-loadable';
+
+const userSlice = createSlice({
+    name: 'user',
+    initialState,
+    reducers: {
+        resetUser: state => loadingReset(state),
+    },
+});
+```
+
+### `loadingStateSelector(slice)`
+
+Curried selector: `loadingStateSelector(sliceName)(state)` returns an `[isLoading, isFailed, isPristine, error]` tuple for that slice.
+
+```ts
+import { loadingStateSelector } from '@rnw-community/redux-loadable';
+
+interface RootState {
+    user: UserState;
+}
+
+const [isLoading, isFailed, isPristine, error] = loadingStateSelector<RootState>('user')(state);
+```
 
 ## License
 

--- a/packages/rxjs-errors/readme.md
+++ b/packages/rxjs-errors/readme.md
@@ -8,7 +8,21 @@ Utils that help work with errors in rxjs observable's.
 
 ## Classes
 
--   `RxJSFilterError` - custom error used by error operators.
+### RxJSFilterError
+
+Custom `Error` subclass; the default error thrown/created by `filterWithException` and `rethrowException` when no custom `ErrorCtor` is passed in.
+
+```typescript
+import { RxJSFilterError } from '@rnw-community/rxjs-errors';
+
+try {
+    throw new RxJSFilterError('Invalid letter received');
+} catch (error) {
+    if (error instanceof RxJSFilterError) {
+        console.error(error.message);
+    }
+}
+```
 
 ## Available operators
 

--- a/packages/wdio/readme.md
+++ b/packages/wdio/readme.md
@@ -8,10 +8,9 @@ WDIO commands and utils.
 
 ## TODO
 
--  [ ] Refactor tests to mock MockElement(rename to MockElementPromise), use it instead of mockElement object
--  [ ] Rename all tests `its` properly after API stabilizes
--  [ ] Write docs with the examples
--  [ ] Add tests for extended class instance ctor return from async function - it resolves to WDIO element =)
+-  [ ] Unify `MockElement`/`mockElement` test scaffolding into one fixture — [#520](https://github.com/rnw-community/rnw-community/issues/520)
+-  [ ] Rename generic test descriptions to describe real behavior — [#521](https://github.com/rnw-community/rnw-community/issues/521)
+-  [ ] Add tests for the Promise-extending component ctor resolving to a WDIO element — [#522](https://github.com/rnw-community/rnw-community/issues/522)
 -  [ ] Rename everything with `$` to `CSS` to make things more clear, leave backward compatibility
 -  [ ] Remove all dependencies from `@wdio`, library should be agnostic, and support `wdio` and `playwright` via adapters(maybe others):
   - [ ] Create generic adapter and element interface
@@ -43,13 +42,14 @@ generated components.
 Example usage:
 
 ```tsx
-import React, { FC } from 'react';
 import { Text } from 'react-native';
 
-import { IOSTestIDProps, setTestId } from '@rnw-community/wdio';
+import { setTestID } from '@rnw-community/wdio';
 
-export const DynamicComponent: = ({ testID = 'ParentTestID' }:IOSTestIDProps) => (
-    <Text {...setTestId(testID, `Text`)}>Text</Text>
+import type { TestIDProps } from '@rnw-community/wdio';
+
+export const DynamicComponent = ({ testID = 'ParentTestID' }: TestIDProps) => (
+    <Text {...setTestID(testID, 'Text')}>Text</Text>
 );
 ```
 
@@ -57,14 +57,27 @@ Which will generate `ParentTestID_Text`;
 
 ### getTestID
 
+Reads the platform-specific testID back out of the props object produced by `setTestID` / `setPropTestID` — `props[WebSelectorConfig]` on web, `props.testID` on Android/iOS, falling back to `defaultTestID`.
+
+```tsx
+import { getTestID, setTestID } from '@rnw-community/wdio';
+
+const props = setTestID('DynamicComponent', 'Text');
+
+getTestID(props); // 'DynamicComponent_Text'
+```
+
 ### setPropTestID
 
 Setting _testID_ similar to `setTestID` but with overriding default _testID_.
 
 ```tsx
 import React from 'react';
-import { Text } from 'react-native';
-import { TestIDProps } from '@rnw-community/wdio';
+import { View } from 'react-native';
+
+import { setPropTestID } from '@rnw-community/wdio';
+
+import type { TestIDProps } from '@rnw-community/wdio';
 
 interface Props extends TestIDProps, React.PropsWithChildren {
     testID?: string;


### PR DESCRIPTION
Refs #490.

## Summary

- Added per-export `###` usage sections to the packages the #490 audit flagged with zero or thin coverage.
- Replaced stale, un-linked TODO checkboxes in `nestjs-rxjs-lock`, `nestjs-rxjs-redis`, and `wdio` — some were already done and removed, the rest converted to issue links (new issues filed where none existed).
- Spot-checked the remaining packages for badge-row completeness and stale content and fixed what turned up (wrong badges, wrong class/method names, dangling imports, copy-paste bugs, empty sections).

## Export coverage (audited packages)

| Package | Exports | `###` sections before | `###` sections after |
|---|---|---|---|
| lock-decorator | 16 | 0 | 16 |
| log-decorator | 8 | 0 | 8 |
| decorators-core | 4 | 0 | 4 |
| histogram-metric-decorator | 4 | 0 | 4 |
| object-field-tree | 7 (issue estimated 8; `combine`'s 5 overloads count as one export) | 2 | 7 |
| nestjs-typed-config | 2 | 1 | 2 |
| nestjs-enterprise | 10 | 7 (linked `.md` files) + 3 narrative categories | 10 (3 new inline sections for `PreDecoratorFunction`, `LockServiceInterface`, `LockHandle`; existing 7 `.md` links untouched) |
| rxjs-errors | 3 | 2 | 3 |

## TODO hygiene

- `nestjs-rxjs-lock`: both TODO items ("Add module tests", "Add `lock$` docs usage example") were already done — `nestjs-rxjs-lock.module.spec.ts` exists and the readme already had a full `lock$` example. Removed the stale section.
- `nestjs-rxjs-redis`: removed the "merge `@nestjs-modules/ioredis`, not updated in 3+ years" TODO — the npm registry shows `2.1.0`/`2.2.1`/`2.2.2` published within the last several months, so the stated premise no longer holds.
- `wdio`: removed the "write docs with examples" item (readme already has extensive Setup/Usage/Components sections). Filed and linked three new issues for the remaining called-out items:
  - #520 — unify `MockElement`/`mockElement` test scaffolding
  - #521 — rename generic test descriptions
  - #522 — add tests for the Promise-extending component ctor resolving to a WDIO element

## Spot-check fixes (badge-row completeness / stale content)

- `platform`: all three badges pointed at `redux-loadable`'s npm package — fixed to `platform`; also removed a duplicated `iosStyles(style)` bullet.
- `nestjs-rxjs-logger`: readme used non-existent casing (`NestJsRxJsLoggerModule`, `NestJsRxjsLoggerService`) and non-existent `$`-suffixed method names (`info$`, `error$`, ...); one example even referenced an import that was never made. Corrected to the real `NestJSRxJSLoggerModule` / `NestJSRxJSLoggerService` / plain method names, and added an exports section covering `AppLogLevelEnum` too.
- `nestjs-rxjs-metrics`: fixed a nonexistent import (`MetricsServiceMixin` → `NestJSRxJSMetricsModule`), a type-only import used as a value, a dangling `PrometheusController` reference, and a copy-pasted Summary example that called `histogramStart`/`histogramEnd` instead of `summaryStart`/`summaryEnd`.
- `redux-loadable`: several sections were empty headers with no body (`### loadingStarted(...)`, `### Redux-toolkit example`, `### ts-action example`) — filled in with real per-export examples for all 7 exports.
- `fast-style`: added the missing `FlexDirectionEnum` / `FlexJustifyContentEnum` / `FlexAlignItemsEnum` documentation (the enums backing `Flex`'s property chain were undocumented).
- `wdio`: fixed a pre-existing empty `### getTestID` section, a reference to a nonexistent `IOSTestIDProps` type, and a `setTestId`/`setTestID` casing bug across two examples.
- `eslint-plugin`: reviewed, already adequate — no changes.

## Test plan

- [x] `yarn lint` passes for every touched package (pre-existing `react-native-payments` lint failure is unrelated and out of scope — that package is owned by #499).
- [x] No source (`.ts`) files were touched — readme-only change set.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update package READMEs to document all exports with signatures and examples
> Brings 16 package READMEs up to per-export parity by adding dedicated sections for each exported function, class, interface, and type, each with TypeScript signatures and usage examples.
>
> - Packages with major expansions include `lock-decorator`, `log-decorator`, `nestjs-rxjs-logger`, `redux-loadable`, and `histogram-metric-decorator`
> - Fixes incorrect npm badge links in `platform` and corrects operator names (`summaryStart`/`summaryEnd`) in `nestjs-rxjs-metrics`
> - Removes stale TODO sections from `nestjs-rxjs-lock` and `nestjs-rxjs-redis`
> - Updates `wdio` examples to reflect current API names (`setTestID`, `TestIDProps`, `getTestID`)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8ef8f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded API documentation and TypeScript examples across decorators, locking, logging, metrics, configuration, Redux loading, errors, and object-field utilities.
  - Clarified usage, options, interfaces, return types, error handling, and integration patterns.
  - Corrected logger and metrics naming and usage examples.
  - Updated platform badges and WebdriverIO test ID guidance.
  - Removed outdated TODO sections and obsolete examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->