### PR TITLE
ci: bound mobile e2e steps so a dead device cannot hold the fleet

### DIFF
--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -75,7 +75,10 @@ jobs:
         needs: detect
         if: needs.detect.outputs.payments_affected == 'true'
         runs-on: [self-hosted, linux-tiered, linux-xl]
-        timeout-minutes: 75
+        # Self-hosted fleet capacity is shared with other repositories, so both the
+        # job and every step below carry an explicit bound. See the step comments
+        # for how each number was sized.
+        timeout-minutes: 65
         strategy:
             fail-fast: false
             matrix:
@@ -87,32 +90,48 @@ jobs:
         steps:
             -   name: Checkout repository
                 uses: actions/checkout@v5
+                timeout-minutes: 10
 
             -   name: Setup Node
                 uses: actions/setup-node@v5
+                timeout-minutes: 10
                 with:
                     node-version: 22.x
                     cache: yarn
 
             -   name: Enable corepack
+                timeout-minutes: 5
                 run: corepack enable
 
             -   name: Install dependencies
+                timeout-minutes: 15
                 run: yarn install --immutable
 
             -   name: Build workspace JS dependencies
+                timeout-minutes: 10
                 run: yarn build --filter=@rnw-community/react-native-payments
 
             -   name: Generate native project (expo)
                 if: matrix.target == 'expo'
+                timeout-minutes: 10
                 working-directory: ${{ env.EXAMPLE_DIR }}
                 run: yarn prebuild:expo
 
             -   name: Set up Android SDK
                 uses: android-actions/setup-android@v3
+                timeout-minutes: 15
+                with:
+                    # The action still defaults to "tools platform-tools", but the
+                    # obsolete "tools" package was withdrawn from the Google SDK
+                    # repository, so sdkmanager exits 1 with "Dependant package with
+                    # key emulator not found!". android-emulator-runner installs the
+                    # emulator and system images it needs by itself, so platform-tools
+                    # is the only package this workflow has to request.
+                    packages: platform-tools
 
             -   name: Restore Gradle cache
                 uses: actions/cache@v4
+                timeout-minutes: 10
                 with:
                     path: |
                         ~/.gradle/caches
@@ -122,6 +141,7 @@ jobs:
                         gradle-${{ matrix.target }}-${{ runner.os }}-
 
             -   name: Install Maestro
+                timeout-minutes: 10
                 run: |
                     maestro_bin="$HOME/.maestro/bin/maestro"
                     if [ ! -x "$maestro_bin" ] || [ "$("$maestro_bin" --version 2>/dev/null | tail -n 1 | tr -d '\r' || true)" != "$MAESTRO_VERSION" ]; then
@@ -130,7 +150,12 @@ jobs:
                     echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
 
             -   name: Boot emulator, build, install, and test
+                id: emulator
                 uses: reactivecircus/android-emulator-runner@v2.38.0
+                # System image download + AVD creation + cold boot + a cold Gradle
+                # release build + the Maestro suite. 50 minutes leaves the rest of the
+                # job roughly 15 minutes of the 65 minute job budget.
+                timeout-minutes: 50
                 with:
                     api-level: 34
                     target: google_apis
@@ -143,27 +168,37 @@ jobs:
                     script: |
                         set -euo pipefail
                         set -x
-                        adb wait-for-device
+                        timeout 300 adb wait-for-device
                         timeout 180 bash -c 'until [ "$(adb shell getprop sys.boot_completed | tr -d "\r")" = "1" ]; do sleep 2; done'
                         (cd "${{ env.APP_DIR }}/android" && ./gradlew assembleRelease)
                         apk=$(find "${{ env.APP_DIR }}/android/app/build/outputs/apk/release" -name '*.apk' | head -1)
-                        adb install -r "$apk"
+                        timeout 300 adb install -r "$apk"
                         cd "${{ env.EXAMPLE_DIR }}"
                         yarn e2e:android:${{ matrix.target }}
 
             -   name: Capture final device state
-                if: failure()
+                # Only meaningful when the emulator step actually ran and failed. If
+                # Android SDK setup (or anything before it) failed, this step is
+                # skipped instead of talking to an adb server that has no device.
+                if: failure() && steps.emulator.outcome == 'failure'
+                # A diagnostic must never outlive the test it is diagnosing.
+                timeout-minutes: 3
                 shell: bash
                 run: |
                     out="${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}"
                     mkdir -p "$out"
-                    adb exec-out screencap -p > "$out/final-screen.png" || true
-                    adb logcat -d > "$out/logcat-full.txt" 2>&1 || true
-                    adb logcat -d -b crash > "$out/logcat-crash.txt" 2>&1 || true
+                    if ! timeout 30 adb wait-for-device; then
+                      echo "No device attached after 30s; skipping device state capture."
+                      exit 0
+                    fi
+                    timeout 30 adb exec-out screencap -p > "$out/final-screen.png" || true
+                    timeout 60 adb logcat -d > "$out/logcat-full.txt" 2>&1 || true
+                    timeout 30 adb logcat -d -b crash > "$out/logcat-crash.txt" 2>&1 || true
 
             -   name: Upload Maestro artifacts
-                if: failure()
+                if: failure() && steps.emulator.outcome == 'failure'
                 uses: actions/upload-artifact@v4
+                timeout-minutes: 5
                 with:
                     name: maestro-android-${{ matrix.target }}
                     path: ${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}/**

--- a/.github/workflows/ios-maestro.yml
+++ b/.github/workflows/ios-maestro.yml
@@ -75,6 +75,9 @@ jobs:
         needs: detect
         if: needs.detect.outputs.payments_affected == 'true'
         runs-on: [self-hosted, macOS, ARM64, macos-maestro]
+        # Self-hosted fleet capacity is shared with other repositories, so both the
+        # job and every step below carry an explicit bound. See the step comments
+        # for how each number was sized.
         timeout-minutes: 60
         strategy:
             fail-fast: false
@@ -87,24 +90,30 @@ jobs:
         steps:
             -   name: Checkout repository
                 uses: actions/checkout@v5
+                timeout-minutes: 10
 
             -   name: Setup Node
                 uses: actions/setup-node@v5
+                timeout-minutes: 10
                 with:
                     node-version: 22.x
                     cache: yarn
 
             -   name: Enable corepack
+                timeout-minutes: 5
                 run: corepack enable
 
             -   name: Install dependencies
+                timeout-minutes: 15
                 run: yarn install --immutable
 
             -   name: Verify Xcode toolchain
+                timeout-minutes: 5
                 run: xcodebuild -version
 
             -   name: Restore CocoaPods global cache
                 uses: actions/cache@v4
+                timeout-minutes: 10
                 with:
                     path: |
                         ~/Library/Caches/CocoaPods
@@ -115,6 +124,7 @@ jobs:
 
             -   name: Restore project Pods and DerivedData cache
                 uses: actions/cache@v4
+                timeout-minutes: 10
                 with:
                     path: |
                         ${{ env.APP_DIR }}/ios/Pods
@@ -124,24 +134,32 @@ jobs:
                         pods-project-ios-${{ matrix.target }}-${{ runner.os }}-
 
             -   name: Build workspace JS dependencies
+                timeout-minutes: 10
                 run: yarn build --filter=@rnw-community/react-native-payments
 
             -   name: Generate native project (expo)
                 if: matrix.target == 'expo'
+                timeout-minutes: 10
                 working-directory: ${{ env.EXAMPLE_DIR }}
                 run: yarn prebuild:expo
 
             -   name: Install CocoaPods dependencies (bare)
                 if: matrix.target == 'bare'
+                timeout-minutes: 20
                 working-directory: ${{ env.APP_DIR }}/ios
                 run: pod install --repo-update
 
             -   name: Install CocoaPods dependencies (expo)
                 if: matrix.target == 'expo'
+                timeout-minutes: 20
                 working-directory: ${{ env.APP_DIR }}/ios
                 run: pod install --repo-update
 
             -   name: Boot iOS Simulator
+                id: simulator
+                # Observed 34-39s across recent runs; 10 minutes is generous headroom
+                # for a cold simulator runtime.
+                timeout-minutes: 10
                 shell: bash
                 run: |
                     set -euo pipefail
@@ -151,11 +169,15 @@ jobs:
                     test -n "$device_udid"
                     echo "Booting simulator: $device_line"
                     xcrun simctl boot "$device_udid" || true
-                    xcrun simctl bootstatus "$device_udid" -b
+                    # `bootstatus -b` blocks forever on a wedged simulator, and macOS
+                    # ships no timeout(1), so bound it with a perl alarm (pending
+                    # alarms survive exec, so SIGALRM kills simctl on expiry).
+                    perl -e 'alarm 300; exec @ARGV' xcrun simctl bootstatus "$device_udid" -b
                     echo "SIMULATOR_UDID=$device_udid" >> "$GITHUB_ENV"
 
             -   name: Build app (bare)
                 if: matrix.target == 'bare'
+                timeout-minutes: 45
                 working-directory: ${{ env.APP_DIR }}/ios
                 run: |
                     set -euo pipefail
@@ -172,6 +194,7 @@ jobs:
 
             -   name: Build app (expo)
                 if: matrix.target == 'expo'
+                timeout-minutes: 45
                 working-directory: ${{ env.APP_DIR }}/ios
                 run: |
                     set -euo pipefail
@@ -187,9 +210,11 @@ jobs:
                     echo "APP_PATH=${{ env.APP_DIR }}/ios/build/Build/Products/Release-iphonesimulator/reactnativepaymentsexpoexample.app" >> "$GITHUB_ENV"
 
             -   name: Install app on simulator
+                timeout-minutes: 10
                 run: xcrun simctl install "$SIMULATOR_UDID" "$APP_PATH"
 
             -   name: Install Maestro
+                timeout-minutes: 10
                 run: |
                     maestro_bin="$HOME/.maestro/bin/maestro"
                     if [ ! -x "$maestro_bin" ] || [ "$("$maestro_bin" --version 2>/dev/null | tail -n 1 | tr -d '\r' || true)" != "$MAESTRO_VERSION" ]; then
@@ -198,23 +223,33 @@ jobs:
                     echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
 
             -   name: Run Maestro suite
+                # The suite itself took ~85s per shard on the Redroid prototype runs;
+                # 25 minutes covers a slow retry loop without holding the fleet.
+                timeout-minutes: 25
                 working-directory: ${{ env.EXAMPLE_DIR }}
                 run: yarn e2e:ios:${{ matrix.target }}
 
             -   name: Capture final simulator state
-                if: failure()
+                # Pointless unless a simulator actually booted: without it
+                # SIMULATOR_UDID is unset and simctl has nothing to talk to.
+                if: failure() && steps.simulator.outcome == 'success'
+                timeout-minutes: 3
                 shell: bash
                 run: |
                     mkdir -p "${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}"
                     xcrun simctl io "$SIMULATOR_UDID" screenshot "${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}/final-screen.png" || true
 
             -   name: Shutdown simulator
-                if: always()
+                # always() is right here (the simulator must be released even when the
+                # job is cancelled) but only once a boot actually happened.
+                if: always() && steps.simulator.outcome == 'success'
+                timeout-minutes: 3
                 run: xcrun simctl shutdown "$SIMULATOR_UDID" || true
 
             -   name: Upload Maestro artifacts
-                if: failure()
+                if: failure() && steps.simulator.outcome == 'success'
                 uses: actions/upload-artifact@v4
+                timeout-minutes: 5
                 with:
                     name: maestro-ios-${{ matrix.target }}
                     path: ${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}/**


### PR DESCRIPTION
## Incident

Run [31325708527](https://github.com/rnw-community/rnw-community/actions/runs/31325708527) ("Android Maestro E2E"), job `93275690093` "Maestro (bare)", self-hosted runner `trf-xl-05bbe1c83f21fcd6`:

| step | outcome | window |
|---|---|---|
| 8 — Set up Android SDK | **failure** | 18:08:58Z → 18:09:12Z |
| 9 — Restore Gradle cache | skipped | — |
| 10 — Install Maestro | skipped | — |
| 11 — Boot emulator, build, install, and test | skipped | — |
| 12 — Capture final device state | **cancelled after 73m 38s** | 18:09:12Z → 19:22:50Z |

The job died at the 1h15m cap. Step 12's entire log output is:

```
* daemon not running; starting now at tcp:5037
* daemon started successfully
error: no devices/emulators found
```

…then 73 minutes of silence, ending in `Terminate orphan process: pid (2255) (adb)`. The step was blocked on `adb logcat -d` against an adb server with no device, because the SDK setup that would have produced one had failed 0 seconds earlier.

**Cost:** 6 CPU and 12 GB — 60% of the shared self-hosted Mac mini's scheduling envelope — held for ~75 minutes producing nothing, delaying other repositories by over an hour.

**This was not a one-off.** Every `android-maestro.yml` run since at least 2026-08-05 shows the identical shape. Sampled from the API:

| run | step 8 | step 12 held for |
|---|---|---|
| 31326032799 (bare) | failure | 74m 19s |
| 31326032799 (expo) | failure | 74m 18s |
| 31309189810 (bare) | failure | 73m 17s |
| 31308963380 (bare) | failure | 74m 1s |
| 31298643615 (bare) | failure | 73m 29s |
| 31295385999 (bare) | failure | 73m 54s |
| 31191409212 (expo) | failure | 73m 25s |
| 31150381575 (bare) | failure | 73m 59s |
| 31076636094 (expo) | failure | 74m 21s |
| 31040987828 (bare) | failure | 73m 55s |

Both matrix targets hang on every run, so each PR touching the payments tree burned roughly **2.5 fleet-hours** for zero signal.

## Root cause of the "Set up Android SDK" failure

Repository-side, not a fleet image problem. `android-actions/setup-android@v3` defaults to `packages: 'tools platform-tools'`. The `tools` package was withdrawn from the Google SDK repository, so `sdkmanager tools` prints

```
Warning: Dependant package with key emulator not found!
Warning: Unable to compute a complete list of dependencies.
Error: The process '.../sdkmanager' failed with exit code 1
```

This PR requests `packages: platform-tools` explicitly. `reactivecircus/android-emulator-runner` installs the emulator binary and system images it needs itself, so `tools` was never required here.

**Nothing about the runner image needs to change** for this failure — the image supplied a working JDK, `unzip`, network access, and `sdkmanager` ran fine; it just refused an obsolete package name the workflow asked for.

## Changes

### 1. `if: always()` / bare `if: failure()` cleanup now guards on a real precondition

- Android "Capture final device state" and "Upload Maestro artifacts": `if: failure()` → `if: failure() && steps.emulator.outcome == 'failure'`. When the SDK setup (or anything earlier) fails, the emulator step is *skipped*, so `outcome` is `skipped` and these are skipped too. A device screenshot from a device that never booted has no diagnostic value.
- iOS "Capture final simulator state" / "Upload Maestro artifacts": same gate on `steps.simulator.outcome == 'success'`. Without a boot, `SIMULATOR_UDID` is unset and `simctl` has nothing to talk to.
- iOS "Shutdown simulator" keeps `always()` — releasing a simulator must survive cancellation — but is now `always() && steps.simulator.outcome == 'success'`.

### 2. Every step in both self-hosted jobs is bounded

Android (`.github/workflows/android-maestro.yml`):

| step | timeout | why |
|---|---|---|
| Boot emulator, build, install, and test | **50** | system image download + AVD create + cold boot + cold Gradle release build + Maestro suite; the only step that legitimately needs tens of minutes. Sized to leave ~15 min of the 65 min job budget for everything else. |
| Set up Android SDK | 15 | observed 4–20 s (11 s of that is the cmdline-tools download); 15 min tolerates a slow `dl.google.com`. |
| Install dependencies | 15 | observed 28 s. |
| Install Maestro | 10 | observed 6–37 s; the installer is `curl \| bash` over the network. |
| Checkout / Setup Node / cache / build / prebuild | 10 | observed 2–23 s each. |
| **Capture final device state** | **3** | a diagnostic must never outlive the test it was diagnosing. This is the step that cost 73 minutes. |
| Upload Maestro artifacts | 5 | small artifact set. |
| Enable corepack | 5 | instantaneous. |
| *job* | 75 → **65** | the emulator step (50) plus the observed ~2 min of preamble plus generous cache/upload slack. The job cap is now a backstop, not the primary bound. |

iOS (`.github/workflows/ios-maestro.yml`):

| step | timeout | why |
|---|---|---|
| Build app (bare) / Build app (expo) | 45 each | mutually exclusive on `matrix.target`; a cold `xcodebuild` Release build of an RN app is the long pole. No successful build exists in run history to measure, so this is a deliberately generous ceiling rather than a measured one. |
| Run Maestro suite | 25 | the suite ran ~85 s per shard on the Redroid prototype jobs; 25 min absorbs retries. |
| Install CocoaPods dependencies | 20 | observed 11–58 s, but `--repo-update` hits the network and the specs repo can be slow. |
| Boot iOS Simulator | 10 | observed 34–39 s across recent runs. |
| Install app on simulator / Install Maestro | 10 | seconds in practice. |
| Install dependencies | 15 | observed ~20–28 s. |
| **Capture final simulator state**, **Shutdown simulator** | **3** each | cleanup/diagnostic — single-digit by policy. |
| Upload Maestro artifacts | 5 | small artifact set. |
| Verify Xcode toolchain / corepack | 5 | one-second commands. |
| *job* | 60 (unchanged) | still comfortably above the sum of the realistic path; kept as a backstop. |

Job-level `timeout-minutes` audit: these two jobs are the **only** ones in the repo on `runs-on: [self-hosted, ...]`, and both already had a job-level bound. No unbounded self-hosted job exists.

### 3. Bounded `adb` forms

Even under `timeout-minutes`, a wedged `adb` should not consume the whole allowance:

- `adb wait-for-device` → `timeout 300 adb wait-for-device`
- `adb install -r "$apk"` → `timeout 300 adb install -r "$apk"`
- capture step: a `timeout 30 adb wait-for-device` probe that `exit 0`s with a message when no device attaches, then `timeout 30 / 60 / 30` on `screencap`, `logcat -d`, `logcat -d -b crash`. Worst case is now ~2.5 min instead of 73.

The Android job runs on Linux (`/usr/bin/bash`, `/home/admin/...`), so coreutils `timeout` is available.

- iOS: `xcrun simctl bootstatus -b` blocks indefinitely on a wedged simulator, so it is wrapped in `perl -e 'alarm 300; exec @ARGV'`. **macOS ships no `timeout(1)`**, so using it there would have turned a hang into a `command not found` failure; pending POSIX alarms survive `exec`, so the perl form is the portable equivalent. All other macOS steps rely on `timeout-minutes`, which is already tight for the cleanup steps.

## Verified with `actionlint` v1.7.7 — clean on both files.

## Found but deliberately not changed

- **`claude.yml` and `pr-closed-cleanup.yml` have no job-level `timeout-minutes`.** Both run on `ubuntu-latest` (GitHub-hosted), so they cannot starve the self-hosted fleet and GitHub's own 6-hour cap applies. Out of scope for this incident; worth a separate hygiene PR.
- **`android-actions/setup-android@v3` targets Node 20** and is force-run on Node 24 with a deprecation warning. Cosmetic, upstream's to fix.
- **The `ci/full-mobile-ci-migration` branch is rebuilding this pipeline around Redroid containers** with a different job shape (`Maestro shard N (target)`). This PR deliberately does not touch that work — it fixes the workflows on `master`, which are what is actually burning fleet capacity today. If that migration lands, the same three rules (per-step bounds, precondition-gated cleanup, bounded `adb`) need re-applying there.
- **`Install Maestro` pipes `curl` into `bash` without `--max-time`.** The 10-minute step bound covers the hang case; adding curl-level retry/timeout tuning is a separate concern.
- **The Gradle cache `restore-keys` fall back across commits**, which can restore a stale cache. Unrelated to the hang.
- **No emulator step has ever completed successfully in this workflow's recorded history**, so the 50-minute Android and 45-minute iOS build bounds are reasoned ceilings, not measurements. They should be tightened once a green run exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound mobile E2E CI steps to prevent dead devices from holding the runner fleet
> - Adds explicit `timeout-minutes` to most steps in both [android-maestro.yml](.github/workflows/android-maestro.yml) and [ios-maestro.yml](.github/workflows/ios-maestro.yml), and reduces the Android job-level timeout from 75 to 65 minutes.
> - Wraps `adb wait-for-device` and `adb install` with `timeout 300` on Android; replaces blocking `xcrun simctl bootstatus -b` with a Perl alarm-bounded 300-second wait on iOS.
> - Scopes artifact capture and upload to only run when the emulator/simulator step ran and failed, avoiding unnecessary work on clean passes.
> - Behavioral Change: Android SDK setup now installs only `platform-tools` instead of a broader package set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 674be17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android and iOS automated testing reliability by adding explicit time limits to jobs and individual steps.
  * Prevented test workflows from hanging indefinitely during emulator or simulator startup, device readiness checks, and app installation.
  * Enhanced failure diagnostics and ensured diagnostic artifacts are collected when test environments fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->