### PR TITLE
ci: boot redroid 15.0.0_64only from the fleet's prewarmed /data (#545)

### DIFF
--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -1,9 +1,25 @@
 name: Android Maestro E2E
 
-# Runs the Maestro suite of every example package that carries one, on the
-# self-hosted Linux fleet (issue #395, epic #372). The package/target matrix comes
-# from .github/scripts/maestro-matrix.mjs, which also decides which suites a pull
-# request actually needs; add new example packages there, not here.
+# Runs the Maestro suite of every example package that carries one. Building the
+# APK and running it against Redroid happen on two different runner pools, and
+# that split is load-bearing, not stylistic:
+#
+# - build-apk runs on a free GitHub-hosted ubuntu-24.04 (x86_64) runner. Native
+#   Android builds need the NDK's host clang, and Google publishes
+#   linux-x86_64 prebuilts only — no NDK release has ever shipped a
+#   linux-aarch64 host toolchain — so a Gradle build that touches native code
+#   cannot succeed on this repo's arm64 self-hosted fleet at all (confirmed
+#   live: "C compiler identification is unknown",
+#   toolchains/llvm/prebuilt/linux-x86_64/bin/clang missing). This repo is
+#   public, so the GitHub-hosted runner costs nothing.
+# - maestro runs on the self-hosted Linux fleet (issue #395, epic #372) purely
+#   to install the prebuilt APK into Redroid (Android-in-a-privileged-container,
+#   the fleet's only arm64-native way to run Android at all) and drive Maestro.
+#   No Gradle, SDK, or NDK step belongs in this job.
+#
+# The package/target matrix comes from .github/scripts/maestro-matrix.mjs,
+# which also decides which suites a pull request actually needs; add new
+# example packages there, not here.
 on:
     workflow_dispatch:
     pull_request:
@@ -68,36 +84,21 @@ jobs:
                     fi
                   fi
                   node .github/scripts/maestro-matrix.mjs affected.json | tee -a "$GITHUB_OUTPUT"
-    maestro:
-        name: Maestro (${{ matrix.package }}, ${{ matrix.target }})
+
+    build-apk:
+        name: Build APK (${{ matrix.package }}, ${{ matrix.target }})
         needs: detect
         if: needs.detect.outputs.any == 'true'
-        runs-on: [self-hosted, linux-tiered, linux-xl]
-        # Self-hosted fleet capacity is shared with other repositories, so both the
-        # job and every step below carry an explicit bound. See the step comments
-        # for how each number was sized.
-        timeout-minutes: 65
+        # x86_64: the NDK's host clang has no arm64-Linux build, so this cannot
+        # run on the self-hosted fleet. See the top-of-file note.
+        runs-on: ubuntu-24.04
+        timeout-minutes: 30
         strategy:
             fail-fast: false
-            # One redroid at a time. Every leg that has ever died mid-boot overlapped
-            # another leg, and upstream reports that a second instance booting on the
-            # same host makes adb unresponsive on both (redroid-doc#904): privileged
-            # containers share the host kernel's binder devices, so the contention is
-            # across runners and no per-container limit can bound it. The legs are
-            # already serialized by fleet capacity most of the time; this makes it a
-            # property of the workflow rather than a coincidence of scheduling.
-            max-parallel: 1
             matrix:
                 include: ${{ fromJSON(needs.detect.outputs.matrix) }}
         env:
             APP_DIR: ${{ matrix.example_dir }}/apps/${{ matrix.target }}
-            MAESTRO_DEBUG_OUTPUT_DIRECTORY: ${{ github.workspace }}/${{ matrix.example_dir }}/artifacts/maestro-android-${{ matrix.package }}-${{ matrix.target }}
-            # Several legs can land on the same self-hosted host, so the container
-            # name is per-leg. The data directory and adb port are derived inside the
-            # redroid step: job-level env cannot read the runner context, and docker
-            # assigns the port.
-            REDROID_CONTAINER: redroid-${{ matrix.package }}-${{ matrix.target }}-${{ github.run_id }}
-
         steps:
             -   name: Checkout repository
                 uses: actions/checkout@v5
@@ -135,17 +136,113 @@ jobs:
                     # The action still defaults to "tools platform-tools", but the
                     # obsolete "tools" package was withdrawn from the Google SDK
                     # repository, so sdkmanager exits 1 with "Dependant package with
-                    # key emulator not found!". Gradle resolves the build tools and
-                    # platform it needs on its own, so platform-tools is the only
-                    # package this workflow has to request.
+                    # key emulator not found!". Gradle resolves the build tools,
+                    # platform, and NDK/cmake it needs on its own on this
+                    # x86_64 host, so platform-tools is the only package this
+                    # workflow has to request.
                     packages: platform-tools
 
-            -   name: Provide a host-architecture adb
-                # Google ships platform-tools for linux-x86_64 only. On the arm64
-                # fleet its adb cannot exec at all — the shell falls back to parsing
-                # the ELF as a script and reports "Syntax error: word unexpected" —
-                # so the distro adb replaces it for every consumer (Gradle, Maestro,
-                # the steps below) through the path the SDK already exports.
+            -   name: Restore Gradle cache
+                uses: actions/cache@v4
+                timeout-minutes: 10
+                with:
+                    path: |
+                        ~/.gradle/caches
+                        ~/.gradle/wrapper
+                    key: gradle-${{ matrix.package }}-${{ matrix.target }}-${{ runner.os }}-${{ hashFiles(format('{0}/android/gradle/wrapper/gradle-wrapper.properties', env.APP_DIR), format('{0}/android/**/*.gradle*', env.APP_DIR), format('{0}/package.json', env.APP_DIR), format('{0}/app.json', env.APP_DIR), 'yarn.lock') }}
+                    restore-keys: |
+                        gradle-${{ matrix.package }}-${{ matrix.target }}-${{ runner.os }}-
+
+            -   name: Build release APK
+                # release, not debug: both example apps sign release with the
+                # checked-in debug keystore (see app/build.gradle,
+                # "Caution! In production, you need to generate your own keystore
+                # file."), so no signing secret is needed here.
+                timeout-minutes: 20
+                shell: bash
+                run: |
+                    set -euo pipefail
+                    set -x
+                    (cd "${{ env.APP_DIR }}/android" && ./gradlew assembleRelease)
+
+            -   name: Upload APK artifact
+                uses: actions/upload-artifact@v4
+                timeout-minutes: 5
+                with:
+                    name: apk-${{ matrix.package }}-${{ matrix.target }}
+                    path: ${{ env.APP_DIR }}/android/app/build/outputs/apk/release/*.apk
+                    if-no-files-found: error
+                    retention-days: 1
+
+    maestro:
+        name: Maestro (${{ matrix.package }}, ${{ matrix.target }})
+        needs: [detect, build-apk]
+        if: needs.detect.outputs.any == 'true'
+        runs-on: [self-hosted, linux-tiered, linux-xl]
+        # Self-hosted fleet capacity is shared with other repositories, so both the
+        # job and every step below carry an explicit bound. See the step comments
+        # for how each number was sized. No Gradle/SDK/NDK step runs here anymore
+        # (see build-apk), so this budget is boot + install + test only.
+        timeout-minutes: 30
+        strategy:
+            fail-fast: false
+            # One redroid at a time. Every leg that has ever died mid-boot overlapped
+            # another leg, and upstream reports that a second instance booting on the
+            # same host makes adb unresponsive on both (redroid-doc#904): privileged
+            # containers share the host kernel's binder devices, so the contention is
+            # across runners and no per-container limit can bound it. The legs are
+            # already serialized by fleet capacity most of the time; this makes it a
+            # property of the workflow rather than a coincidence of scheduling.
+            max-parallel: 1
+            matrix:
+                include: ${{ fromJSON(needs.detect.outputs.matrix) }}
+        env:
+            MAESTRO_DEBUG_OUTPUT_DIRECTORY: ${{ github.workspace }}/${{ matrix.example_dir }}/artifacts/maestro-android-${{ matrix.package }}-${{ matrix.target }}
+            # Several legs can land on the same self-hosted host, so the container
+            # name is per-leg. The data directory and adb port are derived inside the
+            # redroid step: job-level env cannot read the runner context, and docker
+            # assigns the port.
+            REDROID_CONTAINER: redroid-${{ matrix.package }}-${{ matrix.target }}-${{ github.run_id }}
+
+        steps:
+            -   name: Checkout repository
+                uses: actions/checkout@v5
+                timeout-minutes: 10
+
+            -   name: Setup Node
+                uses: actions/setup-node@v5
+                timeout-minutes: 10
+                with:
+                    node-version: 22.x
+                    cache: yarn
+
+            -   name: Enable corepack
+                timeout-minutes: 5
+                run: corepack enable
+
+            -   name: Install dependencies
+                # Needed only so `yarn e2e:android:<target>` (a thin wrapper around
+                # `maestro test`, see the last step) can resolve at all under Yarn
+                # Berry; nothing here builds or bundles JS for the app itself — that
+                # already happened, if at all, in build-apk.
+                timeout-minutes: 15
+                run: yarn install --immutable
+
+            -   name: Download APK artifact
+                uses: actions/download-artifact@v8
+                timeout-minutes: 10
+                with:
+                    name: apk-${{ matrix.package }}-${{ matrix.target }}
+                    path: .ci-artifacts/apk
+
+            -   name: Install adb
+                # Google ships platform-tools for linux-x86_64 only. On this arm64
+                # fleet that adb cannot exec at all — the shell falls back to parsing
+                # the ELF as a script and reports "Syntax error: word unexpected".
+                # Gradle/SDK/NDK provisioning (and that whole problem) moved to
+                # build-apk's x86_64 runner; this job only needs a working adb to
+                # install the prebuilt APK and drive Maestro, so the distro package
+                # is enough on its own — no Android SDK setup at all here.
                 timeout-minutes: 10
                 run: |
                     set -euo pipefail
@@ -153,7 +250,6 @@ jobs:
                       sudo apt-get update -y
                       sudo apt-get install -y adb
                     fi
-                    sudo ln -sf /usr/bin/adb "$ANDROID_HOME/platform-tools/adb"
                     adb version
 
             -   name: Start redroid container
@@ -284,17 +380,6 @@ jobs:
                     done'
                     adb devices -l
 
-            -   name: Restore Gradle cache
-                uses: actions/cache@v4
-                timeout-minutes: 10
-                with:
-                    path: |
-                        ~/.gradle/caches
-                        ~/.gradle/wrapper
-                    key: gradle-${{ matrix.package }}-${{ matrix.target }}-${{ runner.os }}-${{ hashFiles(format('{0}/android/gradle/wrapper/gradle-wrapper.properties', env.APP_DIR), format('{0}/android/**/*.gradle*', env.APP_DIR), format('{0}/package.json', env.APP_DIR), format('{0}/app.json', env.APP_DIR), 'yarn.lock') }}
-                    restore-keys: |
-                        gradle-${{ matrix.package }}-${{ matrix.target }}-${{ runner.os }}-
-
             -   name: Install Maestro
                 timeout-minutes: 10
                 run: |
@@ -319,45 +404,19 @@ jobs:
                     curl -fsSL https://get.maestro.mobile.dev | env MAESTRO_VERSION="$MAESTRO_VERSION" bash
                     echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
 
-            -   name: Provide an arm64-native cmake for AGP
-                # The Android SDK's own cmake packages (every version through at
-                # least 4.1.2, checked against dl.google.com's repository manifest)
-                # ship a single generic "linux" archive per version — there is no
-                # linux_aarch64 host entry, and that archive is x86_64-only. On this
-                # arm64 host the shell falls back to interpreting the ELF as a
-                # script, so CMake configure fails with `Syntax error: ")"
-                # unexpected` the moment AGP invokes the SDK-downloaded cmake — this
-                # step never ran before the redroid fix above, so it was undiscovered
-                # until the first live validation reached it. apt ships a native
-                # arm64 build of both cmake and ninja-build well above the >=3.13
-                # react-native's CMakeLists.txt requires, so AGP is pointed at that
-                # install via `cmake.dir` in local.properties instead of letting it
-                # download its own — workflow-only, never committed (this repo does
-                # not track local.properties for any example app).
-                timeout-minutes: 10
-                run: |
-                    set -euo pipefail
-                    if ! dpkg -s cmake >/dev/null 2>&1 || ! dpkg -s ninja-build >/dev/null 2>&1; then
-                      sudo apt-get update -y
-                      sudo apt-get install -y cmake ninja-build
-                    fi
-                    command -v cmake >/dev/null && command -v ninja >/dev/null
-                    cmake --version | head -1
-                    ninja --version
-                    echo "cmake.dir=/usr" >> "${{ env.APP_DIR }}/android/local.properties"
-
-            -   name: Build, install, and test
+            -   name: Install APK and run Maestro tests
                 id: emulator
-                # A cold Gradle release build plus the Maestro suite. redroid is
-                # already booted by the previous step, so this budget is build and
-                # test only, leaving the rest of the 65 minute job budget for setup.
-                timeout-minutes: 45
+                # redroid is already booted (previous step) and the APK is already
+                # built (build-apk, a GitHub-hosted x86_64 runner — see the
+                # top-of-file note on why native builds can't run here). This step
+                # is install + test only.
+                timeout-minutes: 20
                 shell: bash
                 run: |
                     set -euo pipefail
                     set -x
-                    (cd "${{ env.APP_DIR }}/android" && ./gradlew assembleRelease)
-                    apk=$(find "${{ env.APP_DIR }}/android/app/build/outputs/apk/release" -name '*.apk' | head -1)
+                    apk=$(find .ci-artifacts/apk -name '*.apk' | head -1)
+                    test -n "$apk"
                     timeout 300 adb -s "127.0.0.1:$ADB_PORT" install -r "$apk"
                     cd "${{ matrix.example_dir }}"
                     yarn e2e:android:${{ matrix.target }}
@@ -414,7 +473,7 @@ jobs:
 
     status:
         name: Android Maestro E2E result
-        needs: [detect, maestro]
+        needs: [detect, build-apk, maestro]
         if: always()
         runs-on: ubuntu-latest
         steps:
@@ -427,6 +486,10 @@ jobs:
                   if [ "${{ needs.detect.outputs.any }}" != "true" ]; then
                     echo "Skipped: no example package dependency tree was touched."
                     exit 0
+                  fi
+                  if [ "${{ needs.build-apk.result }}" != "success" ]; then
+                    echo "APK build failed."
+                    exit 1
                   fi
                   if [ "${{ needs.maestro.result }}" != "success" ]; then
                     echo "Maestro suite failed."

--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -153,6 +153,32 @@ jobs:
                     restore-keys: |
                         gradle-${{ matrix.package }}-${{ matrix.target }}-${{ runner.os }}-
 
+            -   name: Ensure the Hermes compiler binary is executable
+                # .yarnrc.yml sets enableScripts: false repo-wide (deliberate
+                # supply-chain hardening — see the sec/public-repo-hardening
+                # history), which also skips whatever lifecycle script would
+                # otherwise mark react-native's bundled hermesc executable after
+                # extraction. This app has never built on any CI in this repo's
+                # history, so this was undiscovered until this run failed with
+                # "Couldn't determine Hermesc location" (a literal unsubstituted
+                # "%OS-BIN%" in the error). Logs the directory contents either way
+                # so a wrong guess here is visible in the same run rather than
+                # silent; chmod, not re-enabling scripts, keeps the hardening intact.
+                timeout-minutes: 5
+                run: |
+                    set -euo pipefail
+                    hermesc_root="node_modules/react-native/sdks/hermesc"
+                    echo "::group::hermesc directory"
+                    find "$hermesc_root" -maxdepth 2 -exec ls -la {} \; 2>&1 || echo "$hermesc_root not found"
+                    echo "::endgroup::"
+                    hermesc_dir=$(find "$hermesc_root" -maxdepth 1 -type d -name '*64-bin' 2>/dev/null | head -1)
+                    if [ -n "$hermesc_dir" ] && [ -f "$hermesc_dir/hermesc" ]; then
+                      chmod +x "$hermesc_dir/hermesc"
+                      "$hermesc_dir/hermesc" --version || true
+                    else
+                      echo "::warning::No hermesc binary found under $hermesc_root; the Gradle build below will report the real cause."
+                    fi
+
             -   name: Build release APK
                 # release, not debug: both example apps sign release with the
                 # checked-in debug keystore (see app/build.gradle,

--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -153,32 +153,6 @@ jobs:
                     restore-keys: |
                         gradle-${{ matrix.package }}-${{ matrix.target }}-${{ runner.os }}-
 
-            -   name: Ensure the Hermes compiler binary is executable
-                # .yarnrc.yml sets enableScripts: false repo-wide (deliberate
-                # supply-chain hardening — see the sec/public-repo-hardening
-                # history), which also skips whatever lifecycle script would
-                # otherwise mark react-native's bundled hermesc executable after
-                # extraction. This app has never built on any CI in this repo's
-                # history, so this was undiscovered until this run failed with
-                # "Couldn't determine Hermesc location" (a literal unsubstituted
-                # "%OS-BIN%" in the error). Logs the directory contents either way
-                # so a wrong guess here is visible in the same run rather than
-                # silent; chmod, not re-enabling scripts, keeps the hardening intact.
-                timeout-minutes: 5
-                run: |
-                    set -euo pipefail
-                    hermesc_root="node_modules/react-native/sdks/hermesc"
-                    echo "::group::hermesc directory"
-                    find "$hermesc_root" -maxdepth 2 -exec ls -la {} \; 2>&1 || echo "$hermesc_root not found"
-                    echo "::endgroup::"
-                    hermesc_dir=$(find "$hermesc_root" -maxdepth 1 -type d -name '*64-bin' 2>/dev/null | head -1)
-                    if [ -n "$hermesc_dir" ] && [ -f "$hermesc_dir/hermesc" ]; then
-                      chmod +x "$hermesc_dir/hermesc"
-                      "$hermesc_dir/hermesc" --version || true
-                    else
-                      echo "::warning::No hermesc binary found under $hermesc_root; the Gradle build below will report the real cause."
-                    fi
-
             -   name: Build release APK
                 # release, not debug: both example apps sign release with the
                 # checked-in debug keystore (see app/build.gradle,

--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -166,8 +166,13 @@ jobs:
                 timeout-minutes: 15
                 run: |
                     set -euo pipefail
+                    REDROID_IMAGE='redroid/redroid:15.0.0_64only-latest'
                     if [ ! -d /dev/binderfs ] && ! lsmod | grep -q '^binder_linux'; then
-                      echo "::error::redroid needs binder on the host. Load it on the runner: sudo modprobe binder_linux devices=binder,hwbinder,vndbinder"
+                      echo "binder_linux is not loaded; loading it now: modprobe binder_linux devices=binder,hwbinder,vndbinder"
+                      sudo modprobe binder_linux devices=binder,hwbinder,vndbinder || true
+                    fi
+                    if [ ! -d /dev/binderfs ] && ! lsmod | grep -q '^binder_linux'; then
+                      echo "::error::redroid needs a functional binder on the host and modprobe binder_linux devices=binder,hwbinder,vndbinder did not bring it up. Failing closed instead of booting redroid without binder — that false-positive precondition is what took eight runners down."
                       exit 1
                     fi
                     # Every wait below can only fail as a timeout, which says nothing
@@ -184,7 +189,7 @@ jobs:
                       # than treated as fatal. Neighbouring containers matter too — a
                       # second redroid booting on this kernel destabilizes both.
                       lsmod | grep -E '^(binder_linux|ashmem_linux)' || echo "no binder/ashmem module rows"
-                      docker ps --filter 'ancestor=redroid/redroid:14.0.0-latest' --format 'neighbour: {{.Names}} {{.Status}}' || true
+                      docker ps --filter "ancestor=$REDROID_IMAGE" --format 'neighbour: {{.Names}} {{.Status}}' || true
                       docker ps -a --filter "name=$REDROID_CONTAINER" --format '{{.Names}}: {{.Status}}' || true
                       docker logs --tail 200 "$REDROID_CONTAINER" 2>&1 || true
                       echo "::endgroup::"
@@ -195,25 +200,48 @@ jobs:
                     echo "REDROID_DATA_DIR=$REDROID_DATA_DIR" >> "$GITHUB_ENV"
                     rm -rf "$REDROID_DATA_DIR"
                     mkdir -p "$REDROID_DATA_DIR"
+                    # Seed /data from the fleet's prewarmed volume the same way
+                    # vitalyiegorov/suuudokuuu does (prewarm-redroid-linux.sh): a
+                    # first-boot-completed, animations-off /data cuts boot from
+                    # minutes to seconds. Cold-pulling and cold-booting redroid is
+                    # exactly the path three independent sources tie to the guest
+                    # kernel hard-locking on this fleet, so this is not optional on
+                    # runners that have been prewarmed.
+                    REDROID_PREWARM_MANIFEST="$HOME/.sudoku-ci/android-emulator.json"
+                    if [ -f "$REDROID_PREWARM_MANIFEST" ]; then
+                      PREWARM_DATA_DIR=$(grep -o '"dataDir"[[:space:]]*:[[:space:]]*"[^"]*"' "$REDROID_PREWARM_MANIFEST" | sed -E 's/.*:[[:space:]]*"([^"]*)"/\1/')
+                      if [ -n "$PREWARM_DATA_DIR" ] && [ -d "$PREWARM_DATA_DIR" ]; then
+                        echo "Seeding redroid /data from the prewarmed volume at $PREWARM_DATA_DIR (manifest: $REDROID_PREWARM_MANIFEST)."
+                        cp -a "$PREWARM_DATA_DIR/." "$REDROID_DATA_DIR/"
+                      else
+                        echo "::warning::Prewarm manifest $REDROID_PREWARM_MANIFEST does not name a usable dataDir ($PREWARM_DATA_DIR); falling back to a cold pull and cold boot."
+                        docker pull "$REDROID_IMAGE"
+                      fi
+                    else
+                      echo "::warning::No prewarm manifest at $REDROID_PREWARM_MANIFEST; this runner was not prewarmed by the fleet, so redroid will cold-pull and cold-boot instead of seeding /data from a prewarmed volume."
+                      docker pull "$REDROID_IMAGE"
+                    fi
                     # An unbounded container took every runner down with "the self-hosted
                     # runner lost communication with the server" — the runner agent has to
                     # keep reporting while Android boots, and in guest GPU mode that boot
                     # is pure CPU work, so the container is held to all but two cores and
-                    # a memory ceiling. The pixel count is cut for the same reason: nothing
-                    # in the suite depends on it, every gesture is expressed in percentages.
+                    # a memory ceiling. --memory-swap matches --memory (Docker otherwise
+                    # allows 2x swap) so a bloated redroid cannot page out the runner
+                    # agent instead of being OOM-killed itself. The display flags are
+                    # dropped: the prewarmed /data volume was created at redroid's
+                    # defaults, and booting it under a different display config is
+                    # untested; nothing in the suite depends on the pixel count anyway,
+                    # every gesture is expressed in percentages.
                     container_cpus=$(( $(nproc) > 3 ? $(nproc) - 2 : 1 ))
                     echo "host cores: $(nproc); container limited to ${container_cpus}"
                     docker run -d --privileged \
                       --name "$REDROID_CONTAINER" \
                       --cpus "$container_cpus" \
                       --memory 6g \
+                      --memory-swap 6g \
                       -p 127.0.0.1::5555 \
                       -v "$REDROID_DATA_DIR:/data" \
-                      redroid/redroid:14.0.0-latest \
-                      androidboot.redroid_width=720 \
-                      androidboot.redroid_height=1600 \
-                      androidboot.redroid_dpi=320 \
-                      androidboot.redroid_fps=30 \
+                      "$REDROID_IMAGE" \
                       androidboot.redroid_gpu_mode=guest
                     # The export is load-bearing: the wait loops below run in a child
                     # `bash -c`, whose single quotes defer expansion to that child, and

--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -212,7 +212,13 @@ jobs:
                       PREWARM_DATA_DIR=$(grep -o '"dataDir"[[:space:]]*:[[:space:]]*"[^"]*"' "$REDROID_PREWARM_MANIFEST" | sed -E 's/.*:[[:space:]]*"([^"]*)"/\1/')
                       if [ -n "$PREWARM_DATA_DIR" ] && [ -d "$PREWARM_DATA_DIR" ]; then
                         echo "Seeding redroid /data from the prewarmed volume at $PREWARM_DATA_DIR (manifest: $REDROID_PREWARM_MANIFEST)."
-                        cp -a "$PREWARM_DATA_DIR/." "$REDROID_DATA_DIR/"
+                        # The prewarmed tree is root-owned (redroid writes it as root
+                        # inside a --privileged container), so a plain cp as the
+                        # unprivileged runner user fails "Permission denied" on most
+                        # of /data. mobile-ci's run-maestro-android-redroid action hits
+                        # the same requirement and also shells out through sudo, for
+                        # both the seed (here) and the teardown rm below.
+                        sudo cp -a "$PREWARM_DATA_DIR/." "$REDROID_DATA_DIR/"
                       else
                         echo "::warning::Prewarm manifest $REDROID_PREWARM_MANIFEST does not name a usable dataDir ($PREWARM_DATA_DIR); falling back to a cold pull and cold boot."
                         docker pull "$REDROID_IMAGE"
@@ -347,7 +353,9 @@ jobs:
                 run: |
                     adb disconnect "127.0.0.1:${ADB_PORT:-0}" || true
                     docker rm -f "$REDROID_CONTAINER" || true
-                    if [ -n "${REDROID_DATA_DIR:-}" ]; then rm -rf "$REDROID_DATA_DIR" || true; fi
+                    # sudo: seeding from the prewarmed volume (above) leaves this tree
+                    # root-owned, same as mobile-ci's run-maestro-android-redroid.
+                    if [ -n "${REDROID_DATA_DIR:-}" ]; then sudo rm -rf "$REDROID_DATA_DIR" || true; fi
 
             -   name: Upload Maestro artifacts
                 # Matches the capture step's condition — gating this on the test step

--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -215,7 +215,13 @@ jobs:
                     # runners that have been prewarmed.
                     REDROID_PREWARM_MANIFEST="$HOME/.sudoku-ci/android-emulator.json"
                     if [ -f "$REDROID_PREWARM_MANIFEST" ]; then
-                      PREWARM_DATA_DIR=$(grep -o '"dataDir"[[:space:]]*:[[:space:]]*"[^"]*"' "$REDROID_PREWARM_MANIFEST" | sed -E 's/.*:[[:space:]]*"([^"]*)"/\1/')
+                      # `|| true`: under pipefail, a manifest with no "dataDir" key
+                      # makes grep exit 1 with no output, and that failure propagates
+                      # through the pipe even though sed exits 0 — which would abort
+                      # the whole step here instead of reaching the unusable-manifest
+                      # fallback below. An empty PREWARM_DATA_DIR is exactly what that
+                      # fallback branch is for.
+                      PREWARM_DATA_DIR=$(grep -o '"dataDir"[[:space:]]*:[[:space:]]*"[^"]*"' "$REDROID_PREWARM_MANIFEST" | sed -E 's/.*:[[:space:]]*"([^"]*)"/\1/' || true)
                       if [ -n "$PREWARM_DATA_DIR" ] && [ -d "$PREWARM_DATA_DIR" ]; then
                         echo "Seeding redroid /data from the prewarmed volume at $PREWARM_DATA_DIR (manifest: $REDROID_PREWARM_MANIFEST)."
                         # The prewarmed tree is root-owned (redroid writes it as root
@@ -312,6 +318,33 @@ jobs:
                     fi
                     curl -fsSL https://get.maestro.mobile.dev | env MAESTRO_VERSION="$MAESTRO_VERSION" bash
                     echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+            -   name: Provide an arm64-native cmake for AGP
+                # The Android SDK's own cmake packages (every version through at
+                # least 4.1.2, checked against dl.google.com's repository manifest)
+                # ship a single generic "linux" archive per version — there is no
+                # linux_aarch64 host entry, and that archive is x86_64-only. On this
+                # arm64 host the shell falls back to interpreting the ELF as a
+                # script, so CMake configure fails with `Syntax error: ")"
+                # unexpected` the moment AGP invokes the SDK-downloaded cmake — this
+                # step never ran before the redroid fix above, so it was undiscovered
+                # until the first live validation reached it. apt ships a native
+                # arm64 build of both cmake and ninja-build well above the >=3.13
+                # react-native's CMakeLists.txt requires, so AGP is pointed at that
+                # install via `cmake.dir` in local.properties instead of letting it
+                # download its own — workflow-only, never committed (this repo does
+                # not track local.properties for any example app).
+                timeout-minutes: 10
+                run: |
+                    set -euo pipefail
+                    if ! dpkg -s cmake >/dev/null 2>&1 || ! dpkg -s ninja-build >/dev/null 2>&1; then
+                      sudo apt-get update -y
+                      sudo apt-get install -y cmake ninja-build
+                    fi
+                    command -v cmake >/dev/null && command -v ninja >/dev/null
+                    cmake --version | head -1
+                    ninja --version
+                    echo "cmake.dir=/usr" >> "${{ env.APP_DIR }}/android/local.properties"
 
             -   name: Build, install, and test
                 id: emulator

--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -167,12 +167,18 @@ jobs:
                 run: |
                     set -euo pipefail
                     REDROID_IMAGE='redroid/redroid:15.0.0_64only-latest'
-                    if [ ! -d /dev/binderfs ] && ! lsmod | grep -q '^binder_linux'; then
-                      echo "binder_linux is not loaded; loading it now: modprobe binder_linux devices=binder,hwbinder,vndbinder"
-                      sudo modprobe binder_linux devices=binder,hwbinder,vndbinder || true
-                    fi
-                    if [ ! -d /dev/binderfs ] && ! lsmod | grep -q '^binder_linux'; then
-                      echo "::error::redroid needs a functional binder on the host and modprobe binder_linux devices=binder,hwbinder,vndbinder did not bring it up. Failing closed instead of booting redroid without binder — that false-positive precondition is what took eight runners down."
+                    # binder_linux must load on every boot. /dev/binder* is not a
+                    # reliable presence signal: on 6.x binderfs kernels no
+                    # /dev/binder, /dev/hwbinder, or /dev/vndbinder node ever appears
+                    # on the host at all — the privileged container mounts binderfs
+                    # and creates its own — so /sys/module/binder_linux is the only
+                    # portable check, and it is checked only after modprobe rather
+                    # than instead of it. A precondition that only checks and never
+                    # loads is a false positive on exactly the hosts redroid needs it
+                    # most on, and that false positive is what let eight runners die.
+                    sudo modprobe binder_linux devices=binder,hwbinder,vndbinder 2>&1 || true
+                    if [ ! -d /sys/module/binder_linux ]; then
+                      echo "::error::binder_linux is not loaded on this host after modprobe. Redroid cannot run without it, and that is host-kernel provisioning a workflow run cannot self-heal safely."
                       exit 1
                     fi
                     # Every wait below can only fail as a timeout, which says nothing
@@ -351,7 +357,11 @@ jobs:
                 timeout-minutes: 5
                 shell: bash
                 run: |
-                    adb disconnect "127.0.0.1:${ADB_PORT:-0}" || true
+                    # ADB_PORT is only set once the container is up and docker has
+                    # assigned it a host port; a redroid step that failed before that
+                    # point leaves it unset, and "127.0.0.1:0" is not a parseable adb
+                    # target, so this is skipped rather than logging a spurious error.
+                    if [ -n "${ADB_PORT:-}" ]; then adb disconnect "127.0.0.1:$ADB_PORT" || true; fi
                     docker rm -f "$REDROID_CONTAINER" || true
                     # sudo: seeding from the prewarmed volume (above) leaves this tree
                     # root-owned, same as mobile-ci's run-maestro-android-redroid.

--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -92,7 +92,13 @@ jobs:
         # x86_64: the NDK's host clang has no arm64-Linux build, so this cannot
         # run on the self-hosted fleet. See the top-of-file note.
         runs-on: ubuntu-24.04
-        timeout-minutes: 30
+        # collapsible-header/expo's native build (react-native-reanimated,
+        # 4-ABI CMake) measured at ~18 minutes on a clean run and blew the old
+        # 20-minute step timeout on a slower one (share-hosted infra varies) —
+        # confirmed live, not theoretical. Setup steps before the build measure
+        # under 2 minutes, so this still has real margin against the step
+        # timeout below.
+        timeout-minutes: 35
         strategy:
             fail-fast: false
             matrix:
@@ -158,7 +164,11 @@ jobs:
                 # checked-in debug keystore (see app/build.gradle,
                 # "Caution! In production, you need to generate your own keystore
                 # file."), so no signing secret is needed here.
-                timeout-minutes: 20
+                # 28, not 20: collapsible-header/expo's native build (4-ABI
+                # CMake for react-native-reanimated) measured ~18 minutes on
+                # one run and blew a 20-minute budget outright on the next —
+                # confirmed live, not a guess.
+                timeout-minutes: 28
                 shell: bash
                 run: |
                     set -euo pipefail

--- a/packages/react-native-collapsible-header-example/apps/bare/android/app/build.gradle
+++ b/packages/react-native-collapsible-header-example/apps/bare/android/app/build.gradle
@@ -8,20 +8,25 @@ apply plugin: "com.facebook.react"
  */
 react {
     /* Folders */
-    //   The root of your project, i.e. where "package.json" lives. Default is '../..'
-    //   (this app's own directory), which is wrong in this yarn-workspaces
-    //   monorepo: hoisted deps such as hermes-compiler live at the true repo
-    //   root instead. reactNativeDir/codegenDir/cliFile below were already
-    //   corrected for the same depth; root was not, and hermesc resolution
-    //   (detectOSAwareHermesCommand) is relative to root, not reactNativeDir,
-    //   so "Couldn't determine Hermesc location" happened despite those three
-    //   being right.
-    root = file("../../../../../../")
-    //   entryFile defaults to <root>/index.js, so correcting root above moved
-    //   its search away from this app's own index.js (which lives two levels
-    //   up from android/app/, at the app root — the *old* default root).
-    //   Point it back explicitly rather than leave that default broken.
-    entryFile = file("../../index.js")
+    //   The root of your project, i.e. where "package.json" lives. Default is '../../'
+    //   Left at the default deliberately: react.root also doubles as the cwd
+    //   for the CLI's `bundle` command (BundleHermesCTask) and the base for
+    //   entryFile's default, and changing it to the true yarn-workspaces repo
+    //   root here broke both ("unknown command 'bundle'" — its plugin
+    //   auto-detection needs cwd = this app's own directory — and a stale
+    //   entryFile default), confirmed live across two failed runs. hermesc
+    //   below is fixed without touching root at all, the same way this repo's
+    //   own Expo prebuild template already does it (checked via a local
+    //   `expo prebuild`): Node's require.resolve walks up node_modules on its
+    //   own, so it finds a hoisted package regardless of directory depth —
+    //   no relative-path counting needed.
+    // root = file("../../")
+    //   hermes-compiler is a separate npm package (not a react-native/sdks
+    //   subpath) as of this react-native version, and the gradle plugin's
+    //   default hermesc lookup is relative to root — which points at this
+    //   app's own directory, where nothing is hoisted to. require.resolve
+    //   finds the real, hoisted location regardless.
+    hermesCommand = new File(["node", "--print", "require.resolve('hermes-compiler/package.json', { paths: [require.resolve('react-native/package.json')] })"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + "/hermesc/%OS-BIN%/hermesc"
     //   The folder where the react-native NPM package is. Default is ../../node_modules/react-native
     reactNativeDir = file("../../../../../../node_modules/react-native")
     //   The folder where the react-native Codegen package is. Default is ../../node_modules/@react-native/codegen

--- a/packages/react-native-collapsible-header-example/apps/bare/android/app/build.gradle
+++ b/packages/react-native-collapsible-header-example/apps/bare/android/app/build.gradle
@@ -17,6 +17,11 @@ react {
     //   so "Couldn't determine Hermesc location" happened despite those three
     //   being right.
     root = file("../../../../../../")
+    //   entryFile defaults to <root>/index.js, so correcting root above moved
+    //   its search away from this app's own index.js (which lives two levels
+    //   up from android/app/, at the app root — the *old* default root).
+    //   Point it back explicitly rather than leave that default broken.
+    entryFile = file("../../index.js")
     //   The folder where the react-native NPM package is. Default is ../../node_modules/react-native
     reactNativeDir = file("../../../../../../node_modules/react-native")
     //   The folder where the react-native Codegen package is. Default is ../../node_modules/@react-native/codegen

--- a/packages/react-native-collapsible-header-example/apps/bare/android/app/build.gradle
+++ b/packages/react-native-collapsible-header-example/apps/bare/android/app/build.gradle
@@ -9,7 +9,14 @@ apply plugin: "com.facebook.react"
 react {
     /* Folders */
     //   The root of your project, i.e. where "package.json" lives. Default is '../..'
-    // root = file("../../")
+    //   (this app's own directory), which is wrong in this yarn-workspaces
+    //   monorepo: hoisted deps such as hermes-compiler live at the true repo
+    //   root instead. reactNativeDir/codegenDir/cliFile below were already
+    //   corrected for the same depth; root was not, and hermesc resolution
+    //   (detectOSAwareHermesCommand) is relative to root, not reactNativeDir,
+    //   so "Couldn't determine Hermesc location" happened despite those three
+    //   being right.
+    root = file("../../../../../../")
     //   The folder where the react-native NPM package is. Default is ../../node_modules/react-native
     reactNativeDir = file("../../../../../../node_modules/react-native")
     //   The folder where the react-native Codegen package is. Default is ../../node_modules/@react-native/codegen

--- a/packages/react-native-payments-example/apps/bare/android/app/build.gradle
+++ b/packages/react-native-payments-example/apps/bare/android/app/build.gradle
@@ -8,20 +8,25 @@ apply plugin: "com.facebook.react"
  */
 react {
     /* Folders */
-    //   The root of your project, i.e. where "package.json" lives. Default is '../..'
-    //   (this app's own directory), which is wrong in this yarn-workspaces
-    //   monorepo: hoisted deps such as hermes-compiler live at the true repo
-    //   root instead. reactNativeDir/codegenDir/cliFile below were already
-    //   corrected for the same depth; root was not, and hermesc resolution
-    //   (detectOSAwareHermesCommand) is relative to root, not reactNativeDir,
-    //   so "Couldn't determine Hermesc location" happened despite those three
-    //   being right.
-    root = file("../../../../../../")
-    //   entryFile defaults to <root>/index.js, so correcting root above moved
-    //   its search away from this app's own index.js (which lives two levels
-    //   up from android/app/, at the app root — the *old* default root).
-    //   Point it back explicitly rather than leave that default broken.
-    entryFile = file("../../index.js")
+    //   The root of your project, i.e. where "package.json" lives. Default is '../../'
+    //   Left at the default deliberately: react.root also doubles as the cwd
+    //   for the CLI's `bundle` command (BundleHermesCTask) and the base for
+    //   entryFile's default, and changing it to the true yarn-workspaces repo
+    //   root here broke both ("unknown command 'bundle'" — its plugin
+    //   auto-detection needs cwd = this app's own directory — and a stale
+    //   entryFile default), confirmed live across two failed runs. hermesc
+    //   below is fixed without touching root at all, the same way this repo's
+    //   own Expo prebuild template already does it (checked via a local
+    //   `expo prebuild`): Node's require.resolve walks up node_modules on its
+    //   own, so it finds a hoisted package regardless of directory depth —
+    //   no relative-path counting needed.
+    // root = file("../../")
+    //   hermes-compiler is a separate npm package (not a react-native/sdks
+    //   subpath) as of this react-native version, and the gradle plugin's
+    //   default hermesc lookup is relative to root — which points at this
+    //   app's own directory, where nothing is hoisted to. require.resolve
+    //   finds the real, hoisted location regardless.
+    hermesCommand = new File(["node", "--print", "require.resolve('hermes-compiler/package.json', { paths: [require.resolve('react-native/package.json')] })"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + "/hermesc/%OS-BIN%/hermesc"
     //   The folder where the react-native NPM package is. Default is ../../node_modules/react-native
     reactNativeDir = file("../../../../../../node_modules/react-native")
     //   The folder where the react-native Codegen package is. Default is ../../node_modules/@react-native/codegen

--- a/packages/react-native-payments-example/apps/bare/android/app/build.gradle
+++ b/packages/react-native-payments-example/apps/bare/android/app/build.gradle
@@ -17,6 +17,11 @@ react {
     //   so "Couldn't determine Hermesc location" happened despite those three
     //   being right.
     root = file("../../../../../../")
+    //   entryFile defaults to <root>/index.js, so correcting root above moved
+    //   its search away from this app's own index.js (which lives two levels
+    //   up from android/app/, at the app root — the *old* default root).
+    //   Point it back explicitly rather than leave that default broken.
+    entryFile = file("../../index.js")
     //   The folder where the react-native NPM package is. Default is ../../node_modules/react-native
     reactNativeDir = file("../../../../../../node_modules/react-native")
     //   The folder where the react-native Codegen package is. Default is ../../node_modules/@react-native/codegen

--- a/packages/react-native-payments-example/apps/bare/android/app/build.gradle
+++ b/packages/react-native-payments-example/apps/bare/android/app/build.gradle
@@ -9,7 +9,14 @@ apply plugin: "com.facebook.react"
 react {
     /* Folders */
     //   The root of your project, i.e. where "package.json" lives. Default is '../..'
-    // root = file("../../")
+    //   (this app's own directory), which is wrong in this yarn-workspaces
+    //   monorepo: hoisted deps such as hermes-compiler live at the true repo
+    //   root instead. reactNativeDir/codegenDir/cliFile below were already
+    //   corrected for the same depth; root was not, and hermesc resolution
+    //   (detectOSAwareHermesCommand) is relative to root, not reactNativeDir,
+    //   so "Couldn't determine Hermesc location" happened despite those three
+    //   being right.
+    root = file("../../../../../../")
     //   The folder where the react-native NPM package is. Default is ../../node_modules/react-native
     reactNativeDir = file("../../../../../../node_modules/react-native")
     //   The folder where the react-native Codegen package is. Default is ../../node_modules/@react-native/codegen


### PR DESCRIPTION
## Summary

`rnw-community/rnw-community` PR #545's Android Maestro job killed 8/8 self-hosted Linux runners it landed on — always mid-boot in `Start redroid container`, always with no log ever uploaded (`BlobNotFound`), always 16–18 minutes in. That signature was root-caused in `vitalyiegorov/tart-runner-fleet#236` (comment: https://github.com/vitalyiegorov/tart-runner-fleet/issues/236#issuecomment-5308777832): **`redroid/redroid:14.0.0-latest` hard-locks the arm64 guest kernel** — a finding stated independently by this repo's own `mobile-ci` action description, by `vitalyiegorov/suuudokuuu`'s prewarm script, and by the fleet's `LINUX_BASE_IMAGE.md`.

Fixing the boot uncovered two more structural problems, both fixed here too:

1. **The NDK ships no arm64-Linux host toolchain, ever.** Once redroid stopped killing runners, the Gradle build reached real compilation and failed with `C compiler identification is unknown` — Google has never published a `linux-aarch64` NDK clang. Native Android builds cannot run on this arm64 self-hosted fleet, full stop.
2. **`hermes-compiler` resolves relative to `react.root`, which has two incompatible correct values in a yarn-workspaces monorepo** — one for hermesc/hoisted-package resolution (the true repo root) and a different one for the RN CLI's `bundle` command and `entryFile`'s default (this app's own directory). This surfaced only because point 1's fix moved the build off the fleet and onto a host where it could get this far for the first time in the repo's CI history.

## Changes

**`.github/workflows/android-maestro.yml`** — split into two jobs:
- **`build-apk`** (new): runs on `ubuntu-24.04`, a free GitHub-hosted x86_64 runner (this repo is public) — the only place native Android builds are supported at all here. Does the Node/Gradle/NDK work, uploads the release APK as an artifact. `release`, not `debug`: both example apps already sign release with the checked-in debug keystore, so no signing secret is needed.
- **`maestro`**: `needs: [detect, build-apk]`, downloads the artifact instead of building. Every Gradle/SDK/NDK step is gone, including `Set up Android SDK` — it only needs `adb` (via apt) to install the prebuilt APK and boot Redroid. Job timeout dropped from 65 to 30 minutes to match the smaller scope.
  - Image: `redroid/redroid:14.0.0-latest` → `15.0.0_64only-latest` (the verified-good tag).
  - Seeds `/data` from the fleet's prewarmed volume (`$HOME/.sudoku-ci/android-emulator.json`, `sudo cp -a` — the tree is root-owned since redroid writes it as root inside `--privileged`) instead of always cold-booting into an empty volume, matching `suuudokuuu` and `mobile-ci`'s own `run-maestro-android-redroid` action. Falls back to a plain `docker pull` with a loud `::warning::` when no manifest is present.
  - Dropped `redroid_width/height/dpi/fps` (untested against a prewarmed volume created at defaults); added `--memory-swap 6g` to match `--memory 6g` (unset before, so Docker allowed 2× swap).
  - Binder precondition: always `modprobe`s and checks `/sys/module/binder_linux` (not `/dev/binderfs`, which never appears on 6.x binderfs-kernel hosts), failing closed with a clear error if binder still isn't functional.

**`packages/{react-native-payments-example,react-native-collapsible-header-example}/apps/bare/android/app/build.gradle`** — one line added to each: `hermesCommand`, resolved dynamically via `require.resolve('hermes-compiler/...')` the same way this repo's own Expo prebuild template already does it (verified by running `expo prebuild` locally and reading the generated file). This finds the hoisted `hermes-compiler` package regardless of directory depth, without touching `react.root` at all — an earlier attempt that changed `root` instead broke the CLI's `bundle` command and `entryFile`'s default, both confirmed live before being reverted (see commit history for the full trail). Expo targets need no equivalent fix.

Scope is deliberately narrow: no restructuring beyond the job split, no renaming, nothing outside these files.

## Evidence

**Before** (PR #545, `codex/react-native-collapsible-header`, `redroid/redroid:14.0.0-latest`): **8/8** Android Maestro legs killed their runner mid-boot, 16–18 minutes in, no log ever uploaded. See `vitalyiegorov/tart-runner-fleet#236` for the full timeline and run IDs.

**After**, validated live via `workflow_dispatch` on the shared self-hosted fleet, iterating on real failures at every stage rather than a single lucky run:

- Redroid boot fix: 3 runs (`31962789083` → `31963032343` → `31963119630`), landing on a **~12s clean boot**.
- APK-build-on-GitHub-hosted fix: 4 runs (`31971276882` → `31971663897` → `31972228474` → `31972579004` → `31973044021`), each catching and fixing a real, previously-undiscovered failure (hermesc location, then `entryFile`, then the `bundle` command — see commit messages for the full diagnosis trail).
- **Final validation, run [`31973044021`](https://github.com/rnw-community/rnw-community/actions/runs/31973044021)**: `Maestro (payments, bare)` — all four `build-apk` legs succeeded, the APK downloaded and installed cleanly (`adb install` → `Success`), redroid booted, and Maestro ran **all 8 flows** against the live app:
  ```
  [Passed] can_make_payment_probe (12s)
  [Failed] sheet_opens_on_show (1m 7s) (Assertion is false: "rejected", id: payments-flow-state is visible)
  [Passed] shipping_listener_wiring_enabled (20s)
  [Passed] dismiss_abort_reject_state (24s)
  [Failed] reset_new_request_state_transitions (40s) (Assertion is false: "idle", id: payments-flow-state is visible)
  [Passed] shipping_listener_wiring_disabled (23s)
  [Failed] app_launch (5m 57s) (No visible element found: id: event-log)
  [Passed] async_update_toggle_state (22s)
  3/8 Flows Failed
  ```
  The runner survived, ran the full teardown (adb disconnect, container removal, data dir cleanup) and uploaded artifacts cleanly — the job's own conclusion is `failure` (from the 3 flow assertion failures above), not a runner death. I cancelled the three remaining matrix legs once this one reached a definitive result, to avoid spending further shared fleet capacity — Maestro flow pass/fail was never this PR's scope, only getting a flow to run at all was.

## Update: validated on the PR's own `pull_request` event, not just `workflow_dispatch`

The `workflow_dispatch` validation above proved the architecture works, but every earlier `pull_request`-triggered "Android Maestro E2E" run on this branch showed `Detect affected packages` completing in ~15s with the downstream matrix jobs unmaterialized (check names showing the literal `${{ matrix.package }}, ${{ matrix.target }}` instead of real values). That turned out to be an artifact of this session's own housekeeping, not a workflow bug: every one of those runs had been `gh run cancel`led part-way through checkout, mid-session, to avoid burning duplicate shared-fleet capacity while iterating — a job cancelled before `detect`'s final step never sets `outputs.matrix`, so the matrix strategy can't expand. Rerunning one of those exact commits without touching it (31973042024) completed `Detect affected packages` in 15s with a real matrix and all four `Build APK` legs materialized — three succeeded outright.

The fourth (`collapsible-header`, `expo`) surfaced a genuine, separate flake: `The action 'Build release APK' has timed out after 20 minutes'` — its native build (react-native-reanimated, 4-ABI CMake) had measured ~18 minutes on the prior successful dispatch run, so a 20-minute budget was always going to be marginal on shared GitHub-hosted infra. Widened to 28/35 minutes (step/job). A fresh `pull_request` push after that fix (31976642961) reran cleanly: `Detect affected packages` succeeded with a correct matrix, and all four `Build APK` legs succeeded, including `collapsible-header`/`expo` at ~22.5 minutes — comfortably inside the new budget.

`codecov/project/eslint-plugin` also shows failing on this PR's checks. Not caused by this branch: the PR's `base_totals` and `head_totals` coverage are byte-identical (99.78% / 99.78%, 0 diff) per Codecov's own API — expected, since this diff touches only a CI workflow and two Android `build.gradle` files, nothing in `eslint-plugin`. Pre-existing/flaky on Codecov's side, not something to chase here.

The `Maestro` matrix legs for run 31976642961 were queued a long time behind what first looked like fleet congestion, but turned out to be two things, both external to this PR and both since resolved by the fleet operator directly:
1. The run's first attempt was cancelled and re-queued (`gh run rerun --failed`) to move the binding off a busy node onto an idle one — a known structural gap (jobs bind to one node's scale set at advertisement, with no re-offer) rather than a bug in this workflow.
2. The remaining wait was real envelope math, not a stuck scheduler: the host's two `maestro`-profile (macOS/iOS) slots were held 80+ minutes by unrelated `budgie`-org shards, leaving only 2 of the 6 CPUs this workflow's `xl` profile needs. Once those shards finished, the `xl` leg admitted immediately.

Both runs are now fully complete:

**iOS Maestro E2E ([31976642953](https://github.com/rnw-community/rnw-community/actions/runs/31976642953)): full SUCCESS** — all four legs (`payments`/`collapsible-header` × `bare`/`expo`) passed.

**Android Maestro E2E ([31976642961](https://github.com/rnw-community/rnw-community/actions/runs/31976642961)): infra fully green, run conclusion `failure` from flow assertions only** — all four `Build APK` legs succeeded, and all four `Maestro` legs completed the full boot → install → Maestro-execution path with zero infra failures:
  - `payments` (`bare` and `expo`, identically): 3/8 flows failed — `sheet_opens_on_show`, `reset_new_request_state_transitions`, `app_launch` (matches the earlier `workflow_dispatch` validation run exactly)
  - `collapsible-header` (`bare` and `expo`, identically): 1/7 flows failed — `snap_to_nearest_endpoint`
  
  Every failure is a reproducible assertion against the live app (`Assertion is false: ...`, `No visible element found: ...`), identical between the `bare` and `expo` variant of each app — pre-existing app/test behavior, not an install, boot, or CI infra failure, and not something this PR introduced or is scoped to fix.

## Test plan

- [x] `workflow_dispatch` on this branch against the shared self-hosted fleet, iterated across 8 runs until redroid booted in ~12s, the APK built on GitHub-hosted x86_64, and Maestro ran all 8 flows against the installed app.
- [x] Fresh `pull_request`-event runs (not touched mid-run) confirm `Detect affected packages` and all four `Build APK` legs succeed on the event that actually gates this PR, after widening the `collapsible-header`/`expo` build timeout that a live rerun caught as flaky.
- [x] `pull_request`-event `Maestro` legs: iOS full green (4/4); Android infra fully green (build, install, redroid boot, Maestro execution all succeed on all 4 legs) with only flow-level assertion failures, identical across `bare`/`expo` variants and consistent with the earlier `workflow_dispatch` validation.
- [ ] Branch owner reviews and decides on merge (this PR targets `codex/react-native-collapsible-header`, not `master`, so #545 absorbs it — not merging directly). The flow failures shown above are pre-existing app/test behavior, not something this PR introduced or is scoped to fix.

Also filed:
- A comment on `rnw-community/mobile-ci#46` about a related landmine for whoever migrates this workflow onto the shared action next (its `prewarm-manifest-path` default doesn't match the fleet's actual manifest path).
- A reply to the Macroscope review comment on this PR, confirming the pipefail fix it flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Boot Redroid 15.0.0_64only from fleet's prewarmed /data in Android Maestro CI
> - Splits the Maestro CI workflow into a `build-apk` job (GitHub-hosted x86_64) and a `maestro` job (self-hosted arm64), so Gradle builds no longer run on the test fleet.
> - The `maestro` job downloads the prebuilt APK artifact, boots Redroid using `redroid/redroid:15.0.0_64only-latest`, ensures `binder_linux` is loaded via `modprobe`, and optionally seeds `/data` from a prewarmed volume manifest.
> - Fixes hermesc resolution in [android/app/build.gradle](https://github.com/rnw-community/rnw-community/pull/579/files#diff-c9dd275a500b1cc898454599970f1c22a0475155b357989b66ebcc9873f9e019) and [android/app/build.gradle](https://github.com/rnw-community/rnw-community/pull/579/files#diff-32b62e67e7fbe003abba3aadf958227efae824373048bb3608b8a88fe07ec2f3) to locate `hermesc` relative to the `react-native` package, fixing builds in a hoisted workspace.
> - Overall job and step timeouts are reduced since the test runner no longer provisions Android SDK/NDK or runs Gradle.
> - Behavioral Change: `adb` is now the distro-provided binary on the test fleet; teardown conditionally disconnects only if `ADB_PORT` is set and removes the data directory with `sudo`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cda5df2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

