### PR TITLE
fix(react-native-payments): resolve canMakePayment without Play Services

### DIFF
--- a/packages/react-native-payments-example/e2e/flows/can_make_payment_probe.yaml
+++ b/packages/react-native-payments-example/e2e/flows/can_make_payment_probe.yaml
@@ -22,5 +22,8 @@ appId: ${APP_ID}
           text: "checking"
       - assertVisible:
           id: "action-show"
+      - scrollUntilVisible:
+          element:
+            id: "event-log-count"
       - assertVisible:
           id: "event-log-count"

--- a/packages/react-native-payments-example/e2e/readme.md
+++ b/packages/react-native-payments-example/e2e/readme.md
@@ -54,6 +54,38 @@ exists and what it proves instead of a real payment authorization outcome.
 | `async_update_toggle_state.yaml`               | Toggling async `updateWith` on does not change request construction or prevent `show` from attaching listeners — the JS-observable half of the async round trip (see the documented gap below for the half this suite cannot reach), read from the log after the iOS sheet dismisses. |
 | `reset_new_request_state_transitions.yaml`     | The full state machine: `idle` → interactive → `rejected` (Android: `action-abort`; iOS: sheet dismissal) → `idle` (reset, logs `request reset`) → interactive again (iOS: the sheet re-presents, proving `action-reset` really rebuilds a fresh request rather than reusing a closed one). |
 
+## Redroid has no Google Play Services (Android)
+
+Redroid images are plain AOSP with no Google Play Services at all, unlike an AVD's `google_apis`
+system image. Before `PaymentsModule` guarded against this, any GMS-dependent call — the
+mount-time `canMakePayment` probe `usePaymentDemo`'s `useEffect` fires on every launch, and
+`action-show`'s `loadPaymentData` — logged `GoogleApiAvailability: Google Play services is
+invalid. Cannot recover.` (`ConnectionResult.SERVICE_INVALID`, a generic availability signal, not
+a statement that Payments specifically is unsupported), and Play Services' own bundled fallback UI
+turned that into a blocking system dialog ("… won't run without Google Play services, which are
+not supported by your device.") over the whole screen. Since every flow routes through
+`launch_and_wait_for_probe.yaml`, that dialog occluded `payments-flow-state` for all of them, not
+just the flows that call `action-show`.
+
+`PaymentsModule.canMakePayments`/`hasEnrolledInstrument`/`show` now check
+`GoogleApiAvailability.isGooglePlayServicesAvailable()` before the chained
+`isReadyToPay()`/`loadPaymentData()` call that actually reaches into Play services —
+`Wallet.getPaymentsClient(...)` itself never fails on its own. On a device or emulator without
+valid Play Services, `canMakePayment()`/`hasEnrolledInstrument()` now simply resolve `false`
+instead of surfacing the dialog, the same outcome a real user would see on any Play-Services-less
+Android device. `launch_and_wait_for_probe.yaml` keeps an `optional: true` "OK" dismissal on
+Android as a defensive fallback — matching the pattern `subflows/show_request.yaml` already used
+for the `action-show` tap — in case some other GMS-backed path this suite doesn't yet cover ever
+surfaces a similar dialog; it is a no-op once the native guard applies.
+
+Separately (and unrelated to Play Services): `launch_and_wait_for_probe.yaml` used to assert
+`event-log` visible immediately after launch, and `can_make_payment_probe.yaml`'s Android branch
+asserted `event-log-count` the same way. Both ids sit below the fold on Redroid's screen profile,
+so neither is actually on-screen without scrolling first. The shared subflow's assertion was
+dropped (redundant — flows that need `event-log`'s content already scroll to it themselves, e.g.
+`app_launch.yaml`), and `can_make_payment_probe.yaml` gained a `scrollUntilVisible` ahead of its
+own `event-log-count` assertion.
+
 ## Documented gap: the PassKit sheet sandboxes the app's accessibility tree (iOS)
 
 While a `PKPaymentAuthorizationController` sheet is presented, iOS blocks UI-test tooling

--- a/packages/react-native-payments-example/e2e/subflows/launch_and_wait_for_probe.yaml
+++ b/packages/react-native-payments-example/e2e/subflows/launch_and_wait_for_probe.yaml
@@ -2,13 +2,18 @@ appId: ${APP_ID}
 ---
 - launchApp:
     clearState: true
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn:
+          text: "OK"
+          optional: true
 - assertVisible:
     id: "payments-flow-state"
     text: "idle"
 - assertVisible:
     id: "action-show"
-- assertVisible:
-    id: "event-log"
 - extendedWaitUntil:
     notVisible:
       id: "payments-can-make-status"

--- a/packages/react-native-payments/android/src/main/java/com/payments/PaymentsModule.java
+++ b/packages/react-native-payments/android/src/main/java/com/payments/PaymentsModule.java
@@ -9,6 +9,8 @@ import android.util.Log;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.api.Status;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.OnCompleteListener;
@@ -108,6 +110,11 @@ public class PaymentsModule extends PaymentsSpec {
         // HINT: We store promise reference to resolve/reject it later
         mPromise = promise;
 
+        if (isGooglePlayServicesUnavailable(currentActivity)) {
+            rejectPromise(E_UNSUPPORTED_ANDROID_PAY, "AndroidPay is not supported: Google Play services is unavailable");
+            return;
+        }
+
         validatePaymentRequestJSON(paymentMethodData);
 
         // https://developers.google.com/android/reference/com/google/android/gms/wallet/PaymentDataRequest#fromJson(java.lang.String)
@@ -139,6 +146,17 @@ public class PaymentsModule extends PaymentsSpec {
         });
     }
 
+    // Wallet.getPaymentsClient(...) itself never fails; it is the chained isReadyToPay()/loadPaymentData()
+    // call that reaches into Play services and, on a device where it is missing or invalid, surfaces an
+    // unrecoverable system dialog over the whole screen instead of failing the task. Checking availability
+    // first keeps that dialog from ever appearing and reports AndroidPay as unsupported instead, exactly
+    // like https://developers.google.com/android/guides/api-client recommends for any Play services caller.
+    private boolean isGooglePlayServicesUnavailable(Activity activity) {
+        int status = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(activity);
+
+        return status != ConnectionResult.SUCCESS;
+    }
+
     private IsReadyToPayRequest buildExistingPaymentMethodRequiredRequest(String paymentMethodData) {
         try {
             JSONObject requestJson = new JSONObject(paymentMethodData);
@@ -157,6 +175,11 @@ public class PaymentsModule extends PaymentsSpec {
 
         // HINT: We store promise reference to resolve/reject it later
         mPromise = promise;
+
+        if (isGooglePlayServicesUnavailable(currentActivity)) {
+            rejectPromise(E_FAILED_SHOWING_ANDROID_PAY, "Failed showing AndroidPay: Google Play services is unavailable");
+            return;
+        }
 
         validatePaymentRequestJSON(paymentMethodData);
 

--- a/packages/react-native-payments/docs/platforms/android.md
+++ b/packages/react-native-payments/docs/platforms/android.md
@@ -49,6 +49,14 @@ dependencies {
 
 ## Known deviations
 
+- **`canMakePayment()`/`hasEnrolledInstrument()`/`show()` resolve gracefully without Google Play
+  Services.** `GoogleApiAvailability.isGooglePlayServicesAvailable()` is checked before the chained
+  `isReadyToPay()`/`loadPaymentData()` call that actually reaches into Play services —
+  `Wallet.getPaymentsClient(...)` itself never fails on its own. On a device where Play Services is
+  missing or invalid, Play Services would otherwise turn that chained call into a blocking,
+  unrecoverable system dialog over the whole screen instead of failing the promise; the guard
+  reports AndroidPay as unsupported instead, so `canMakePayment()`/`hasEnrolledInstrument()`
+  resolve `false` and `show()` rejects like any other unsupported configuration.
 - **Change events are a no-op.** Google Pay renders its sheet in its own activity and never asks the app for an
   in-sheet update, so `addEventListener` can be called but a registered listener never fires on Android. See
   [guides/change-events.md](../guides/change-events.md).


### PR DESCRIPTION
## Summary

Rescues the still-valuable app/test-level parts of #457
(`feat/rnp-447-canary-optimizations`, closed in favor of #550) per the
maintainer's cross-check request, and fixes the underlying product bug
behind the GMS dialog those tests were working around.

## Diagnosis: run 31268719610 (four failed Maestro shards on #457's branch)

All four Android shards on that run failed identically:
`Assertion is false: id: event-log is visible`, at the very first steps of
the shared `launch_and_wait_for_probe.yaml` subflow — before any
flow-specific step ever ran. That is **not** the GMS dialog: `payments-flow-state`
and `action-show` (asserted immediately before it) both passed on all 16
flow executions across the 4 shards, which means the branch's `tapOn: {text:
"OK", optional: true}` mitigation is effective at dismissing the dialog.

The actual blocker is a second, unrelated, pre-existing bug: the subflow
bare-`assertVisible`s the `event-log` container right after launch, but that
section sits below the fold on Redroid's screen profile
(`w360dp h640dp` per `dumpsys activity top` in the run's artifacts) —
confirmed visually: `final-screen.png` for every failing shard is cropped
right after the three action buttons, before the "Event log" heading ever
renders. It was masked until now because every prior run failed earlier, at
the dialog itself.

I independently confirmed the dialog is still live on #550: its latest
completed Android run
([31262116308](https://github.com/rnw-community/rnw-community/actions/runs/31262116308))
fails all 4 shards with `Assertion is false: "idle", id: payments-flow-state
is visible` — i.e. the *full* pre-mitigation failure, plus
`GoogleApiAvailability: Google Play services is invalid. Cannot recover.` in
logcat at the exact moment `MainActivity` displays. Commented this on #550
with a pointer to this PR.

## The GMS problem — verdict: yes, this is a product bug

`PaymentsModule.canMakePayments`/`hasEnrolledInstrument`/`show` called
straight into `Wallet.getPaymentsClient(...).isReadyToPay()`/`loadPaymentData()`
with no availability check. `Wallet.getPaymentsClient(...)` itself never
fails; it's that chained call that reaches into Play services, and when Play
services is missing or invalid, Play services' own fallback UI turns the
failure into a full-screen, unrecoverable system dialog instead of failing
the task. The example app's `usePaymentDemo` hook calls `canMakePayment()`
unconditionally on mount, so **any real device without valid Google Play
Services would see this exact intrusive dialog just from opening the demo
screen** — not a CI artifact, a real UX bug for users on Play-Services-less
Android hardware (AOSP forks, some regional devices, de-Googled ROMs).

Fix, at what I judge the right layer: `PaymentsModule.java` now checks
`GoogleApiAvailability.isGooglePlayServicesAvailable()` before the
GMS-dependent chained call, in both the `canMakePayments`/`hasEnrolledInstrument`
path and `show()`. On an unavailable/invalid result it resolves/rejects like
any other unsupported configuration — exactly the outcome Google's own
guidance (https://developers.google.com/android/guides/api-client)
recommends for any Play services caller, and it fixes the dialog for real
users, not just Redroid.

I considered and rejected the other two options from the task brief:
- **Dismiss-only in the e2e subflow** (#457's original approach): works, but
  leaves the real product bug in place for actual users.
- **Handle it in the shared `mobile-ci` Redroid action** (e.g. bundling a
  GApps-flashed Redroid image): would fix CI only, not the product, and
  raises its own licensing/complexity questions for a shared reusable
  action used by other consumers.

The e2e subflow's `tapOn: {text: "OK", optional: true}` dismissal is kept as
a defensive, no-op-when-absent fallback — the same pattern
`subflows/show_request.yaml` already used for the `action-show` tap before
this PR, now applied consistently to the mount-time probe too.

## What's rescued from #457, and what's intentionally left behind

Checked all three items the maintainer's comments flagged, against current
master and #550:

| Item | Verdict |
| --- | --- |
| Bare app's `android/app/build.gradle` + `settings.gradle` (hermesCommand / gradle-plugin `includeBuild` path fixes) | **Skipped — already in #550, byte-identical diff against master.** Nothing to port. |
| `.gitignore` additions | **Skipped — already landed on master** (diff against #457's branch is empty). |
| GMS-dialog handling in the e2e subflow | **Rescued and corrected**: kept as defense-in-depth per the verdict above, plus the unrelated below-the-fold `event-log` bug fixed so the suite can actually reach flow-specific steps. |
| e2e readme documentation | **Rescued and rewritten** to describe the actual fix (native guard + defensive dismissal) rather than the original dismiss-only mitigation, plus the `event-log` scroll fix. |

No CI/workflow YAML is touched by this PR — that surface belongs to #550 and
`mobile-ci`.

## Known follow-up risk (not fixed here, flagged for visibility)

The small Redroid screen size likely exposes more below-the-fold
assert/tap risk elsewhere in the same e2e suite (e.g.
`reset_new_request_state_transitions.yaml` taps `action-reset` without a
preceding scroll, right after a previous step scrolled deep into the event
log). I did not blind-fix these — I have direct artifact evidence for the
two defects fixed in this PR, but not for anything further down the suite.
Recommend re-validating the full suite against a real Redroid run once this
lands, per #550's own smoke-test loop, before spending more effort here.

## Verification

- `yarn ts`, `yarn ts:nodenext`, `yarn lint`, `yarn test` all pass repo-wide.
- The `PaymentsModule.java` change cannot be compiled/verified locally (no
  Android SDK in this environment); it mirrors the existing file's own
  `com.google.android.gms.common.api.Status` import (same `play-services-wallet`
  transitive dependency graph provides `common.ConnectionResult` /
  `common.GoogleApiAvailability`) and preserves the existing
  resolve/reject/error-code shape of both call sites it touches.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard Android Google Pay against missing Play services and fix e2e scroll failures
> - Adds `isGooglePlayServicesUnavailable()` helper in [`PaymentsModule.java`](https://github.com/rnw-community/rnw-community/pull/552/files#diff-cf6f87ae1550312f3f526240d16a9155a44d1cc095e8cc55b07c2546de378a4b); `checkIsReadyToPay` and `show` now reject immediately with error codes instead of triggering a blocking system dialog when Play services are absent.
> - The [`launch_and_wait_for_probe.yaml`](https://github.com/rnw-community/rnw-community/pull/552/files#diff-e1ef38a4fff2d05a0410f4265d8a4607af7fe17bfd8f1205ee05ff616f5c8ccb) subflow adds an optional tap of the "OK" system dialog on Android after app launch to prevent e2e hangs on Redroid (which lacks Play services).
> - The [`can_make_payment_probe.yaml`](https://github.com/rnw-community/rnw-community/pull/552/files#diff-106b90cfa8d4d92bb5c9ff5352f84de9cda03c1d8736ea9eadf3629218ae958f) Android flow scrolls to `event-log-count` before asserting its visibility, fixing false failures when the element is below the fold.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 34715b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android payment capability checks when Google Play Services is unavailable.
  * Prevented payment actions from triggering blocking system dialogs on unsupported devices.
  * Payment availability checks now return unsupported status, while payment display reports a clear failure.

* **Documentation**
  * Updated Android payment behavior and compatibility guidance.
  * Improved end-to-end test flows for Android dialogs, scrolling, and event-log verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->