### PR TITLE
fix(react-native-payments-example): resolve .js-suffixed TS imports in Metro

### DIFF
--- a/packages/react-native-payments-example/apps/bare/metro.config.js
+++ b/packages/react-native-payments-example/apps/bare/metro.config.js
@@ -15,5 +15,16 @@ module.exports = mergeConfig(getDefaultConfig(projectRoot), {
             path.resolve(monorepoRoot, 'node_modules'),
         ],
         unstable_enableSymlinks: true,
+        resolveRequest: (context, moduleName, platform) => {
+            try {
+                return context.resolveRequest(context, moduleName, platform);
+            } catch (error) {
+                if (moduleName.startsWith('.') && /\.m?js$/.test(moduleName)) {
+                    return context.resolveRequest(context, moduleName.replace(/\.m?js$/, ''), platform);
+                }
+
+                throw error;
+            }
+        },
     },
 });

--- a/packages/react-native-payments-example/apps/expo/metro.config.js
+++ b/packages/react-native-payments-example/apps/expo/metro.config.js
@@ -15,5 +15,16 @@ config.resolver.nodeModulesPaths = [
     path.resolve(monorepoRoot, 'node_modules'),
 ];
 config.resolver.unstable_enableSymlinks = true;
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+    try {
+        return context.resolveRequest(context, moduleName, platform);
+    } catch (error) {
+        if (moduleName.startsWith('.') && /\.m?js$/.test(moduleName)) {
+            return context.resolveRequest(context, moduleName.replace(/\.m?js$/, ''), platform);
+        }
+
+        throw error;
+    }
+};
 
 module.exports = config;


### PR DESCRIPTION
## Summary

- Every Metro bundle of `react-native-payments-example` fails on master with `Unable to resolve module ./component/app.js from .../react-native-payments-example/src/index.ts`, which has broken **all mobile e2e builds on master** (old and new CI alike, including the nightly scheduled runs since 2026-08-03).
- Root cause: `2d49b46` ("chore: release v2.12.10") introduced ESM-style `.js`-suffixed relative imports (the TS `moduleResolution: "bundler"` idiom — e.g. `export { App } from './component/app.js';` where the real file is `app.tsx`) across ~29 files under `packages/react-native-payments-example/src`. Metro's resolver never strips a literal `.js` extension to retry `.ts`/`.tsx`, so it fails hard on any of these imports.
- Fix: add a `resolver.resolveRequest` shim to **both** example apps' Metro configs (`apps/bare/metro.config.js`, `apps/expo/metro.config.js`). It delegates to Metro's default resolver first; on failure for a relative `.js`/`.mjs` specifier it retries with the suffix stripped, letting Metro's normal `sourceExts` (`.ts`, `.tsx`, `.js`, `.jsx`) find the real file. This is deliberately **not** a 29-file codemod on the source imports — the `.js` suffixes are the intentional TS/ESM build idiom for this package and are left untouched.

## Why this approach

Rewriting 29 source files to drop `.js` suffixes would fight the package's own TS/ESM build convention (`moduleResolution: "bundler"`), and would need to be re-applied every time a new file is added. A resolver-level shim fixes it once, at the layer that's actually broken (Metro), without touching source.

## Verification performed

- Confirmed root cause: `git show --stat 2d49b46 -- packages/react-native-payments-example/src` shows the commit introducing all 29 affected files; `grep` confirms the `.js`-suffixed relative imports.
- Reproduced the exact failure: with the fix reverted, `npx react-native bundle --entry-file index.js --platform ios --dev false` in `apps/bare` fails with:
  ```
  Error: Unable to resolve module ./component/app.js from .../react-native-payments-example/src/index.ts
  ```
- With the shim applied, the same bundle command completes successfully (`Done writing bundle output`, ~1.8MB iOS bundle produced).
- `npx eslint` on both changed `metro.config.js` files reports no issues.
- No source files under `packages/react-native-payments-example/src` were modified — diff is scoped to the two Metro configs.

This unblocks PR #543's smoke runs, which bundle these example apps for e2e.

## Test plan

- [x] Reproduce failure without fix (`react-native bundle` on `apps/bare`, iOS)
- [x] Confirm fix resolves it (same command succeeds)
- [x] `eslint` clean on both changed files
- [ ] CI (mobile e2e smoke) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix .js-suffixed TypeScript imports in Metro for react-native-payments-example
> Adds a custom `resolver.resolveRequest` to the Metro configs for both the [bare](https://github.com/rnw-community/rnw-community/pull/544/files#diff-e65528fc4c1d14b3208284c48080991d5758cb60132c5eca385f8cda92143bb1) and [Expo](https://github.com/rnw-community/rnw-community/pull/544/files#diff-0cb1fae532dcc1b4ee27ab85373cf95415dfb860d13da528e7bcc2a3204bae14) example apps. When resolution fails for a relative import ending in `.js` or `.mjs`, it retries after stripping the extension, matching how TypeScript emits imports with explicit `.js` extensions that Metro cannot resolve natively.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a46132.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved module loading in the React Native example apps.
  - Resolved issues where certain JavaScript and modern module files could not be located during bundling.
  - Preserved existing error handling for unsupported module resolution failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->