### PR TITLE
fix: align Kotlin Gradle Plugin version for bare Android's settings-plugin

### DIFF
--- a/packages/react-native-payments-example/apps/bare/android/settings.gradle
+++ b/packages/react-native-payments-example/apps/bare/android/settings.gradle
@@ -1,6 +1,6 @@
-pluginManagement { includeBuild("../../../../../node_modules/@react-native/gradle-plugin") }
+pluginManagement { includeBuild("../../../node_modules/@react-native/gradle-plugin") }
 plugins { id("com.facebook.react.settings") }
 extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
 rootProject.name = 'ReactNativePaymentsExample'
 include ':app'
-includeBuild('../../../../../node_modules/@react-native/gradle-plugin')
+includeBuild('../../../node_modules/@react-native/gradle-plugin')


### PR DESCRIPTION
## Root cause

The bare Android target's native build fails on any CI (this is a pure dependency-resolution bug, not runner-specific) with:

```
Execution failed for task ':gradle-plugin:settings-plugin:compileKotlin'
... Class 'kotlin.io.FilesKt__UtilsKt' was compiled with an incompatible version of Kotlin.
The actual metadata version is 2.2.0, but the compiler version 1.9.0 can read versions up to 2.0.0.
```

`packages/react-native-payments-example/apps/bare/android/settings.gradle` (lines 1 and 6) hardcoded:

```groovy
pluginManagement { includeBuild("../../../../../node_modules/@react-native/gradle-plugin") }
...
includeBuild('../../../../../node_modules/@react-native/gradle-plugin')
```

— 5 directory levels up from `android/`, landing on the **workspace root** `node_modules/@react-native/gradle-plugin`. In this yarn workspace that root copy resolves to **`@react-native/gradle-plugin@0.76.9`**, because `@rnw-community/fast-style` and `@rnw-community/platform` still declare `"react-native": "^0.76.1"` and yarn hoists their transitive `@react-native/gradle-plugin@0.76.9` to the workspace root (confirmed via `yarn why @react-native/gradle-plugin` and `check-dependency-version-consistency`, which already flags the `react-native` version split across the workspace: `^0.76.1` vs `0.86.2`).

`@react-native/gradle-plugin@0.76.9`'s own `gradle/libs.versions.toml` pins `kotlin = "1.9.25"` — an independent, separate composite build (`gradle-plugin-root`, included via `includeBuild`) with its own `pluginManagement`/version catalog that does **not** inherit the app's `kotlinVersion = "2.1.20"` (declared in `packages/react-native-payments-example/apps/bare/android/build.gradle:8`). Kotlin 1.9.25's compiler cannot read the Kotlin 2.2.x stdlib metadata that ships bundled with Gradle 9.3.1, so `:gradle-plugin:settings-plugin:compileKotlin` fails.

The example app itself depends on `react-native@0.86.2`, and yarn nests a matching, correctly-versioned copy of `@react-native/gradle-plugin@0.86.2` (whose `libs.versions.toml` pins `kotlin = "2.1.20"`, matching the app's own pin) three directory levels up, at `packages/react-native-payments-example/node_modules/@react-native/gradle-plugin`.

## Fix

Minimal change: point both `includeBuild` calls in `settings.gradle` at that correctly-versioned nested copy instead of the ambiguous, hoisting-dependent workspace root:

```diff
-pluginManagement { includeBuild("../../../../../node_modules/@react-native/gradle-plugin") }
+pluginManagement { includeBuild("../../../node_modules/@react-native/gradle-plugin") }
 ...
-includeBuild('../../../../../node_modules/@react-native/gradle-plugin')
+includeBuild('../../../node_modules/@react-native/gradle-plugin')
```

## Verification

Reproduced and fixed locally (JDK 17, no Android SDK available in the sandbox, so this only exercises `:gradle-plugin:*` subprojects, not the full `:app` assemble):

- With the original 5-level path: `./gradlew :gradle-plugin:settings-plugin:compileKotlin` fails with the exact reported `incompatible version of Kotlin` error (metadata 2.2.0 vs compiler-readable 2.0.0).
- With the fix (3-level path): the same task, and the sibling `:gradle-plugin:shared` / `:gradle-plugin:react-native-gradle-plugin` compileKotlin tasks, all succeed. The build then fails later only on `SDK location not found` for `:app`, which is expected/unrelated — this sandbox has no `ANDROID_HOME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Kotlin Gradle Plugin path in bare Android `settings.gradle`
> Corrects the relative path to the React Native Gradle plugin in [settings.gradle](https://github.com/rnw-community/rnw-community/pull/549/files#diff-43815ee643b11fbd1d3f5033bea960eb6215f3a5040743d623309cef5f911026) by shortening the traversal from `../../../../../node_modules` to `../../../node_modules` in both the `pluginManagement` and standalone `includeBuild` statements.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93ef58c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Android build configuration paths in the React Native payments example, improving project setup and build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->