### PR TITLE
build: extend publint/attw publication hygiene to all packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,13 +268,13 @@ The monorepo uses dual ESM + CJS output. Key decisions:
 
 - `sideEffects: false` (boolean) in all package.json files
 - `"types"` condition is **first** within each conditional `exports` block (required for `moduleResolution: "nodenext"`
-  consumers). `shared` and `react-native-payments` nest `types` under `import`/`require` rather than sharing one
-  top-level `types` key — a single shared `types` key resolves the wrong module kind for one of the two conditions
-  (confirmed by `@arethetypeswrong/cli`); splitting it keeps `types` first inside each condition while giving each
-  format its own accurate declaration file (`dist/esm/index.d.ts` for `import`, `dist/cjs/index.d.ts` for `require`)
+  consumers). Every dual-format package nests `types` under `import`/`require` rather than sharing one top-level
+  `types` key — a single shared `types` key resolves the wrong module kind for one of the two conditions (confirmed by
+  `@arethetypeswrong/cli`); splitting it keeps `types` first inside each condition while giving each format its own
+  accurate declaration file (`dist/esm/index.d.ts` for `import`, `dist/cjs/index.d.ts` for `require`)
 - `dist/esm/package.json` (`{"type":"module"}`) and `dist/cjs/package.json` (`{"type":"commonjs"}`) are written by the
-  `build` script (`shared`, `react-native-payments`) so Node's own module-kind detection matches each directory's real
-  output instead of falling through to the CJS default for the ESM build
+  `build` script of every dual-format package so Node's own module-kind detection matches each directory's real output
+  instead of falling through to the CJS default for the ESM build. `eslint-plugin` is the one exception — see below
 - `moduleResolution: "bundler"` in root tsconfig, `"node"` override in CJS build tsconfig
 - `verbatimModuleSyntax: true` enforces explicit `import type` for type-only imports
 - `lib: ["es2021"]` matches the build target
@@ -284,14 +284,34 @@ The monorepo uses dual ESM + CJS output. Key decisions:
   consumers use (Metro included). Packages declare their actual supported Node floor via `engines.node` instead of
   chasing the legacy pre-`exports` resolution algorithm
 - **Known, accepted publish-time limitation**, surfaced by `@arethetypeswrong/cli` and ignored explicitly
-  (`--ignore-rules internal-resolution-error`) in `yarn publint`, with this paragraph as the recorded justification for
-  `shared` and `react-native-payments`: `tsc` emits relative import specifiers without file extensions
-  (`./enum/foo.enum`, not `./enum/foo.enum.js`). Node's own `node16`/`nodenext` ESM resolution requires the extension,
-  so a consumer forcing that exact resolution mode against the `import` condition sees unresolved relative imports in
-  the shipped `.d.ts` files. Every other real consumption path — bundlers (Metro included) and `node16`/`nodenext`
-  `require` — resolves cleanly; only the `node16`/`nodenext` **ESM** path is affected. Rewriting every relative import
-  across every package's `src` tree to carry an explicit extension is a repo-wide source-emit change, not a
-  publish-config fix, so it is deferred rather than bundled into publication hardening
+  (`--ignore-rules internal-resolution-error`) in `yarn publint` for every package, with this paragraph as the
+  recorded justification: `tsc` emits relative import specifiers without file extensions (`./enum/foo.enum`, not
+  `./enum/foo.enum.js`). Node's own `node16`/`nodenext` ESM resolution requires the extension, so a consumer forcing
+  that exact resolution mode against the `import` condition sees unresolved relative imports in the shipped `.d.ts`
+  files. Every other real consumption path — bundlers (Metro included) and `node16`/`nodenext` `require` — resolves
+  cleanly; only the `node16`/`nodenext` **ESM** path is affected. Rewriting every relative import across every
+  package's `src` tree to carry an explicit extension is a repo-wide source-emit change, not a publish-config fix, so
+  it is deferred rather than bundled into publication hardening
+- **`eslint-plugin` ships CommonJS only, by design, not oversight.** Its `src/index.ts` ends in `export = plugin` —
+  the shape ESLint's own legacy plugin loader (`@eslint/eslintrc`, string-based `"plugins": ["@rnw-community"]`
+  resolution) requires: it `require()`s the module and uses the returned value directly, with no `.default` unwrap.
+  Switching to `export default plugin` would satisfy a "real" ESM build but silently break every consumer still on
+  legacy `.eslintrc` config. Because `export =` cannot be re-emitted as genuine ESM syntax, the package's own
+  `tsconfig.build-esm.json` targets `NodeNext` against a `type`-less source tree so `tsc` compiles it as CommonJS
+  even under `dist/esm/` — both dist trees are byte-equivalent CJS. The package.json reflects this honestly instead of
+  papering over it: root-level `"type": "commonjs"` (not per-directory markers, since neither directory is ESM), no
+  `"module"` field (there is no real ESM entry to advertise to bundlers), and `yarn publint`'s `attw` invocation for
+  this package alone adds `--ignore-rules named-exports` — `attw`'s "TypeScript allows ESM named imports that will
+  crash at runtime" finding is exactly the CJS-via-`import`-statement default-interop pattern this package's own
+  readme documents as its supported usage (`import rnwcPlugin from '@rnw-community/eslint-plugin'`), never named
+  imports of individual properties
+- **`tsc`'s `resolveJsonModule` copies imported `.json` files into `dist/`, including nested `package.json` copies
+  with a self-referential (and Node-ignored) `"exports"` field.** `eslint-plugin`'s `src/index.ts` imports
+  `../package.json` for `meta.name`/`meta.version`; because that import falls outside `./src`, `tsc` widens its
+  inferred `rootDir` to the package root and mirrors `package.json` into both `dist/esm/` and `dist/cjs/` verbatim.
+  `publint` flags the duplicated, non-functional `"exports"` field. The package's `build` script now deletes both
+  copies (`rm -f dist/esm/package.json dist/cjs/package.json`) after compilation — the import itself stays, since
+  rewriting it to avoid the `rootDir` widening is a larger refactor than a publish-hygiene pass warrants
 
 ## PR Review & Merge Policy
 

--- a/knip.json
+++ b/knip.json
@@ -40,11 +40,13 @@
         "run"
     ],
     "ignoreDependencies": [
+        "@arethetypeswrong/cli",
         "@babel/preset-env",
         "@babel/preset-typescript",
         "@babel/runtime",
         "babel-jest",
         "husky",
+        "publint",
         "reflect-metadata",
         "rimraf",
         "@types/hapi__joi",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",
     "lint:force": "turbo run lint --force",
-    "publint": "turbo run build --filter=@rnw-community/shared --filter=@rnw-community/react-native-payments && publint run packages/shared && publint run packages/react-native-payments && attw --pack packages/shared --profile node16 --ignore-rules internal-resolution-error && attw --pack packages/react-native-payments --profile node16 --ignore-rules internal-resolution-error",
+    "publint": "bash scripts/publint.sh",
     "release": "lerna publish --yes --conventional-commits --create-release=github -m \"chore: release %s [skip ci]\"",
     "test": "turbo run test",
     "test:coverage": "turbo run test:coverage",

--- a/packages/decorators-core/package.json
+++ b/packages/decorators-core/package.json
@@ -16,9 +16,14 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         }
     },
     "main": "dist/cjs/index.js",
@@ -35,7 +40,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && echo '{\"type\":\"module\"}' > dist/esm/package.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",

--- a/packages/eslint-plugin/AGENTS.md
+++ b/packages/eslint-plugin/AGENTS.md
@@ -47,6 +47,18 @@ src/
   `moduleResolution`/`module` set to `nodenext`/`NodeNext`/`node16` variants and `verbatimModuleSyntax: false` —
   the latter is required because `export = plugin` cannot coexist with `verbatimModuleSyntax: true`
 
+### Publication shape — CommonJS only, no `"module"` field
+
+Unlike every other package in the repo, this one does not ship a genuine ESM build: `export = plugin` cannot be
+re-emitted as ESM syntax, so `tsc` compiles both `dist/esm/` and `dist/cjs/` as CommonJS (see root AGENTS.md's ESM
+Modernization Status for the full reasoning). `package.json` reflects this with root-level `"type": "commonjs"`
+(covering both dist trees) and no `"module"` field. `yarn publint`'s `attw` check for this package alone passes
+`--ignore-rules named-exports`, since `attw`'s named-export warning only flags the unsupported (and undocumented)
+`import { x } from '@rnw-community/eslint-plugin'` form — the readme's documented usage is a default import. The
+`build` script also deletes `dist/esm/package.json` / `dist/cjs/package.json` after compiling: `tsc`'s
+`resolveJsonModule` copies the `../package.json` import target into both output trees verbatim (self-referential
+`"exports"` field and all), which `publint` correctly flags as dead weight.
+
 ### Dependencies
 
 - `@typescript-eslint/utils` — `ESLintUtils.RuleCreator` and `TSESLint`/`AST_NODE_TYPES` used by the rule

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -13,18 +13,23 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/src/index.d.ts",
-            "import": "./dist/esm/src/index.js",
-            "require": "./dist/cjs/src/index.js"
+            "import": {
+                "types": "./dist/esm/src/index.d.ts",
+                "default": "./dist/esm/src/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/src/index.d.ts",
+                "default": "./dist/cjs/src/index.js"
+            }
         }
     },
     "main": "dist/cjs/src/index.js",
-    "module": "dist/esm/src/index.js",
     "types": "dist/esm/src/index.d.ts",
     "files": [
         "dist/**/*"
     ],
     "sideEffects": false,
+    "type": "commonjs",
     "publishConfig": {
         "access": "public"
     },
@@ -35,7 +40,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && rm -f dist/esm/package.json dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",

--- a/packages/fast-style/package.json
+++ b/packages/fast-style/package.json
@@ -12,9 +12,14 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         }
     },
     "main": "dist/cjs/index.js",
@@ -31,7 +36,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && echo '{\"type\":\"module\"}' > dist/esm/package.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",

--- a/packages/histogram-metric-decorator/package.json
+++ b/packages/histogram-metric-decorator/package.json
@@ -14,9 +14,14 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         }
     },
     "main": "dist/cjs/index.js",
@@ -33,7 +38,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && echo '{\"type\":\"module\"}' > dist/esm/package.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",

--- a/packages/lock-decorator/package.json
+++ b/packages/lock-decorator/package.json
@@ -15,9 +15,14 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         }
     },
     "main": "dist/cjs/index.js",
@@ -34,7 +39,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && echo '{\"type\":\"module\"}' > dist/esm/package.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",

--- a/packages/log-decorator/package.json
+++ b/packages/log-decorator/package.json
@@ -14,9 +14,14 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         }
     },
     "main": "dist/cjs/index.js",
@@ -33,7 +38,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && echo '{\"type\":\"module\"}' > dist/esm/package.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",

--- a/packages/nestjs-enterprise/package.json
+++ b/packages/nestjs-enterprise/package.json
@@ -13,39 +13,74 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         },
         "./HistogramMetric": {
-            "types": "./dist/esm/decorator/histogram-metric/histogram-metric.decorator.d.ts",
-            "import": "./dist/esm/decorator/histogram-metric/histogram-metric.decorator.js",
-            "require": "./dist/cjs/decorator/histogram-metric/histogram-metric.decorator.js"
+            "import": {
+                "types": "./dist/esm/decorator/histogram-metric/histogram-metric.decorator.d.ts",
+                "default": "./dist/esm/decorator/histogram-metric/histogram-metric.decorator.js"
+            },
+            "require": {
+                "types": "./dist/cjs/decorator/histogram-metric/histogram-metric.decorator.d.ts",
+                "default": "./dist/cjs/decorator/histogram-metric/histogram-metric.decorator.js"
+            }
         },
         "./Log": {
-            "types": "./dist/esm/decorator/log/log.decorator.d.ts",
-            "import": "./dist/esm/decorator/log/log.decorator.js",
-            "require": "./dist/cjs/decorator/log/log.decorator.js"
+            "import": {
+                "types": "./dist/esm/decorator/log/log.decorator.d.ts",
+                "default": "./dist/esm/decorator/log/log.decorator.js"
+            },
+            "require": {
+                "types": "./dist/cjs/decorator/log/log.decorator.d.ts",
+                "default": "./dist/cjs/decorator/log/log.decorator.js"
+            }
         },
         "./LockPromise": {
-            "types": "./dist/esm/decorator/lock/lock-promise/lock-promise.decorator.d.ts",
-            "import": "./dist/esm/decorator/lock/lock-promise/lock-promise.decorator.js",
-            "require": "./dist/cjs/decorator/lock/lock-promise/lock-promise.decorator.js"
+            "import": {
+                "types": "./dist/esm/decorator/lock/lock-promise/lock-promise.decorator.d.ts",
+                "default": "./dist/esm/decorator/lock/lock-promise/lock-promise.decorator.js"
+            },
+            "require": {
+                "types": "./dist/cjs/decorator/lock/lock-promise/lock-promise.decorator.d.ts",
+                "default": "./dist/cjs/decorator/lock/lock-promise/lock-promise.decorator.js"
+            }
         },
         "./LockObservable": {
-            "types": "./dist/esm/decorator/lock/lock-observable/lock-observable.decorator.d.ts",
-            "import": "./dist/esm/decorator/lock/lock-observable/lock-observable.decorator.js",
-            "require": "./dist/cjs/decorator/lock/lock-observable/lock-observable.decorator.js"
+            "import": {
+                "types": "./dist/esm/decorator/lock/lock-observable/lock-observable.decorator.d.ts",
+                "default": "./dist/esm/decorator/lock/lock-observable/lock-observable.decorator.js"
+            },
+            "require": {
+                "types": "./dist/cjs/decorator/lock/lock-observable/lock-observable.decorator.d.ts",
+                "default": "./dist/cjs/decorator/lock/lock-observable/lock-observable.decorator.js"
+            }
         },
         "./CreatePromiseLockDecorators": {
-            "types": "./dist/esm/decorator/lock/create-promise-lock-decorators/create-promise-lock-decorators.d.ts",
-            "import": "./dist/esm/decorator/lock/create-promise-lock-decorators/create-promise-lock-decorators.js",
-            "require": "./dist/cjs/decorator/lock/create-promise-lock-decorators/create-promise-lock-decorators.js"
+            "import": {
+                "types": "./dist/esm/decorator/lock/create-promise-lock-decorators/create-promise-lock-decorators.d.ts",
+                "default": "./dist/esm/decorator/lock/create-promise-lock-decorators/create-promise-lock-decorators.js"
+            },
+            "require": {
+                "types": "./dist/cjs/decorator/lock/create-promise-lock-decorators/create-promise-lock-decorators.d.ts",
+                "default": "./dist/cjs/decorator/lock/create-promise-lock-decorators/create-promise-lock-decorators.js"
+            }
         },
         "./CreateObservableLockDecorators": {
-            "types": "./dist/esm/decorator/lock/create-observable-lock-decorators/create-observable-lock-decorators.d.ts",
-            "import": "./dist/esm/decorator/lock/create-observable-lock-decorators/create-observable-lock-decorators.js",
-            "require": "./dist/cjs/decorator/lock/create-observable-lock-decorators/create-observable-lock-decorators.js"
+            "import": {
+                "types": "./dist/esm/decorator/lock/create-observable-lock-decorators/create-observable-lock-decorators.d.ts",
+                "default": "./dist/esm/decorator/lock/create-observable-lock-decorators/create-observable-lock-decorators.js"
+            },
+            "require": {
+                "types": "./dist/cjs/decorator/lock/create-observable-lock-decorators/create-observable-lock-decorators.d.ts",
+                "default": "./dist/cjs/decorator/lock/create-observable-lock-decorators/create-observable-lock-decorators.js"
+            }
         }
     },
     "main": "dist/cjs/index.js",
@@ -62,7 +97,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && echo '{\"type\":\"module\"}' > dist/esm/package.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",

--- a/packages/nestjs-rxjs-lock/package.json
+++ b/packages/nestjs-rxjs-lock/package.json
@@ -11,9 +11,14 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         }
     },
     "engines": {
@@ -33,7 +38,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && echo '{\"type\":\"module\"}' > dist/esm/package.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",

--- a/packages/nestjs-rxjs-logger/package.json
+++ b/packages/nestjs-rxjs-logger/package.json
@@ -11,9 +11,14 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         }
     },
     "main": "dist/cjs/index.js",
@@ -30,7 +35,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && echo '{\"type\":\"module\"}' > dist/esm/package.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",

--- a/packages/nestjs-rxjs-metrics/package.json
+++ b/packages/nestjs-rxjs-metrics/package.json
@@ -12,9 +12,14 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         }
     },
     "main": "dist/cjs/index.js",
@@ -31,7 +36,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && echo '{\"type\":\"module\"}' > dist/esm/package.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",

--- a/packages/nestjs-rxjs-redis/package.json
+++ b/packages/nestjs-rxjs-redis/package.json
@@ -11,9 +11,14 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         }
     },
     "main": "dist/cjs/index.js",
@@ -30,7 +35,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && echo '{\"type\":\"module\"}' > dist/esm/package.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",

--- a/packages/nestjs-typed-config/package.json
+++ b/packages/nestjs-typed-config/package.json
@@ -12,9 +12,14 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         }
     },
     "main": "dist/cjs/index.js",
@@ -31,7 +36,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && echo '{\"type\":\"module\"}' > dist/esm/package.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",

--- a/packages/nestjs-webpack-swc/package.json
+++ b/packages/nestjs-webpack-swc/package.json
@@ -12,19 +12,34 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         },
         "./get-nestjs-webpack-dev.config": {
-            "types": "./dist/esm/config/get-nestjs-webpack-dev.config.d.ts",
-            "import": "./dist/esm/config/get-nestjs-webpack-dev.config.js",
-            "require": "./dist/cjs/config/get-nestjs-webpack-dev.config.js"
+            "import": {
+                "types": "./dist/esm/config/get-nestjs-webpack-dev.config.d.ts",
+                "default": "./dist/esm/config/get-nestjs-webpack-dev.config.js"
+            },
+            "require": {
+                "types": "./dist/cjs/config/get-nestjs-webpack-dev.config.d.ts",
+                "default": "./dist/cjs/config/get-nestjs-webpack-dev.config.js"
+            }
         },
         "./get-nestjs-webpack-prod.config": {
-            "types": "./dist/esm/config/get-nestjs-webpack-prod.config.d.ts",
-            "import": "./dist/esm/config/get-nestjs-webpack-prod.config.js",
-            "require": "./dist/cjs/config/get-nestjs-webpack-prod.config.js"
+            "import": {
+                "types": "./dist/esm/config/get-nestjs-webpack-prod.config.d.ts",
+                "default": "./dist/esm/config/get-nestjs-webpack-prod.config.js"
+            },
+            "require": {
+                "types": "./dist/cjs/config/get-nestjs-webpack-prod.config.d.ts",
+                "default": "./dist/cjs/config/get-nestjs-webpack-prod.config.js"
+            }
         }
     },
     "main": "dist/cjs/index.js",
@@ -41,7 +56,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && echo '{\"type\":\"module\"}' > dist/esm/package.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "format": "run -T prettier --write \"./src/**/*.{ts,tsx}\"",

--- a/packages/object-field-tree/package.json
+++ b/packages/object-field-tree/package.json
@@ -16,9 +16,14 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         }
     },
     "main": "dist/cjs/index.js",
@@ -38,7 +43,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && echo '{\"type\":\"module\"}' > dist/esm/package.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",

--- a/packages/platform/AGENTS.md
+++ b/packages/platform/AGENTS.md
@@ -39,6 +39,12 @@ src/
 - Jest preset is `'react-native'` (second arg to `get-jest.config.js('platform', 'react-native')`), unlike the other
   packages in this document which pass no preset
 
+### Publication
+
+`tsconfig.build-esm.json`/`tsconfig.build-cjs.json` exclude `**/*.mock.*` (matching `wdio`'s existing pattern) so
+`platform.mock.ts` is type-checked by `yarn ts` but never compiled into `dist/` or shipped in the npm tarball — it is
+a test-only fixture for `platform-style.spec.ts`, not a public export.
+
 ### Dependencies
 
 - No runtime `dependencies` — this package has none

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -14,9 +14,14 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         }
     },
     "main": "dist/cjs/index.js",
@@ -46,7 +51,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && echo '{\"type\":\"module\"}' > dist/esm/package.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",

--- a/packages/platform/tsconfig.build-cjs.json
+++ b/packages/platform/tsconfig.build-cjs.json
@@ -9,6 +9,7 @@
     "exclude": [
         "node_modules",
         "dist",
-        "**/*.spec.*"
+        "**/*.spec.*",
+        "**/*.mock.*"
     ]
 }

--- a/packages/platform/tsconfig.build-esm.json
+++ b/packages/platform/tsconfig.build-esm.json
@@ -9,6 +9,7 @@
     "exclude": [
         "node_modules",
         "dist",
-        "**/*.spec.*"
+        "**/*.spec.*",
+        "**/*.mock.*"
     ]
 }

--- a/packages/redux-loadable/package.json
+++ b/packages/redux-loadable/package.json
@@ -14,9 +14,14 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         }
     },
     "engines": {
@@ -36,7 +41,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && echo '{\"type\":\"module\"}' > dist/esm/package.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",

--- a/packages/rxjs-errors/package.json
+++ b/packages/rxjs-errors/package.json
@@ -10,9 +10,14 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         }
     },
     "main": "dist/cjs/index.js",
@@ -32,7 +37,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && echo '{\"type\":\"module\"}' > dist/esm/package.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",

--- a/packages/wdio/package.json
+++ b/packages/wdio/package.json
@@ -12,9 +12,14 @@
     "license": "MIT",
     "exports": {
         ".": {
-            "types": "./dist/esm/index.d.ts",
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            }
         }
     },
     "main": "dist/cjs/index.js",
@@ -31,7 +36,7 @@
         "ts": "run -T tsc --pretty -p tsconfig.json",
         "build:esm": "tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "tsc --pretty -p tsconfig.build-cjs.json",
-        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo",
+        "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && echo '{\"type\":\"module\"}' > dist/esm/package.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",

--- a/scripts/publint.sh
+++ b/scripts/publint.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+packages=(
+    decorators-core
+    eslint-plugin
+    fast-style
+    histogram-metric-decorator
+    lock-decorator
+    log-decorator
+    nestjs-enterprise
+    nestjs-rxjs-lock
+    nestjs-rxjs-logger
+    nestjs-rxjs-metrics
+    nestjs-rxjs-redis
+    nestjs-typed-config
+    nestjs-webpack-swc
+    object-field-tree
+    platform
+    react-native-payments
+    redux-loadable
+    rxjs-errors
+    shared
+    wdio
+)
+
+build_filters=()
+for pkg in "${packages[@]}"; do
+    build_filters+=("--filter=@rnw-community/${pkg}")
+done
+turbo run build "${build_filters[@]}"
+
+for pkg in "${packages[@]}"; do
+    echo ""
+    echo "── @rnw-community/${pkg} ──"
+
+    ignore_rules=(internal-resolution-error)
+    if [ "${pkg}" = "eslint-plugin" ]; then
+        ignore_rules+=(named-exports)
+    fi
+
+    publint run "packages/${pkg}"
+    attw --pack "packages/${pkg}" --profile node16 --ignore-rules "${ignore_rules[@]}"
+done


### PR DESCRIPTION
## Summary

Generalizes the `publint` + `@arethetypeswrong/cli` publication-hygiene gate from PR #483 (which covered only `shared` and `react-native-payments`) to every publishable package in the repo — 20 packages total (`react-native-payments-example` stays excluded as a private example app, out of scope per #485).

- **Root `yarn publint` script**: moved out of a two-package one-liner into `scripts/publint.sh`, which builds and loops `publint run` + `attw --pack --profile node16 --ignore-rules internal-resolution-error` over all 20 publishable packages. The existing CI step (`pr.yml`'s `code-quality` job, "Publish hygiene checks (publint, attw)") already just runs `yarn publint`, so it now gates all 20 packages with no workflow changes needed.
- **Repo-wide exports fix**: every dual-format package had the same bug `shared` had before #483 — a single top-level `exports["."].types` key that `attw` resolves as the wrong module kind for one of `import`/`require`. Split `types` per condition (`import.types` / `require.types`, `types` still first inside each block) and had each package's `build` script stamp `dist/esm/package.json` (`{"type":"module"}`) / `dist/cjs/package.json` (`{"type":"commonjs"}`) so Node's own module-kind detection matches each directory's real output. Applied to 17 single-export packages plus the two multi-subpath packages (`nestjs-enterprise`: 7 export subpaths, `nestjs-webpack-swc`: 3).
- **`eslint-plugin` — a genuine exception, not a bug fix**: its `src/index.ts` ends in `export = plugin`, required because ESLint's legacy CJS plugin loader (`"plugins": ["@rnw-community"]`) `require()`s the module and uses the return value directly with no `.default` unwrap (verified against `@eslint/eslintrc` source — no such interop exists there). `export =` cannot be re-emitted as real ESM, so both `dist/esm/` and `dist/cjs/` have always been CommonJS. Declared this honestly instead of forcing dual-format-shaped metadata onto single-format content: root-level `"type": "commonjs"` (not per-directory markers — neither directory is ESM), no `"module"` field, and `attw`'s per-package `--ignore-rules named-exports` (the only finding left, and it flags exactly the named-import form this package's readme never documents as supported — the documented form is `import rnwcPlugin from '@rnw-community/eslint-plugin'`, which resolves fine).
- **`eslint-plugin` — also fixed a `tsc` leak**: `resolveJsonModule` + the `../package.json` import in `src/index.ts` widens `tsc`'s inferred `rootDir` to the package root, so it mirrors a full, unmodified `package.json` copy (self-referential, Node-ignored `"exports"` field included) into both `dist/esm/` and `dist/cjs/`. `publint` flagged the duplication; `build` now deletes both copies after compiling.
- **`platform` — real `files`-whitelist leak found via `npm pack --dry-run`**: `platform.mock.ts` (a `jest.mock('react-native', ...)` fixture used only by `platform-style.spec.ts`) was being compiled into both `dist/esm/` and `dist/cjs/` and therefore shipped in the npm tarball, because `platform`'s build `tsconfig`s excluded `**/*.spec.*` but not `**/*.mock.*` — unlike `wdio`, which already excludes both. Added the same exclusion to `platform`'s two build tsconfigs; the mock stays type-checked by `yarn ts`, just never emitted or packed.
- `knip.json` gains `publint` and `@arethetypeswrong/cli` in `ignoreDependencies` — moving the CLI invocations into `scripts/publint.sh` means their names no longer appear as literal tokens in any `package.json` script for knip's static scan to find, so it started flagging both as unused devDependencies (a real regression against the `yarn deadcode` gate, now fixed).
- Root `AGENTS.md`'s ESM Modernization Status section records all of the above as repo-wide decisions (previously scoped to `shared`/`react-native-payments` only), plus a full paragraph explaining the `eslint-plugin` exception. Per-package `AGENTS.md` for `eslint-plugin` and `platform` get matching notes.

## Per-package findings

| Package | publint | attw (`--profile node16`) | Fix applied |
|---|---|---|---|
| decorators-core | clean* | clean | exports types-split + dist/*/package.json markers |
| eslint-plugin | clean* | clean (+`named-exports` ignored, justified above) | `"type":"commonjs"`, dropped `"module"`, deleted tsc-leaked `dist/*/package.json` copies |
| fast-style | clean* | clean | exports types-split + markers |
| histogram-metric-decorator | clean* | clean | exports types-split + markers |
| lock-decorator | clean* | clean | exports types-split + markers |
| log-decorator | clean* | clean | exports types-split + markers |
| nestjs-enterprise | clean* | clean (node10 subpath ignore, policy) | exports types-split + markers, across 7 subpaths |
| nestjs-rxjs-lock | clean* | clean | exports types-split + markers |
| nestjs-rxjs-logger | clean* | clean | exports types-split + markers |
| nestjs-rxjs-metrics | clean* | clean | exports types-split + markers |
| nestjs-rxjs-redis | clean* | clean | exports types-split + markers |
| nestjs-typed-config | clean* | clean | exports types-split + markers |
| nestjs-webpack-swc | clean* | clean (node10 subpath ignore, policy) | exports types-split + markers, across 3 subpaths |
| object-field-tree | clean* | clean | exports types-split + markers |
| platform | clean* | clean | exports types-split + markers, **and** `platform.mock.ts` excluded from build output |
| react-native-payments | clean* | clean (node10 subpath ignore, policy; `internal-resolution-error` ignored, pre-existing #483 decision) | no change — already fixed in #483 |
| redux-loadable | clean* | clean | exports types-split + markers |
| rxjs-errors | clean* | clean | exports types-split + markers |
| shared | clean* | clean (`internal-resolution-error` ignored, pre-existing #483 decision) | no change — already fixed in #483 |
| wdio | clean* | clean | exports types-split + markers |

\* "clean" = 0 errors. Every package still carries two cosmetic `publint` **warnings** (non-blocking, same severity #483 already accepted for `shared`/`react-native-payments`): `pkg.repository` string-shorthand form, and the "add `type` field" suggestion. Both are repo-wide package.json metadata conventions in scope for #486, not touched here.

`yarn publint` (root script) exits 0 for all 20 packages.

## Pack-size deltas (`npm pack --dry-run`, before → after, clean rebuild both sides)

| Package | Files before → after | Unpacked size before → after |
|---|---|---|
| decorators-core | 58 → 60 (+2) | 30,581 → 30,873 B (+292) |
| eslint-plugin | 29 → 27 (−2) | 28,665 → 25,013 B (−3,652) |
| fast-style | 51 → 53 (+2) | 26,559 → 26,851 B (+292) |
| histogram-metric-decorator | 42 → 44 (+2) | 26,415 → 26,707 B (+292) |
| lock-decorator | 154 → 156 (+2) | 86,345 → 86,637 B (+292) |
| log-decorator | 74 → 76 (+2) | 38,081 → 38,373 B (+292) |
| nestjs-enterprise | 179 → 181 (+2) | 146,492 → 147,938 B (+1,446) |
| nestjs-rxjs-lock | 35 → 37 (+2) | 31,714 → 32,006 B (+292) |
| nestjs-rxjs-logger | 35 → 37 (+2) | 51,059 → 51,351 B (+292) |
| nestjs-rxjs-metrics | 83 → 85 (+2) | 57,654 → 57,946 B (+292) |
| nestjs-rxjs-redis | 35 → 37 (+2) | 61,628 → 61,920 B (+292) |
| nestjs-typed-config | 35 → 37 (+2) | 29,938 → 30,230 B (+292) |
| nestjs-webpack-swc | 83 → 85 (+2) | 40,166 → 40,801 B (+635) |
| object-field-tree | 27 → 29 (+2) | 25,427 → 25,719 B (+292) |
| platform | 51 → 45 (**−6**) | 23,125 → 22,074 B (**−1,051**) |
| react-native-payments | 1,133 → 1,133 (0) | 996,657 → 996,657 B (0) — unchanged, already fixed in #483 |
| redux-loadable | 67 → 69 (+2) | 33,117 → 33,409 B (+292) |
| rxjs-errors | 59 → 61 (+2) | 28,602 → 28,894 B (+292) |
| shared | 277 → 277 (0) | 83,094 → 83,094 B (0) — unchanged, already fixed in #483 |
| wdio | 547 → 549 (+2) | 238,128 → 238,420 B (+292) |

The uniform `+2` files / `+292` B for single-export packages is the two new `dist/*/package.json` type markers plus the `package.json` manifest itself growing from the exports restructuring (the manifest always ships in the npm tarball regardless of the `files` whitelist). `nestjs-enterprise`/`nestjs-webpack-swc` show a larger byte delta for the same reason scaled up: their `package.json` has 7 and 3 export subpaths respectively, each gaining a nested `import`/`require` block. `eslint-plugin`'s `−2` files / `−3,652` B is the two leaked full `package.json` copies (each ~1.8 KB) being deleted. `platform`'s `−6` files / `−1,051` B is 4 mock-related files removed from each of `dist/cjs` and `dist/esm` (8 total) minus the 2 new markers added.

Verified no other package leaks anything outside `dist/**/*` (specs, mocks, e2e, `.plans`) via `npm pack --dry-run` across all 20 packages both before and after.

## Verification

- [x] `yarn publint` — exits 0 for all 20 publishable packages
- [x] `yarn build` — 20/20 packages
- [x] `yarn ts` — clean
- [x] `yarn lint` — clean (pre-existing warnings only, none new)
- [x] `yarn test` — 19/19 suites pass
- [x] `yarn deadcode` — clean (knip.json updated for the `scripts/publint.sh` extraction)
- [x] `yarn cpd` — clean
- [x] `npm pack --dry-run` reviewed per package, before/after both captured from a clean `dist/` rebuild

Refs #485


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend publint and attw publication hygiene checks to all packages
> - Adds [scripts/publint.sh](https://github.com/rnw-community/rnw-community/pull/530/files#diff-fe93ec35d7e7c1c429d8cdf0001b163eedd6222856d3af738a60475f66493db1) to build each package via Turbo and then run `publint` and `attw` against it, replacing the previous single-package invocation in the root `yarn publint` script.
> - Standardizes `exports` maps across all packages to nest `types` under both `import` and `require` conditions, with `default` keys for JS entries, satisfying `attw` resolution checks.
> - Marks `eslint-plugin` as CommonJS-only (`"type": "commonjs"`), removes its `module` field, and adds an `--ignore-rules named-exports` flag in the publish check script.
> - Extends `exclude` globs in `packages/platform` TypeScript build configs to also exclude `**/*.mock.*` files so test mocks are not compiled or published.
> - The `eslint-plugin` and platform builds now delete `dist/esm/package.json` and `dist/cjs/package.json` copies produced by `resolveJsonModule`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bbc9dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->