### PR TITLE
fix: nodenext spec type-check gate and ioredis import regression

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,6 +61,9 @@ jobs:
             -   name: Typescript checks
                 run: yarn turbo run ts --affected
 
+            -   name: Typescript checks (spec files, nodenext resolution)
+                run: yarn turbo run ts:nodenext --affected
+
             -   name: ESLint checks
                 run: yarn turbo run lint --affected
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,6 +319,24 @@ The monorepo uses dual ESM + CJS output. Key decisions:
   relative imports in the shipped ESM tree, `#531`) is now a real compile failure long before `publint` ever runs.
   `yarn smoke:esm` (and the `package-manager-smoke` CI job) packs and imports every publishable package's tarball
   under real `node --input-type=module`/`require()` to keep this from regressing at the runtime layer too
+- **`yarn ts` alone does not catch every `nodenext`-only defect, because it deliberately never runs `nodenext`
+  against spec files.** `yarn ts` uses `moduleResolution: "bundler"` (matches Metro's leniency, see above);
+  `tsconfig.build-esm.json` is the only `nodenext`-mode compile, and every package's copy of it excludes
+  `**/*.spec.*` (specs are never part of the publishable build). A default import of a CJS-only dependency whose
+  `.d.ts` uses `export default X` instead of the CJS-correct `export = X` (`ioredis`'s `Redis`, for one) type-checks
+  fine under `bundler` but fails under real `nodenext` (`TS2709`/`TS2351`) — and until this gate existed, that failure
+  mode could recur inside a `.spec.ts` file indefinitely with zero CI signal, since Jest never type-checks
+  (`babel-jest` is transpile-only) and `yarn smoke:esm` only exercises published tarballs, which never contain specs.
+  Each dual-format package (plus `eslint-plugin`) now carries a sibling `tsconfig.nodenext-check.json` that extends
+  the package's own `tsconfig.build-esm.json`, flips `noEmit` back to `true`, and — critically — re-declares
+  `include`/`exclude` without the `**/*.spec.*` exclusion, so every spec file gets checked under the exact same
+  `nodenext` resolution the ESM build uses, without ever emitting to `dist/`. This is a parallel, check-only compile
+  (`yarn ts:nodenext`, wired into the `code-quality` CI job right after the existing `yarn turbo run ts --affected`
+  step, which itself runs after packages are built so workspace `@rnw-community/*` deps resolve their real `dist/`
+  output) — it does not touch `tsconfig.build-esm.json` itself (which must keep excluding specs) or `yarn ts`'s
+  `bundler` resolution (changing that would lose the "validates against the same leniency real consumers get"
+  property documented above), and it does not affect Jest's own resolution in any way (Jest never reads any of these
+  tsconfig files). Runs in low single-digit seconds across all 20 packages, cold, via `turbo`'s per-package caching.
 - **`eslint-plugin` ships CommonJS only, by design, not oversight.** Its `src/index.ts` ends in `export = plugin` —
   the shape ESLint's own legacy plugin loader (`@eslint/eslintrc`, string-based `"plugins": ["@rnw-community"]`
   resolution) requires: it `require()`s the module and uses the returned value directly, with no `.default` unwrap.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "test": "turbo run test",
     "test:coverage": "turbo run test:coverage",
     "ts": "turbo run ts",
-    "ts:force": "turbo run ts --force"
+    "ts:force": "turbo run ts --force",
+    "ts:nodenext": "turbo run ts:nodenext",
+    "ts:nodenext:force": "turbo run ts:nodenext --force"
   },
   "resolutions": {
     "axios": "^1.19.0",

--- a/packages/decorators-core/package.json
+++ b/packages/decorators-core/package.json
@@ -49,7 +49,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "dependencies": {
         "@rnw-community/shared": "workspace:^"

--- a/packages/decorators-core/tsconfig.nodenext-check.json
+++ b/packages/decorators-core/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -42,6 +42,7 @@
     },
     "scripts": {
         "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json",
         "build:esm": "run -T tsc --pretty -p tsconfig.build-esm.json",
         "build:cjs": "run -T tsc --pretty -p tsconfig.build-cjs.json",
         "build": "yarn build:esm && yarn build:cjs && rm -rf ./dist/*/*.tsbuildinfo && rm -f dist/esm/package.json dist/cjs/package.json",

--- a/packages/eslint-plugin/tsconfig.nodenext-check.json
+++ b/packages/eslint-plugin/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/fast-style/package.json
+++ b/packages/fast-style/package.json
@@ -48,7 +48,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "dependencies": {
         "@rnw-community/object-field-tree": "^2.12.9",

--- a/packages/fast-style/tsconfig.nodenext-check.json
+++ b/packages/fast-style/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/histogram-metric-decorator/package.json
+++ b/packages/histogram-metric-decorator/package.json
@@ -47,7 +47,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "dependencies": {
         "@rnw-community/decorators-core": "workspace:^",

--- a/packages/histogram-metric-decorator/tsconfig.nodenext-check.json
+++ b/packages/histogram-metric-decorator/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/lock-decorator/package.json
+++ b/packages/lock-decorator/package.json
@@ -48,7 +48,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "dependencies": {
         "@rnw-community/decorators-core": "workspace:^",

--- a/packages/lock-decorator/tsconfig.nodenext-check.json
+++ b/packages/lock-decorator/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/log-decorator/package.json
+++ b/packages/log-decorator/package.json
@@ -47,7 +47,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "dependencies": {
         "@rnw-community/decorators-core": "workspace:^",

--- a/packages/log-decorator/tsconfig.nodenext-check.json
+++ b/packages/log-decorator/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/nestjs-enterprise/package.json
+++ b/packages/nestjs-enterprise/package.json
@@ -106,7 +106,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "dependencies": {
         "@rnw-community/histogram-metric-decorator": "workspace:^",

--- a/packages/nestjs-enterprise/src/decorator/lock/lock-observable/lock-observable-decorator.spec.ts
+++ b/packages/nestjs-enterprise/src/decorator/lock/lock-observable/lock-observable-decorator.spec.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import Redis from 'ioredis';
 import { EMPTY, Observable, lastValueFrom, of, tap } from 'rxjs';
 
 import { LockableService } from '../lockable.service.js';
 
 import { LockObservable } from './lock-observable.decorator.js';
+
+import type { Redis } from 'ioredis';
 
 const getRedisService = (): Redis => jest.fn() as unknown as Redis;
 const mockRelease = jest.fn<() => Promise<boolean>>().mockResolvedValue(true);

--- a/packages/nestjs-enterprise/src/decorator/lock/lock-promise/lock-promise-decorator.spec.ts
+++ b/packages/nestjs-enterprise/src/decorator/lock/lock-promise/lock-promise-decorator.spec.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import Redis from 'ioredis';
 
 import { LockableService } from '../lockable.service.js';
 
 import { LockPromise } from './lock-promise.decorator.js';
+
+import type { Redis } from 'ioredis';
 
 const getRedisService = (): Redis => jest.fn() as unknown as Redis;
 const mockRelease = jest.fn<() => Promise<boolean>>().mockResolvedValue(true);

--- a/packages/nestjs-enterprise/tsconfig.nodenext-check.json
+++ b/packages/nestjs-enterprise/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/nestjs-rxjs-lock/package.json
+++ b/packages/nestjs-rxjs-lock/package.json
@@ -44,7 +44,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "dependencies": {
         "@nestjs-modules/ioredis": "^2.2.2",

--- a/packages/nestjs-rxjs-lock/src/nestjs-rxjs-lock-service/nestjs-rxjs-lock.service.spec.ts
+++ b/packages/nestjs-rxjs-lock/src/nestjs-rxjs-lock-service/nestjs-rxjs-lock.service.spec.ts
@@ -8,7 +8,7 @@ import { type NestJSRxJSLockModuleOptions, defaultNestJSRxJSLockModuleOptions } 
 
 import { NestJSRxJSLockService } from './nestjs-rxjs-lock.service.js';
 
-import type Redis from 'ioredis';
+import type { Redis } from 'ioredis';
 
 const mockRelease = jest.fn<() => Promise<boolean>>().mockResolvedValue(true);
 const mockAcquire = jest

--- a/packages/nestjs-rxjs-lock/tsconfig.nodenext-check.json
+++ b/packages/nestjs-rxjs-lock/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/nestjs-rxjs-logger/package.json
+++ b/packages/nestjs-rxjs-logger/package.json
@@ -44,7 +44,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "dependencies": {
         "@rnw-community/shared": "^2.12.9"

--- a/packages/nestjs-rxjs-logger/tsconfig.nodenext-check.json
+++ b/packages/nestjs-rxjs-logger/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/nestjs-rxjs-metrics/package.json
+++ b/packages/nestjs-rxjs-metrics/package.json
@@ -45,7 +45,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "dependencies": {
         "@rnw-community/shared": "^2.12.9"

--- a/packages/nestjs-rxjs-metrics/tsconfig.nodenext-check.json
+++ b/packages/nestjs-rxjs-metrics/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/nestjs-rxjs-redis/package.json
+++ b/packages/nestjs-rxjs-redis/package.json
@@ -44,7 +44,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "dependencies": {
         "@rnw-community/shared": "^2.12.9"

--- a/packages/nestjs-rxjs-redis/tsconfig.nodenext-check.json
+++ b/packages/nestjs-rxjs-redis/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/nestjs-typed-config/package.json
+++ b/packages/nestjs-typed-config/package.json
@@ -45,7 +45,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "dependencies": {
         "@rnw-community/shared": "^2.12.9"

--- a/packages/nestjs-typed-config/tsconfig.nodenext-check.json
+++ b/packages/nestjs-typed-config/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/nestjs-webpack-swc/package.json
+++ b/packages/nestjs-webpack-swc/package.json
@@ -63,7 +63,8 @@
         "format": "run -T prettier --write \"./src/**/*.{ts,tsx}\"",
         "lint": "run -T eslint src",
         "lint:fix": "run -T eslint --fix src",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "dependencies": {
         "@rnw-community/shared": "^2.12.9"

--- a/packages/nestjs-webpack-swc/tsconfig.nodenext-check.json
+++ b/packages/nestjs-webpack-swc/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/object-field-tree/package.json
+++ b/packages/object-field-tree/package.json
@@ -49,7 +49,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "dependencies": {
         "@rnw-community/shared": "^2.12.9"

--- a/packages/object-field-tree/tsconfig.nodenext-check.json
+++ b/packages/object-field-tree/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -47,7 +47,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "devDependencies": {
         "react": "^18.3.1",

--- a/packages/platform/tsconfig.nodenext-check.json
+++ b/packages/platform/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/react-native-payments/package.json
+++ b/packages/react-native-payments/package.json
@@ -92,7 +92,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "dependencies": {
         "@expo/config-plugins": "^9.1.7",

--- a/packages/react-native-payments/tsconfig.nodenext-check.json
+++ b/packages/react-native-payments/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/redux-loadable/package.json
+++ b/packages/redux-loadable/package.json
@@ -47,7 +47,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "engines": {
         "node": ">=22.0.0"

--- a/packages/redux-loadable/tsconfig.nodenext-check.json
+++ b/packages/redux-loadable/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/rxjs-errors/package.json
+++ b/packages/rxjs-errors/package.json
@@ -43,7 +43,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "dependencies": {
         "@rnw-community/shared": "^2.12.9"

--- a/packages/rxjs-errors/tsconfig.nodenext-check.json
+++ b/packages/rxjs-errors/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -47,7 +47,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "engines": {
         "node": ">=22.0.0"

--- a/packages/shared/tsconfig.nodenext-check.json
+++ b/packages/shared/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/wdio/package.json
+++ b/packages/wdio/package.json
@@ -45,7 +45,8 @@
         "lint:fix": "run -T eslint --fix src",
         "test": "run -T jest",
         "test:coverage": "run -T jest --coverage",
-        "ts": "run -T tsc --pretty -p tsconfig.json"
+        "ts": "run -T tsc --pretty -p tsconfig.json",
+        "ts:nodenext": "run -T tsc --pretty -p tsconfig.nodenext-check.json"
     },
     "dependencies": {
         "@rnw-community/shared": "^2.12.9",

--- a/packages/wdio/tsconfig.nodenext-check.json
+++ b/packages/wdio/tsconfig.nodenext-check.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.build-esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo-nodenext.json"
+    },
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -26,6 +26,14 @@
         "node_modules/.cache/tsbuildinfo.json"
       ]
     },
+    "ts:nodenext": {
+      "dependsOn": [
+        "^topo"
+      ],
+      "outputs": [
+        "node_modules/.cache/tsbuildinfo-nodenext.json"
+      ]
+    },
     "lint": {
       "dependsOn": [
         "^topo"


### PR DESCRIPTION
## Summary

- Fixes #536: three spec files still used the broken `import Redis from 'ioredis'` default-import form that PR #532 fixed everywhere in production code.
- Fixes #540: no gate ever type-checked a spec file under `nodenext` resolution, which is exactly why the #536 regression slipped through PR #532's own (thorough) verification. Adds that gate.
- Refs epic #535.

## #536 — the defect

`ioredis` ships CJS-only with a `.d.ts` that re-exports its default via ES `export default` syntax instead of the CJS-correct `export = Redis`. Under `nodenext`, `import Redis from 'ioredis'` types as the whole module namespace, not the `Redis` class — `TS2709`/`TS2351` the moment `Redis` is used in a type position. PR #532 switched every production consumer to `import { Redis } from 'ioredis'`, but missed:

- `packages/nestjs-enterprise/src/decorator/lock/lock-observable/lock-observable-decorator.spec.ts`
- `packages/nestjs-enterprise/src/decorator/lock/lock-promise/lock-promise-decorator.spec.ts`
- `packages/nestjs-rxjs-lock/src/nestjs-rxjs-lock-service/nestjs-rxjs-lock.service.spec.ts`

Fix matches the exact form already established by each file's production sibling:
- The two `nestjs-enterprise` specs only ever use `Redis` as a type (no NestJS DI/reflection involved, same as `lockable.service.ts`) → `import type { Redis } from 'ioredis'`.
- `nestjs-rxjs-lock.service.spec.ts` already imported it as `import type Redis from 'ioredis'` (type-only) → mechanically became `import type { Redis } from 'ioredis'`, same as the sibling `nestjs-rxjs-redis.service.spec.ts`, which already used this exact form.

## #540 — the gate that would have caught it

**Why nothing caught it:** `yarn ts` uses `moduleResolution: "bundler"` (deliberately — it matches Metro's real leniency, see `AGENTS.md`). `tsconfig.build-esm.json` is the only `nodenext`-mode compile, and every package's copy of it excludes `**/*.spec.*` (specs aren't part of the publishable build). Jest never type-checks (`babel-jest` is transpile-only). `yarn smoke:esm` only executes packed tarballs, which never contain spec files. So a default-import-of-a-mistyped-CJS-package regression inside any `.spec.ts` had zero CI signal.

**Design decision — new sibling tsconfig per package, not a change to `yarn ts` or `tsconfig.build-esm.json`:**

- Modifying `tsconfig.build-esm.json` to include specs was rejected — it must keep excluding them; they're not part of the publishable build, and mixing them in would also require excluding them again at build time via some other mechanism.
- Modifying root `tsconfig.json` (`yarn ts`) to use `nodenext` was rejected — it exists specifically to validate against `bundler` resolution, the same leniency Metro/real consumers get (documented, deliberate, pre-existing invariant). Changing its resolution mode would silently start failing things that are actually fine for real consumers, and would conflate two different questions ("does this type-check for Metro" vs "does this type-check for a strict Node ESM consumer").
- Instead: every dual-format package (plus `eslint-plugin`, which is `nodenext`-mode internally per `AGENTS.md`) gets a sibling `tsconfig.nodenext-check.json` that `extends` the package's own `tsconfig.build-esm.json`, flips `noEmit` back to `true`, and re-declares `include`/`exclude` *without* the `**/*.spec.*` exclusion — so specs are checked under the exact same `nodenext` resolution the ESM build already enforces for production code, with zero `dist/` output. Exposed as a per-package `ts:nodenext` script, a `ts:nodenext` turbo task (cached like `ts`), and root `yarn ts:nodenext` / `yarn ts:nodenext:force`.
- This doesn't touch Jest's resolution at all (Jest never reads any of these tsconfig files) and runs as a parallel step, not a replacement, so the common `yarn ts` path is unaffected.
- Wired into the `code-quality` CI job (`ubuntu-latest`, not a fleet-labeled runner) directly after the existing `Typescript checks` step, which itself runs after `Build packages` — required, since workspace `@rnw-community/*` deps resolve their real `dist/` output under `nodenext`'s `exports`-map resolution (confirmed empirically below).
- Documented in `AGENTS.md`'s "ESM Modernization Status" section.

### Before/after proof (stashed the fix, ran the gate, restored it)

```
$ git stash push -- <the 3 spec files>
$ cd packages/nestjs-enterprise && tsc -p tsconfig.nodenext-check.json
src/decorator/lock/lock-observable/lock-observable-decorator.spec.ts:9:29 - error TS2709: Cannot use namespace 'Redis' as a type.
src/decorator/lock/lock-promise/lock-promise-decorator.spec.ts:8:29 - error TS2709: Cannot use namespace 'Redis' as a type.
Found 6 errors in 2 files.

$ cd packages/nestjs-rxjs-lock && tsc -p tsconfig.nodenext-check.json
src/nestjs-rxjs-lock-service/nestjs-rxjs-lock.service.spec.ts:30:31 - error TS2709: Cannot use namespace 'Redis' as a type.
Found 4 errors in the same file.

$ git stash pop
$ # re-run both — exit 0, no errors
```

Confirmed: the gate **fails on the pre-fix state** with exactly the errors #536/#540 describe, and **passes clean after the fix**.

### Repo-wide sweep — what it found

Ran `yarn ts:nodenext` (all 20 packages with a `tsconfig.build-esm.json`) after `yarn build`:

- **Before building `shared` first**: `react-native-payments` failed to resolve `isDecimalMonetaryValue` from `@rnw-community/shared`. This is **not** a `nodenext`-specific defect — the *same* error reproduces with the pre-existing `yarn ts` (`bundler` resolution) when `shared`'s `dist/` doesn't exist yet, because both resolution modes read `@rnw-community/shared`'s `exports` map, which points at `dist/esm/index.d.ts`. It's an artifact of a fresh checkout with no prior build, not something introduced by this gate. CI already runs `Build packages` before `Typescript checks`, so this never surfaces there; confirmed by rebuilding and re-running.
- **After building**: all 20 packages pass clean. No other spec-only interop issues were found beyond the three files fixed in this PR — matching #540's own conclusion that the defect pattern is narrow (only `ioredis`, already enumerated against every other default-import in the repo by the epic's sweep).

### Timing

All measured cold (`--force`, no turbo cache) on this machine, repo root:

| Command | Turbo-reported time | Wall time |
|---|---|---|
| `yarn build` (20 packages) | 25.3s | 26.1s |
| `yarn ts` (21 packages, existing) | 9.4s | 10.2s |
| `yarn ts:nodenext` (20 packages, new) | 6.6s | 7.3s |
| `yarn lint` | 18.2s | 18.9s |
| `yarn test` | 22.3s | 23.0s |
| `yarn publint` | — | 29.7s |
| `yarn smoke:esm` | — | 13.1s |

The new gate is comparable to (slightly faster than) the existing `yarn ts` step and adds low single-digit seconds to the PR pipeline — well within the "belongs in the PR gate" bar.

## Full verification

`yarn build && yarn ts && yarn lint && yarn test && yarn publint && yarn smoke:esm && yarn ts:nodenext` — all green, all 20/21 packages, no regressions, pre-existing coverage thresholds intact.

## Test plan

- [x] Reproduced the pre-fix `TS2709`/`TS2351` failures against the exact 3 spec files via the new gate (stash/pop proof above)
- [x] `yarn ts:nodenext` passes clean post-fix, repo-wide
- [x] `yarn build && yarn ts && yarn lint && yarn test && yarn publint && yarn smoke:esm` all green
- [ ] CI: `code-quality` job (build/ts/ts:nodenext/lint/test/publint)
- [ ] CI: `package-manager-smoke` matrix

Fixes #536
Fixes #540


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add NodeNext TypeScript spec check gate to CI and fix `ioredis` default import regression
> - Adds a `ts:nodenext` turbo task and per-package `tsconfig.nodenext-check.json` configs across all packages to type-check spec files under NodeNext module resolution without emitting output.
> - Wires the new task into the CI code-quality job via a new `yarn turbo run ts:nodenext --affected` step in [pr.yml](.github/workflows/pr.yml).
> - Fixes the immediate regression that triggered this: `ioredis` default imports in three spec files are replaced with `import type { Redis }` named imports, which is required for correctness under NodeNext resolution.
> - Behavioral Change: CI will now fail for affected packages if NodeNext-incompatible imports are introduced in spec files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49da806.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Quality Improvements**
  - Added NodeNext TypeScript validation across supported packages and specification files.
  - Integrated the new checks into automated code-quality workflows, helping identify module-resolution and typing issues earlier.
  - Added reusable validation commands for standard and forced checks.

- **Bug Fixes**
  - Updated Redis test imports to use compatible type-only and named imports without changing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->