### PR TITLE
ci: adopt mobile-ci v1.0.0 reusable workflows for mobile e2e and PR cleanup

### DIFF
--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -21,8 +21,10 @@ permissions:
 
 jobs:
     e2e:
-        uses: rnw-community/mobile-ci/.github/workflows/android-maestro.yml@3ecd0054f64589c063112b73469a492b224bd866 # v1.0.1
+        uses: rnw-community/mobile-ci/.github/workflows/android-maestro.yml@0eadcb345bc704b1ccc8e9965634af1ff3d2e25e # v1.1.0
         with:
+            build-runner-labels: '["self-hosted","macOS","ARM64","macos-maestro"]'
+            test-runner-labels: '["self-hosted","linux-tiered","linux-xl"]'
             targets: >-
                 [{"name":"bare","appDir":"packages/react-native-payments-example/apps/bare","appId":"com.reactnativepaymentsexample","prebuildCommand":""},{"name":"expo","appDir":"packages/react-native-payments-example/apps/expo","appId":"com.reactnativepaymentsexpoexample","prebuildCommand":"yarn prebuild"}]
             flows-dir: packages/react-native-payments-example/e2e/flows

--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -1,9 +1,5 @@
 name: Android Maestro E2E
 
-# Draft workflow for issue #395 (react-native-payments revival, epic #372). The
-# self-hosted Linux fleet is not registered yet (blocked on #396), so runs
-# simply queue until that lands. workflow_dispatch + path filters + a nightly
-# schedule keep this safe to land ahead of the fleet.
 on:
     workflow_dispatch:
     pull_request:
@@ -23,171 +19,18 @@ concurrency:
 permissions:
     contents: read
 
-env:
-    MAESTRO_VERSION: '2.8.0'
-    MAESTRO_CLI_NO_ANALYTICS: true
-    MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED: true
-    YARN_ENABLE_IMMUTABLE_INSTALLS: true
-    EXAMPLE_DIR: packages/react-native-payments-example
-
 jobs:
-    detect:
-        name: Detect affected packages
-        runs-on: ubuntu-latest
-        outputs:
-            payments_affected: ${{ steps.affected.outputs.payments_affected }}
-        steps:
-            - uses: actions/checkout@v5
-              with:
-                  fetch-depth: 0
-                  persist-credentials: false
-            - uses: actions/setup-node@v5
-              with:
-                  node-version: 22.x
-            - name: Compute affected packages
-              id: affected
-              env:
-                  TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
-              run: |
-                  if [ "${{ github.event_name }}" != "pull_request" ]; then
-                    echo "payments_affected=true" >> "$GITHUB_OUTPUT"
-                    echo "Non-PR event: payments pipeline always runs."
-                    exit 0
-                  fi
-                  affected=$(npx -y turbo@2.10.8 ls --affected --output=json | node -e '
-                    let raw = "";
-                    process.stdin.on("data", chunk => (raw += chunk));
-                    process.stdin.on("end", () => {
-                      const names = (JSON.parse(raw).packages?.items ?? []).map(item => item.name);
-                      const targets = [
-                        "@rnw-community/react-native-payments",
-                        "@rnw-community/react-native-payments-example",
-                        "@rnw-community/react-native-payments-example-bare",
-                        "@rnw-community/react-native-payments-example-expo",
-                      ];
-                      process.stdout.write(String(names.some(name => targets.includes(name))));
-                    });
-                  ')
-                  echo "payments_affected=${affected}" >> "$GITHUB_OUTPUT"
-                  echo "payments_affected=${affected}"
-    maestro:
-        name: Maestro (${{ matrix.target }})
-        needs: detect
-        if: needs.detect.outputs.payments_affected == 'true'
-        runs-on: [self-hosted, linux-tiered, linux-xl]
-        timeout-minutes: 75
-        strategy:
-            fail-fast: false
-            matrix:
-                target: [bare, expo]
-        env:
-            APP_DIR: packages/react-native-payments-example/apps/${{ matrix.target }}
-            MAESTRO_DEBUG_OUTPUT_DIRECTORY: ${{ github.workspace }}/packages/react-native-payments-example/artifacts/maestro-android-${{ matrix.target }}
-
-        steps:
-            -   name: Checkout repository
-                uses: actions/checkout@v5
-
-            -   name: Setup Node
-                uses: actions/setup-node@v5
-                with:
-                    node-version: 22.x
-                    cache: yarn
-
-            -   name: Enable corepack
-                run: corepack enable
-
-            -   name: Install dependencies
-                run: yarn install --immutable
-
-            -   name: Build workspace JS dependencies
-                run: yarn build --filter=@rnw-community/react-native-payments
-
-            -   name: Generate native project (expo)
-                if: matrix.target == 'expo'
-                working-directory: ${{ env.EXAMPLE_DIR }}
-                run: yarn prebuild:expo
-
-            -   name: Set up Android SDK
-                uses: android-actions/setup-android@v3
-
-            -   name: Restore Gradle cache
-                uses: actions/cache@v4
-                with:
-                    path: |
-                        ~/.gradle/caches
-                        ~/.gradle/wrapper
-                    key: gradle-${{ matrix.target }}-${{ runner.os }}-${{ hashFiles(format('{0}/android/gradle/wrapper/gradle-wrapper.properties', env.APP_DIR), format('{0}/android/**/*.gradle*', env.APP_DIR), format('{0}/package.json', env.APP_DIR), format('{0}/app.json', env.APP_DIR), 'yarn.lock') }}
-                    restore-keys: |
-                        gradle-${{ matrix.target }}-${{ runner.os }}-
-
-            -   name: Install Maestro
-                run: |
-                    maestro_bin="$HOME/.maestro/bin/maestro"
-                    if [ ! -x "$maestro_bin" ] || [ "$("$maestro_bin" --version 2>/dev/null | tail -n 1 | tr -d '\r' || true)" != "$MAESTRO_VERSION" ]; then
-                      curl -fsSL https://get.maestro.mobile.dev | env MAESTRO_VERSION="$MAESTRO_VERSION" bash
-                    fi
-                    echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
-
-            -   name: Boot emulator, build, install, and test
-                uses: reactivecircus/android-emulator-runner@v2.38.0
-                with:
-                    api-level: 34
-                    target: google_apis
-                    arch: x86_64
-                    profile: pixel_6
-                    disable-animations: true
-                    disable-spellchecker: true
-                    force-avd-creation: false
-                    emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-                    script: |
-                        set -euo pipefail
-                        set -x
-                        adb wait-for-device
-                        timeout 180 bash -c 'until [ "$(adb shell getprop sys.boot_completed | tr -d "\r")" = "1" ]; do sleep 2; done'
-                        (cd "${{ env.APP_DIR }}/android" && ./gradlew assembleRelease)
-                        apk=$(find "${{ env.APP_DIR }}/android/app/build/outputs/apk/release" -name '*.apk' | head -1)
-                        adb install -r "$apk"
-                        cd "${{ env.EXAMPLE_DIR }}"
-                        yarn e2e:android:${{ matrix.target }}
-
-            -   name: Capture final device state
-                if: failure()
-                shell: bash
-                run: |
-                    out="${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}"
-                    mkdir -p "$out"
-                    adb exec-out screencap -p > "$out/final-screen.png" || true
-                    adb logcat -d > "$out/logcat-full.txt" 2>&1 || true
-                    adb logcat -d -b crash > "$out/logcat-crash.txt" 2>&1 || true
-
-            -   name: Upload Maestro artifacts
-                if: failure()
-                uses: actions/upload-artifact@v4
-                with:
-                    name: maestro-android-${{ matrix.target }}
-                    path: ${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}/**
-                    if-no-files-found: warn
-                    retention-days: 7
-
-    status:
-        name: Android Maestro E2E result
-        needs: [detect, maestro]
-        if: always()
-        runs-on: ubuntu-latest
-        steps:
-            - name: Report
-              run: |
-                  if [ "${{ needs.detect.result }}" != "success" ]; then
-                    echo "Detection job did not succeed."
-                    exit 1
-                  fi
-                  if [ "${{ needs.detect.outputs.payments_affected }}" != "true" ]; then
-                    echo "Skipped: payments dependency tree untouched."
-                    exit 0
-                  fi
-                  if [ "${{ needs.maestro.result }}" != "success" ]; then
-                    echo "Maestro suite failed."
-                    exit 1
-                  fi
-                  echo "Maestro suite passed."
+    e2e:
+        uses: rnw-community/mobile-ci/.github/workflows/android-maestro.yml@bc5927455f3ca5aed5c1b7733c9286fc8b53769e # v1.0.0
+        with:
+            targets: >-
+                [{"name":"bare","appDir":"packages/react-native-payments-example/apps/bare","appId":"com.reactnativepaymentsexample","prebuildCommand":""},{"name":"expo","appDir":"packages/react-native-payments-example/apps/expo","appId":"com.reactnativepaymentsexpoexample","prebuildCommand":"yarn prebuild"}]
+            flows-dir: packages/react-native-payments-example/e2e/flows
+            flows-name-pattern: '*.yaml'
+            shard-count: 2
+            target-packages: |
+                @rnw-community/react-native-payments
+                @rnw-community/react-native-payments-example
+                @rnw-community/react-native-payments-example-bare
+                @rnw-community/react-native-payments-example-expo
+            build-command: yarn build --filter=@rnw-community/react-native-payments

--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -26,7 +26,7 @@ jobs:
             targets: >-
                 [{"name":"bare","appDir":"packages/react-native-payments-example/apps/bare","appId":"com.reactnativepaymentsexample","prebuildCommand":""},{"name":"expo","appDir":"packages/react-native-payments-example/apps/expo","appId":"com.reactnativepaymentsexpoexample","prebuildCommand":"yarn prebuild"}]
             flows-dir: packages/react-native-payments-example/e2e/flows
-            flows-name-pattern: '*.yaml'
+            flows-name-pattern: '*.yaml *.yml'
             shard-count: 2
             target-packages: |
                 @rnw-community/react-native-payments
@@ -34,3 +34,4 @@ jobs:
                 @rnw-community/react-native-payments-example-bare
                 @rnw-community/react-native-payments-example-expo
             build-command: yarn build --filter=@rnw-community/react-native-payments
+            repack-on-hit: true

--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
     e2e:
-        uses: rnw-community/mobile-ci/.github/workflows/android-maestro.yml@bc5927455f3ca5aed5c1b7733c9286fc8b53769e # v1.0.0
+        uses: rnw-community/mobile-ci/.github/workflows/android-maestro.yml@3ecd0054f64589c063112b73469a492b224bd866 # v1.0.1
         with:
             targets: >-
                 [{"name":"bare","appDir":"packages/react-native-payments-example/apps/bare","appId":"com.reactnativepaymentsexample","prebuildCommand":""},{"name":"expo","appDir":"packages/react-native-payments-example/apps/expo","appId":"com.reactnativepaymentsexpoexample","prebuildCommand":"yarn prebuild"}]

--- a/.github/workflows/ios-maestro.yml
+++ b/.github/workflows/ios-maestro.yml
@@ -27,7 +27,7 @@ jobs:
             targets: >-
                 [{"name":"bare","appDir":"packages/react-native-payments-example/apps/bare","workspace":"ReactNativePaymentsExample.xcworkspace","scheme":"ReactNativePaymentsExample","appId":"org.reactjs.native.example.ReactNativePaymentsExample","prebuildCommand":""},{"name":"expo","appDir":"packages/react-native-payments-example/apps/expo","workspace":"reactnativepaymentsexpoexample.xcworkspace","scheme":"reactnativepaymentsexpoexample","appId":"com.reactnativepaymentsexpoexample","prebuildCommand":"yarn prebuild"}]
             flows-dir: packages/react-native-payments-example/e2e/flows
-            flows-name-pattern: '*.yaml'
+            flows-name-pattern: '*.yaml *.yml'
             shard-count: 2
             target-packages: |
                 @rnw-community/react-native-payments
@@ -35,3 +35,4 @@ jobs:
                 @rnw-community/react-native-payments-example-bare
                 @rnw-community/react-native-payments-example-expo
             build-command: yarn build --filter=@rnw-community/react-native-payments
+            repack-on-hit: true

--- a/.github/workflows/ios-maestro.yml
+++ b/.github/workflows/ios-maestro.yml
@@ -1,9 +1,5 @@
 name: iOS Maestro E2E
 
-# Draft workflow for issue #395 (react-native-payments revival, epic #372). The
-# self-hosted macOS fleet is not registered yet (blocked on #396), so runs
-# simply queue until that lands. workflow_dispatch + path filters + a nightly
-# schedule keep this safe to land ahead of the fleet.
 on:
     workflow_dispatch:
     pull_request:
@@ -23,222 +19,19 @@ concurrency:
 permissions:
     contents: read
 
-env:
-    MAESTRO_VERSION: '2.8.0'
-    MAESTRO_CLI_NO_ANALYTICS: true
-    MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED: true
-    YARN_ENABLE_IMMUTABLE_INSTALLS: true
-    EXAMPLE_DIR: packages/react-native-payments-example
-
 jobs:
-    detect:
-        name: Detect affected packages
-        runs-on: ubuntu-latest
-        outputs:
-            payments_affected: ${{ steps.affected.outputs.payments_affected }}
-        steps:
-            - uses: actions/checkout@v5
-              with:
-                  fetch-depth: 0
-                  persist-credentials: false
-            - uses: actions/setup-node@v5
-              with:
-                  node-version: 22.x
-            - name: Compute affected packages
-              id: affected
-              env:
-                  TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
-              run: |
-                  if [ "${{ github.event_name }}" != "pull_request" ]; then
-                    echo "payments_affected=true" >> "$GITHUB_OUTPUT"
-                    echo "Non-PR event: payments pipeline always runs."
-                    exit 0
-                  fi
-                  affected=$(npx -y turbo@2.10.8 ls --affected --output=json | node -e '
-                    let raw = "";
-                    process.stdin.on("data", chunk => (raw += chunk));
-                    process.stdin.on("end", () => {
-                      const names = (JSON.parse(raw).packages?.items ?? []).map(item => item.name);
-                      const targets = [
-                        "@rnw-community/react-native-payments",
-                        "@rnw-community/react-native-payments-example",
-                        "@rnw-community/react-native-payments-example-bare",
-                        "@rnw-community/react-native-payments-example-expo",
-                      ];
-                      process.stdout.write(String(names.some(name => targets.includes(name))));
-                    });
-                  ')
-                  echo "payments_affected=${affected}" >> "$GITHUB_OUTPUT"
-                  echo "payments_affected=${affected}"
-    maestro:
-        name: Maestro (${{ matrix.target }})
-        needs: detect
-        if: needs.detect.outputs.payments_affected == 'true'
-        runs-on: [self-hosted, macOS, ARM64, macos-maestro]
-        timeout-minutes: 60
-        strategy:
-            fail-fast: false
-            matrix:
-                target: [bare, expo]
-        env:
-            APP_DIR: packages/react-native-payments-example/apps/${{ matrix.target }}
-            MAESTRO_DEBUG_OUTPUT_DIRECTORY: ${{ github.workspace }}/packages/react-native-payments-example/artifacts/maestro-ios-${{ matrix.target }}
-
-        steps:
-            -   name: Checkout repository
-                uses: actions/checkout@v5
-
-            -   name: Setup Node
-                uses: actions/setup-node@v5
-                with:
-                    node-version: 22.x
-                    cache: yarn
-
-            -   name: Enable corepack
-                run: corepack enable
-
-            -   name: Install dependencies
-                run: yarn install --immutable
-
-            -   name: Verify Xcode toolchain
-                run: xcodebuild -version
-
-            -   name: Restore CocoaPods global cache
-                uses: actions/cache@v4
-                with:
-                    path: |
-                        ~/Library/Caches/CocoaPods
-                        ~/.cocoapods
-                    key: pods-global-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-                    restore-keys: |
-                        pods-global-${{ runner.os }}-
-
-            -   name: Restore project Pods and DerivedData cache
-                uses: actions/cache@v4
-                with:
-                    path: |
-                        ${{ env.APP_DIR }}/ios/Pods
-                        ${{ env.APP_DIR }}/ios/build
-                    key: pods-project-ios-${{ matrix.target }}-${{ runner.os }}-${{ hashFiles(format('{0}/ios/Podfile.lock', env.APP_DIR), format('{0}/package.json', env.APP_DIR), format('{0}/app.json', env.APP_DIR), 'yarn.lock') }}
-                    restore-keys: |
-                        pods-project-ios-${{ matrix.target }}-${{ runner.os }}-
-
-            -   name: Build workspace JS dependencies
-                run: yarn build --filter=@rnw-community/react-native-payments
-
-            -   name: Generate native project (expo)
-                if: matrix.target == 'expo'
-                working-directory: ${{ env.EXAMPLE_DIR }}
-                run: yarn prebuild:expo
-
-            -   name: Install CocoaPods dependencies (bare)
-                if: matrix.target == 'bare'
-                working-directory: ${{ env.APP_DIR }}/ios
-                run: pod install --repo-update
-
-            -   name: Install CocoaPods dependencies (expo)
-                if: matrix.target == 'expo'
-                working-directory: ${{ env.APP_DIR }}/ios
-                run: pod install --repo-update
-
-            -   name: Boot iOS Simulator
-                shell: bash
-                run: |
-                    set -euo pipefail
-                    device_line=$(xcrun simctl list devices available | grep -E '^\s+iPhone.*\(' | tail -1)
-                    test -n "$device_line"
-                    device_udid=$(grep -oE '[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}' <<< "$device_line")
-                    test -n "$device_udid"
-                    echo "Booting simulator: $device_line"
-                    xcrun simctl boot "$device_udid" || true
-                    xcrun simctl bootstatus "$device_udid" -b
-                    echo "SIMULATOR_UDID=$device_udid" >> "$GITHUB_ENV"
-
-            -   name: Build app (bare)
-                if: matrix.target == 'bare'
-                working-directory: ${{ env.APP_DIR }}/ios
-                run: |
-                    set -euo pipefail
-                    xcodebuild \
-                        -workspace ReactNativePaymentsExample.xcworkspace \
-                        -scheme ReactNativePaymentsExample \
-                        -configuration Release \
-                        -sdk iphonesimulator \
-                        -destination 'generic/platform=iOS Simulator' \
-                        -derivedDataPath build \
-                        CODE_SIGNING_ALLOWED=NO \
-                        build
-                    echo "APP_PATH=${{ env.APP_DIR }}/ios/build/Build/Products/Release-iphonesimulator/ReactNativePaymentsExample.app" >> "$GITHUB_ENV"
-
-            -   name: Build app (expo)
-                if: matrix.target == 'expo'
-                working-directory: ${{ env.APP_DIR }}/ios
-                run: |
-                    set -euo pipefail
-                    xcodebuild \
-                        -workspace reactnativepaymentsexpoexample.xcworkspace \
-                        -scheme reactnativepaymentsexpoexample \
-                        -configuration Release \
-                        -sdk iphonesimulator \
-                        -destination 'generic/platform=iOS Simulator' \
-                        -derivedDataPath build \
-                        CODE_SIGNING_ALLOWED=NO \
-                        build
-                    echo "APP_PATH=${{ env.APP_DIR }}/ios/build/Build/Products/Release-iphonesimulator/reactnativepaymentsexpoexample.app" >> "$GITHUB_ENV"
-
-            -   name: Install app on simulator
-                run: xcrun simctl install "$SIMULATOR_UDID" "$APP_PATH"
-
-            -   name: Install Maestro
-                run: |
-                    maestro_bin="$HOME/.maestro/bin/maestro"
-                    if [ ! -x "$maestro_bin" ] || [ "$("$maestro_bin" --version 2>/dev/null | tail -n 1 | tr -d '\r' || true)" != "$MAESTRO_VERSION" ]; then
-                      curl -fsSL https://get.maestro.mobile.dev | env MAESTRO_VERSION="$MAESTRO_VERSION" bash
-                    fi
-                    echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
-
-            -   name: Run Maestro suite
-                working-directory: ${{ env.EXAMPLE_DIR }}
-                run: yarn e2e:ios:${{ matrix.target }}
-
-            -   name: Capture final simulator state
-                if: failure()
-                shell: bash
-                run: |
-                    mkdir -p "${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}"
-                    xcrun simctl io "$SIMULATOR_UDID" screenshot "${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}/final-screen.png" || true
-
-            -   name: Shutdown simulator
-                if: always()
-                run: xcrun simctl shutdown "$SIMULATOR_UDID" || true
-
-            -   name: Upload Maestro artifacts
-                if: failure()
-                uses: actions/upload-artifact@v4
-                with:
-                    name: maestro-ios-${{ matrix.target }}
-                    path: ${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}/**
-                    if-no-files-found: warn
-                    retention-days: 7
-
-    status:
-        name: iOS Maestro E2E result
-        needs: [detect, maestro]
-        if: always()
-        runs-on: ubuntu-latest
-        steps:
-            - name: Report
-              run: |
-                  if [ "${{ needs.detect.result }}" != "success" ]; then
-                    echo "Detection job did not succeed."
-                    exit 1
-                  fi
-                  if [ "${{ needs.detect.outputs.payments_affected }}" != "true" ]; then
-                    echo "Skipped: payments dependency tree untouched."
-                    exit 0
-                  fi
-                  if [ "${{ needs.maestro.result }}" != "success" ]; then
-                    echo "Maestro suite failed."
-                    exit 1
-                  fi
-                  echo "Maestro suite passed."
+    e2e:
+        uses: rnw-community/mobile-ci/.github/workflows/ios-maestro.yml@bc5927455f3ca5aed5c1b7733c9286fc8b53769e # v1.0.0
+        with:
+            runner-labels: '["self-hosted","macOS","ARM64","macos-maestro"]'
+            targets: >-
+                [{"name":"bare","appDir":"packages/react-native-payments-example/apps/bare","workspace":"ReactNativePaymentsExample.xcworkspace","scheme":"ReactNativePaymentsExample","appId":"org.reactjs.native.example.ReactNativePaymentsExample","prebuildCommand":""},{"name":"expo","appDir":"packages/react-native-payments-example/apps/expo","workspace":"reactnativepaymentsexpoexample.xcworkspace","scheme":"reactnativepaymentsexpoexample","appId":"com.reactnativepaymentsexpoexample","prebuildCommand":"yarn prebuild"}]
+            flows-dir: packages/react-native-payments-example/e2e/flows
+            flows-name-pattern: '*.yaml'
+            shard-count: 2
+            target-packages: |
+                @rnw-community/react-native-payments
+                @rnw-community/react-native-payments-example
+                @rnw-community/react-native-payments-example-bare
+                @rnw-community/react-native-payments-example-expo
+            build-command: yarn build --filter=@rnw-community/react-native-payments

--- a/.github/workflows/ios-maestro.yml
+++ b/.github/workflows/ios-maestro.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
     e2e:
-        uses: rnw-community/mobile-ci/.github/workflows/ios-maestro.yml@bc5927455f3ca5aed5c1b7733c9286fc8b53769e # v1.0.0
+        uses: rnw-community/mobile-ci/.github/workflows/ios-maestro.yml@3ecd0054f64589c063112b73469a492b224bd866 # v1.0.1
         with:
             runner-labels: '["self-hosted","macOS","ARM64","macos-maestro"]'
             targets: >-

--- a/.github/workflows/ios-maestro.yml
+++ b/.github/workflows/ios-maestro.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
     e2e:
-        uses: rnw-community/mobile-ci/.github/workflows/ios-maestro.yml@3ecd0054f64589c063112b73469a492b224bd866 # v1.0.1
+        uses: rnw-community/mobile-ci/.github/workflows/ios-maestro.yml@0eadcb345bc704b1ccc8e9965634af1ff3d2e25e # v1.1.0
         with:
             runner-labels: '["self-hosted","macOS","ARM64","macos-maestro"]'
             targets: >-

--- a/.github/workflows/pr-closed-cleanup.yml
+++ b/.github/workflows/pr-closed-cleanup.yml
@@ -8,4 +8,4 @@ jobs:
     cleanup:
         permissions:
             actions: write
-        uses: rnw-community/mobile-ci/.github/workflows/pr-closed-cleanup-reusable.yml@bc5927455f3ca5aed5c1b7733c9286fc8b53769e # v1.0.0
+        uses: rnw-community/mobile-ci/.github/workflows/pr-closed-cleanup-reusable.yml@3ecd0054f64589c063112b73469a492b224bd866 # v1.0.1

--- a/.github/workflows/pr-closed-cleanup.yml
+++ b/.github/workflows/pr-closed-cleanup.yml
@@ -4,9 +4,6 @@ on:
     pull_request:
         types: [closed]
 
-permissions:
-    actions: write
-
 jobs:
     cleanup:
         permissions:

--- a/.github/workflows/pr-closed-cleanup.yml
+++ b/.github/workflows/pr-closed-cleanup.yml
@@ -4,59 +4,11 @@ on:
     pull_request:
         types: [closed]
 
+permissions:
+    actions: write
+
 jobs:
-    cancel-queued-runs:
-        name: Cancel queued/in-progress runs for the closed PR branch
-        runs-on: ubuntu-latest
+    cleanup:
         permissions:
             actions: write
-
-        steps:
-            -   name: Cancel queued and in-progress runs for this branch
-                env:
-                    GH_TOKEN: ${{ github.token }}
-                    HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
-                    CURRENT_RUN_ID: ${{ github.run_id }}
-                    PR_NUMBER: ${{ github.event.pull_request.number }}
-                run: |
-                    set -euo pipefail
-
-                    max_iterations=20
-
-                    for status in queued in_progress; do
-                      iteration=0
-                      while :; do
-                        iteration=$((iteration + 1))
-                        if [ "$iteration" -gt "$max_iterations" ]; then
-                          echo "Reached max iterations (${max_iterations}) for status=${status}, stopping."
-                          break
-                        fi
-
-                        response=$(gh api --method GET \
-                          "repos/${{ github.repository }}/actions/runs" \
-                          -f "branch=${HEAD_BRANCH}" \
-                          -f "status=${status}" \
-                          -f "per_page=100" \
-                          -f "page=1")
-
-                        cancellable_ids=$(echo "$response" | jq -r --arg repo "${{ github.repository }}" --arg current "$CURRENT_RUN_ID" --argjson pr_number "$PR_NUMBER" '
-                          [.workflow_runs[]
-                            | select(.head_repository.full_name == $repo)
-                            | select(.event == "pull_request")
-                            | select([.pull_requests[]?.number] | index($pr_number))
-                            | select((.id | tostring) != $current)
-                            | .id
-                          ] | .[]
-                        ')
-
-                        if [ -z "$cancellable_ids" ]; then
-                          break
-                        fi
-
-                        echo "$cancellable_ids" | while read -r run_id; do
-                          echo "Cancelling run ${run_id}"
-                          gh api --method POST \
-                            "repos/${{ github.repository }}/actions/runs/${run_id}/cancel" || true
-                        done
-                      done
-                    done
+        uses: rnw-community/mobile-ci/.github/workflows/pr-closed-cleanup-reusable.yml@bc5927455f3ca5aed5c1b7733c9286fc8b53769e # v1.0.0

--- a/.github/workflows/pr-closed-cleanup.yml
+++ b/.github/workflows/pr-closed-cleanup.yml
@@ -8,4 +8,4 @@ jobs:
     cleanup:
         permissions:
             actions: write
-        uses: rnw-community/mobile-ci/.github/workflows/pr-closed-cleanup-reusable.yml@3ecd0054f64589c063112b73469a492b224bd866 # v1.0.1
+        uses: rnw-community/mobile-ci/.github/workflows/pr-closed-cleanup-reusable.yml@0eadcb345bc704b1ccc8e9965634af1ff3d2e25e # v1.1.0


### PR DESCRIPTION
## Summary

Collapses this repo's three hand-rolled mobile CI workflows into thin
`workflow_call` consumers of [`rnw-community/mobile-ci`](https://github.com/rnw-community/mobile-ci)
`v1.0.0` (pinned to `bc5927455f3ca5aed5c1b7733c9286fc8b53769e`), per the
rollout step "this repo's own workflows collapse to `workflow_call`
consumers" tracked in rnw-community/rnw-community#448.

- `ios-maestro.yml` and `android-maestro.yml` drop their hand-rolled
  `detect` (turbo-affected) job and `target: [bare, expo]` matrix build+test
  job in favor of `uses: rnw-community/mobile-ci/.github/workflows/{ios,android}-maestro.yml@v1.0.0`.
  Triggers, path filters, concurrency group, and the nightly cron are kept
  as-is.
- `pr-closed-cleanup.yml` drops its hand-rolled run-cancellation script in
  favor of `uses: rnw-community/mobile-ci/.github/workflows/pr-closed-cleanup-reusable.yml@v1.0.0`.
  Trigger (`pull_request: types: [closed]`) is kept; `permissions: actions:
  write` is now declared at both the caller-workflow and job level per that
  workflow's doc.

This **supersedes #457** (`feat/rnp-447-canary-optimizations`)'s hand-rolled
native-app-cache / ccache / sharding work — all of it now comes from
`mobile-ci` itself (`native-app-cache`, `setup-ccache-ios`,
`native-fingerprint`, shard-index computation in the `detect` job), including
the fresh-JS `repack-app` step that #457 had listed as an unimplemented
follow-up (wired here via `repack-on-hit`, left at its default `false` — see
flags below). Do not merge #457; its branch is left untouched per this PR's
task scope.

## Target mapping | target | platform | appDir | workspace/scheme (iOS only) | appId | prebuildCommand |
| --- | --- | --- | --- | --- | --- |
| `bare` | iOS | `packages/react-native-payments-example/apps/bare` | `ReactNativePaymentsExample.xcworkspace` / `ReactNativePaymentsExample` | `org.reactjs.native.example.ReactNativePaymentsExample` | `""` |
| `bare` | Android | `packages/react-native-payments-example/apps/bare` | — | `com.reactnativepaymentsexample` | `""` |
| `expo` | iOS | `packages/react-native-payments-example/apps/expo` | `reactnativepaymentsexpoexample.xcworkspace` / `reactnativepaymentsexpoexample` | `com.reactnativepaymentsexpoexample` | `yarn prebuild` |
| `expo` | Android | `packages/react-native-payments-example/apps/expo` | — | `com.reactnativepaymentsexpoexample` | `yarn prebuild` |

`flows-dir: packages/react-native-payments-example/e2e/flows`,
`flows-name-pattern: '*.yaml'` (this repo's 8 scenario files are plain
`*.yaml`, not mobile-ci's default `*.flow.yaml`; subflows live in the
sibling `e2e/subflows` dir so the default `flows-max-depth: 1` already keeps
them out of the shard). `shard-count: 2` on both platforms.
`target-packages` carries over the same four package names the old
hand-rolled `detect` job checked (`@rnw-community/react-native-payments`,
`@rnw-community/react-native-payments-example{,-bare,-expo}`).
`build-command: yarn build --filter=@rnw-community/react-native-payments`
preserves the old "build workspace JS deps before native build" step.

## Flagged decisions/assumptions for maintainer confirmation

- **`prebuildCommand` corrected from the originally-assumed `yarn
  prebuild:expo` to `yarn prebuild`.** mobile-ci's `build`/`build-android-app`
  jobs run `prebuildCommand` with `working-directory: matrix.target.appDir`
  (i.e. cwd = `apps/expo`), not from `packages/react-native-payments-example`
  like the old hand-rolled workflow did. `apps/expo/package.json` defines its
  own `"prebuild": "expo prebuild"` script; the example-level
  `"prebuild:expo"` script (`yarn workspace ...-expo prebuild`) doesn't exist
  in that cwd's workspace and would fail closed with "command not found".
  Verified by reading both `package.json` files in the target repo.
- **`android-driver` left at mobile-ci's default (`redroid`)**, not the
  hand-rolled `reactivecircus/android-emulator-runner` (x86_64 AVD) the old
  `android-maestro.yml` used. This assumes the self-hosted Android pool is
  `linux-aarch64` (Google ships no `linux-aarch64` emulator/NDK/cmake build,
  so `avd` cannot boot there) — consistent with #457 switching to Redroid for
  the same reason and with `vitalyiegorov/suuudokuuu` running Redroid
  successfully on the same `[self-hosted, linux-tiered, linux-xl]` labels.
  **Please confirm the fleet is in fact `linux-aarch64`** before merging; if
  it's actually x86_64, set `android-driver: avd` instead (and the emulator
  inputs the old workflow hard-coded: `emulator-api-level: 34`,
  `emulator-target: google_apis`, `emulator-arch: x86_64`,
  `emulator-profile: pixel_6`, which happen to match mobile-ci's own `avd`
  defaults already).
- `runner-labels` on the iOS caller is set explicitly to
  `["self-hosted","macOS","ARM64","macos-maestro"]` to preserve the old
  workflow's extra `macos-maestro` pool tag (mobile-ci's default omits it).
  **Superseded by the topology update below**: the Android caller no longer
  uses a single `runner-labels` pool for both build and test.
- `redroid-prewarm-manifest-path` left at mobile-ci's default
  (`$HOME/.rnw-ci/android-emulator.json`) — not verified against whatever
  path `vitalyiegorov/suuudokuuu`'s host actually uses; flagging in case the
  fleet's prewarm manifest lives somewhere else.
- Removed the "self-hosted fleet not registered yet, blocked on #396" draft
  comments from both Maestro workflows' headers since they predate this
  migration; drop a note here if the fleet is still not registered and these
  will keep queuing either way (`workflow_dispatch` lets you test on demand
  once it is).

## Update: Android build/test pool split (v1.1.0) + smoke test findings

The `v1.0.1` Android smoke run (single `runner-labels` pool for both build
and test, `android-driver: redroid`) confirmed the `linux-aarch64` fleet
cannot natively **build** Android at all: Google ships no `linux-aarch64`
build of the Android NDK/`cmake`, so the Gradle native build failed before
Maestro ever ran, for both targets.

Fix (bumped to `mobile-ci@v1.1.0`, which added the split): the Android
caller now sets

```yaml
build-runner-labels: '["self-hosted","macOS","ARM64","macos-maestro"]'
test-runner-labels: '["self-hosted","linux-tiered","linux-xl"]'
```

— build the APK on the macOS ARM64 pool (Google's macOS NDK/`cmake` build is
arm64-native there, and it's the same pool `ios-maestro.yml` already uses),
then hand the built APK to the `linux-aarch64` pool to boot Redroid and run
Maestro. This mirrors `vitalyiegorov/suuudokuuu`'s proven build-on-macOS /
test-on-Redroid topology. `runner-labels` itself is no longer set on the
Android caller (superseded by the two new inputs).

**Re-run results (commit `7b49952`, run
[31235818059](https://github.com/rnw-community/rnw-community/actions/runs/31235818059)):**

- Both `Build (bare)` and `Build (expo)` jobs confirmed running on the
  macOS pool (`runner_name: trf-maestro-*`, labels
  `["self-hosted","macOS","ARM64","macos-maestro"]`).
- **`Build (expo)` got past the NDK/`cmake` install and compiled the native
  library for all four ABIs** (`arm64-v8a`, `armeabi-v7a`, `x86`, `x86_64`)
  — the pool-split fix works as intended. It then failed at a later,
  unrelated step: `:app:createBundleReleaseJsAndAssets` fails with `Unable
  to resolve module ./component/app.js from
  .../packages/react-native-payments-example/src/index.ts`. That import
  really does say `.js` while the file on disk is
  `src/component/app.tsx` — a pre-existing source defect in the example
  app's `index.ts`, unrelated to this PR's CI wiring or to `mobile-ci`
  itself. It was never previously exercised because every prior Android CI
  attempt failed earlier, at the native/`cmake` stage. Filed as a follow-up
  (needs a fix to `packages/react-native-payments-example/src/index.ts`,
  out of scope here).
- `Build (bare)` still fails as expected, with the pre-existing
  `:gradle-plugin:settings-plugin:compileKotlin` / Kotlin-metadata-version
  conflict tracked in #549 (unrelated to this PR; that fix targets `master`
  directly).
- Because both `Build` jobs failed, the `Maestro shard` test jobs on the
  Linux/Redroid pool never started (`skipped`) — the build/test hand-off
  itself couldn't be exercised end-to-end this run. Re-run once #549 and the
  `index.ts` fix land to validate the Redroid test phase.

## Validation

- `actionlint -color` — clean on all three changed files.
- `zizmor` (no repo-local config in this consumer repo; run without one) —
  no findings on all three changed files.
- No `run:` blocks remain in any of the three files, so `shellcheck` is
  not applicable here.

Refs #448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Adopt `mobile-ci` v1.0.0 reusable workflows for Android/iOS e2e and PR cleanup
> - Replaces the multi-job Android and iOS Maestro workflows with single `e2e` jobs that delegate to `rnw-community/mobile-ci` reusable workflows, removing inline emulator/simulator setup, artifact handling, and detection/gating logic.
> - Both e2e workflows now run with 2 shards across separate build and test runner labels, covering `bare` and `expo` targets.
> - Replaces the inline shell-based PR cleanup job in [pr-closed-cleanup.yml](.github/workflows/pr-closed-cleanup.yml) with a reusable workflow call, requiring `permissions.actions=write`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b49952.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined Android and iOS end-to-end test workflows by using reusable, standardized automation.
  * Preserved existing triggers and concurrency behavior while configuring platform targets, test flows, sharding, and build commands.
  * Simplified pull request cleanup automation to reliably handle unfinished workflow runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
