### PR TITLE
test(eslint-plugin): cover logical-AND prop and handler call cases in no-complex-jsx-logic

### DIFF
--- a/packages/eslint-plugin/src/rules/no-complex-jsx-logic/no-complex-jsx-logic.spec.ts
+++ b/packages/eslint-plugin/src/rules/no-complex-jsx-logic/no-complex-jsx-logic.spec.ts
@@ -36,6 +36,9 @@ ruleTester.run('no-complex-jsx-logic', noComplexJsxLogicRule, {
             code: '<Component>{handleLogic(args)}</Component>',
         },
         {
+            code: '<Component onClick={handleClick(value)} />',
+        },
+        {
             code: '<Component>{condition && <AnotherComponent />}</Component>',
         },
         {
@@ -54,6 +57,10 @@ ruleTester.run('no-complex-jsx-logic', noComplexJsxLogicRule, {
         {
             code: '<Component prop={myVar + myVar2} />',
             errors: [{ messageId: 'noPropsCalculations' }],
+        },
+        {
+            code: '<Component prop={condition && value} />',
+            errors: [{ messageId: 'noPropsTernary' }],
         },
         {
             code: '<Component objectProp={{ field: 1, boolField: true}} />',


### PR DESCRIPTION
Split out of #546 — the change is unrelated to that PR's package and was riding along in its diff.

Adds two `RuleTester` cases to `no-complex-jsx-logic` that pin down behaviour the suite did not previously assert:

- valid: `<Component onClick={handleClick(value)} />` — a bare call expression in a prop is allowed, distinguishing it from `<Component onClick={handleClick(condition ? "1" : "2")} />`, which the suite already asserts is an error.
- invalid: `<Component prop={condition && value} />` — a logical-AND expression in a prop reports `noPropsTernary`, matching the existing ternary-in-prop case, while `{condition && <AnotherComponent />}` in *children* stays valid.

No rule source change; this is coverage only.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test cases for logical-AND prop and handler call in `no-complex-jsx-logic` rule
> Extends the test suite in [no-complex-jsx-logic.spec.ts](https://github.com/rnw-community/rnw-community/pull/597/files#diff-e9c5684c4bcc508f0bd16264fb3aff3bb8ef546079a70e8fc390b048951de4ee) with two new cases: a valid case allowing a callback prop call (`onClick={handleClick(value)}`), and an invalid case asserting that a logical-AND expression in a prop (`prop={condition && value}`) is disallowed with the `noPropsTernary` message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f28248.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming event-handler calls with arguments are accepted in JSX properties.
  * Added coverage ensuring logical-AND expressions in JSX properties are flagged by the complexity rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->