### PR TITLE
feat(react-native-collapsible-header): reduced-motion-aware snap and generic scrollable support

### DIFF
--- a/packages/react-native-collapsible-header/AGENTS.md
+++ b/packages/react-native-collapsible-header/AGENTS.md
@@ -46,14 +46,18 @@ src/
     collapsible-header-props.interface.ts — public slot, geometry, behavior, style, and ViewProps contract
     collapsible-header-scroll.interface.ts — public scroll wiring contract returned by the scroll hook
     collapsible-header-scroll-context-value.interface.ts — internal context value (adds snap registry)
+    collapsible-header-scroll-worklets-config.interface.ts — internal scroll worklet factory input
     collapsible-header-snap-config.interface.ts — internal snap geometry shape
   provider/
     collapsible-header-provider/
       collapsible-header-provider.tsx — public provider owning scrollY, scroll handler, ref, snap registry
       collapsible-header-provider.spec.tsx
+      collapsible-header-provider-reduced-motion.spec.tsx — animated/instant snap per system motion setting
+      collapsible-header-provider-scrollables.spec.tsx — snap wiring across every supported scrollable shape
   type/
     collapsible-header-geometry.type.ts — normalized geometry validation input
     collapsible-header-mode.type.ts — public 'flow' | 'overlay' layout strategy
+    collapsible-header-scroll-ref.type.ts — public animated scroll ref attachable to any scrollable
   util/
     create-collapsible-header-scroll-worklets/
       create-collapsible-header-scroll-worklets.ts — internal scroll/drag worklet factory; snap runs once the
@@ -85,13 +89,27 @@ src/
   sibling screens independent (pinned by `collapsible-header-provider-isolation.spec.tsx` and by the example's two
   Maestro freeze flows); a provider shared across screens makes the last-scrolled screen drive every header. Several
   headers within one screen may share a provider — they animate from one offset by design.
-- `snap` requires the provider (snapping drives the registered scrollable via `scrollTo`); headers register snap
-  geometry into the provider's shared-value registry on mount and clear it on unmount, but only when the slot still
+- `snap` requires the provider **and** a mounted `CollapsibleHeader` — the provider owns the slot, the header fills it,
+  so a provider whose snapping header is unmounted (tab switch, `freezeOnBlur`) simply stops snapping until it returns.
+  Snapping drives the registered scrollable via `scrollTo`; headers register snap geometry
+  into the provider's shared-value registry on mount and clear it on unmount, but only when the slot still
   holds the config that header wrote, so unmounting one header never disables a still-mounted one. Snapping is a
   property of the scrollable, not the header: `assertVacantCollapsibleHeaderSnapSlot` throws when a second snapping
   header claims the slot with different geometry, and `assertSnappableCollapsibleHeaderScroll` throws when `snap` is
   combined with a caller-owned `scrollY` prop (the two sources could disagree). A keyed registry with a min/max union
   policy is the escape hatch if multi-header snapping ever becomes a real requirement — deliberately not built.
+- Snapping is animated only while the system allows motion: the provider reads `useReducedMotion()` and passes
+  `snapAnimated` into the worklet factory, which forwards it as `scrollTo`'s `animated` argument. Not configurable —
+  an animated snap is motion the user never initiated, so it follows the platform setting rather than a prop.
+- `CollapsibleHeaderScrollRef` (the type of the provider's `scrollRef`) is `AnimatedRef<Component>` intersected with a
+  `(instance: never) => void` call signature. `useAnimatedRef<Component>()` satisfies it with no cast (return-type-void
+  assignability), and the extra signature makes it assignable to `React.Ref<T>` for every `T` through `RefCallback`'s
+  bivariant parameter — instance refs (`Animated.FlatList`), `createAnimatedComponent` wrappers, and imperative handle
+  refs (FlashList, LegendList) alike. A generic type parameter was rejected: Reanimated 3.17 constrains
+  `AnimatedRef<T extends Component>`, which handle-shaped refs cannot satisfy. Plain `AnimatedRef<Component>` was
+  rejected too: under `@types/react` 19 its call signature returns `ShadowNodeWrapper | HTMLElement`, which no
+  `RefCallback` accepts. FlashList and LegendList stay out of `package.json` — the contract is structural, so support is
+  type-level plus readme recipes, and specs use locally declared handle-shaped stubs.
 - `collapseDistance` defaults to `expandedHeight - collapsedHeight`; `collapseStart` is optional, non-negative, and
   defaults to `0`.
 - `motion` is additive and partial; missing fields resolve against `DefaultCollapsibleHeaderMotionConfig` (public)

--- a/packages/react-native-collapsible-header/llms.txt
+++ b/packages/react-native-collapsible-header/llms.txt
@@ -2,7 +2,7 @@
 
 > Generic slot-based collapsible header for React Native and react-native-web, driven by a Reanimated shared scroll
 > value. Ships ESM + CJS, precompiled with the React Compiler (React 18+), peer-depends on react-native-reanimated
-> >=3.17.2 <5. Works with ScrollView, FlatList, SectionList, and FlashList.
+> >=3.17.2 <5. Works with ScrollView, FlatList, SectionList, FlashList, and LegendList.
 
 ## Exports
 
@@ -12,12 +12,15 @@
 - `CollapsibleHeaderProvider` — context provider owning scrollY, onScroll handler, and animated scroll ref; enables
   prop-less header wiring and snap-to-endpoint.
 - `useCollapsibleHeaderScroll()` — returns `{ scrollY, onScroll, scrollRef }` for attaching a scrollable; throws
-  without a provider ancestor.
+  without a provider ancestor. `scrollRef` (type `CollapsibleHeaderScrollRef`) attaches to any list ref shape —
+  component instances (Animated.FlatList), createAnimatedComponent wrappers, or imperative handles (FlashList,
+  LegendList) — with no cast; LegendList takes it through `refScrollView`.
 - `useCollapsibleHeaderProgress()` — returns collapse progress SharedValue (0 expanded → 1 collapsed) inside header
   slots for custom slot animations; throws without a header ancestor.
 - `getCollapsibleHeaderContentInsetStyle(expandedHeight)` — `{ paddingTop }` style for overlay-mode scroll content.
 - `DefaultCollapsibleHeaderMotionConfig` — baseline motion preset for building custom presets.
-- Types: `CollapsibleHeaderProps`, `CollapsibleHeaderMotionConfig`, `CollapsibleHeaderScroll`, `CollapsibleHeaderMode`.
+- Types: `CollapsibleHeaderProps`, `CollapsibleHeaderMotionConfig`, `CollapsibleHeaderScroll`, `CollapsibleHeaderMode`,
+  `CollapsibleHeaderScrollRef`.
 
 ## Use cases
 
@@ -35,7 +38,9 @@ holds one scrollY, one scroll handler, one scroll ref, and one snap slot. Per-sc
 independent scroll state (safe with react-native-screens freezeOnBlur); one provider shared across screens makes the
 last-scrolled screen drive every header. Multiple headers in ONE screen may share a provider (same offset, e.g. hero
 plus sticky sub-header), but only one may set snap: a second snapping header with different geometry throws, and
-combining snap with a scrollY prop throws.
+combining snap with a scrollY prop throws. Snap also needs a mounted CollapsibleHeader — the provider owns the snap
+slot, the header registers the geometry that fills it, so a provider alone never snaps. Snapping follows the system
+reduce-motion setting: instant instead of animated when it is on.
 
 ## Behavior contract
 

--- a/packages/react-native-collapsible-header/readme.md
+++ b/packages/react-native-collapsible-header/readme.md
@@ -3,7 +3,8 @@
 A generic, slot-based collapsible header powered by React Native Reanimated. The package animates header geometry and
 crossfades caller-owned expanded and collapsed content from a scroll offset it either receives as a prop or wires
 automatically through `CollapsibleHeaderProvider`. It works with any vertical scrollable — `ScrollView`, `FlatList`,
-`SectionList`, or FlashList — because the only integration contract is a Reanimated `SharedValue` scroll offset.
+`SectionList`, FlashList, or LegendList — because the only integration contract is a Reanimated `SharedValue` scroll
+offset.
 
 [![npm version](https://badge.fury.io/js/%40rnw-community%2Freact-native-collapsible-header.svg)](https://badge.fury.io/js/%40rnw-community%2Freact-native-collapsible-header)
 [![coverage](https://img.shields.io/codecov/c/github/rnw-community/rnw-community?flag=react-native-collapsible-header&label=coverage)](https://app.codecov.io/gh/rnw-community/rnw-community)
@@ -164,6 +165,19 @@ Owns the scroll wiring — a `scrollY` shared value, a Reanimated scroll handler
 it through context. Descendant headers fall back to the provider's `scrollY` when the prop is omitted, and `snap`
 requires the provider because snapping drives the registered scrollable via `scrollTo`.
 
+The provider also reads Reanimated's `useReducedMotion()` and snaps instantly instead of animating whenever the system
+"reduce motion" accessibility setting is on. Nothing is configurable here on purpose: an animated snap is an unrequested
+motion the user did not initiate, so it follows the platform setting.
+
+### Snap requires a mounted CollapsibleHeader
+
+The provider owns the snap slot, but a `CollapsibleHeader` fills it: a header rendered with `snap` registers its
+geometry (`collapseStart` and `collapseStart + collapseDistance`) into the provider's registry on mount and clears it on
+unmount. A provider with no mounted snapping header therefore never snaps — scrolling settles wherever it lands. This is
+deliberate: snap endpoints are header geometry, so there is nothing to snap to without a header. Conditionally
+unmounting the header (a tab switch, a `freezeOnBlur` screen) turns snapping off for as long as it is gone, and
+remounting restores it.
+
 ### One provider per scrollable
 
 **Mount a provider per screen, inside the screen — never once around a navigator.** A provider holds exactly one
@@ -184,8 +198,33 @@ disagree and snap the list without moving the header.
 ## useCollapsibleHeaderScroll
 
 Returns the provider-owned wiring for attaching a scrollable: `{ scrollY, onScroll, scrollRef }`. Attach `onScroll`
-(and `scrollRef` when snapping) to any Reanimated-animated scrollable — `Animated.ScrollView`, `Animated.FlatList`, or
-an animated FlashList. Throws when no `CollapsibleHeaderProvider` ancestor exists.
+(and `scrollRef` when snapping) to any Reanimated-animated scrollable — `Animated.ScrollView`, `Animated.FlatList`, an
+animated `SectionList`, FlashList, or LegendList. Throws when no `CollapsibleHeaderProvider` ancestor exists. See the
+[recipes](#recipes) for the per-list wiring.
+
+## CollapsibleHeaderScrollRef
+
+The type of `scrollRef`. It is an `AnimatedRef` that additionally satisfies React's `Ref<T>` for every `T`, so the same
+ref attaches to lists whose `ref` prop is a component instance (`Animated.FlatList` → `Ref<FlatList>`), a
+`createAnimatedComponent` wrapper, or an imperative handle object (FlashList's `FlashListRef`, LegendList's
+`LegendListRef`) — with no cast at the call site. Name it when the scrollable lives in a child component and the ref
+travels as a prop:
+
+```tsx
+interface TransactionListProps {
+    readonly scrollRef: CollapsibleHeaderScrollRef;
+    readonly onScroll: ScrollHandlerProcessed;
+}
+
+const TransactionList = ({ scrollRef, onScroll }: TransactionListProps) => (
+    <AnimatedFlashList ref={scrollRef} onScroll={onScroll} data={transactions} renderItem={renderItem} />
+);
+```
+
+Snapping resolves the underlying native scrollable from whatever instance the list hands the ref: Reanimated reads
+`getScrollableNode()` / `getNativeScrollRef()` when the instance exposes them, which is how handle-based lists stay
+snappable. When a list exposes its inner animated `ScrollView` ref separately (LegendList's `refScrollView`), prefer that
+prop — it is the most direct target for `scrollTo`.
 
 ## useCollapsibleHeaderProgress
 
@@ -249,9 +288,9 @@ out the whole screen.
 
 ## Recipes
 
-### FlatList / SectionList / FlashList
+### FlatList
 
-The header is list-agnostic — attach the provider wiring to any Reanimated-animated list:
+`Animated.FlatList` ships with Reanimated — attach the wiring directly:
 
 ```tsx
 const TransactionList = () => {
@@ -269,7 +308,85 @@ const TransactionList = () => {
 };
 ```
 
-For FlashList, wrap it once with `Animated.createAnimatedComponent(FlashList)` and use the same props.
+### SectionList
+
+Reanimated has no built-in animated `SectionList`; wrap it once at module scope so the component identity is stable:
+
+```tsx
+const AnimatedSectionList = Animated.createAnimatedComponent(SectionList<Transaction>);
+
+const TransactionSections = () => {
+    const { onScroll, scrollRef } = useCollapsibleHeaderScroll();
+
+    return (
+        <AnimatedSectionList
+            ref={scrollRef}
+            sections={sections}
+            renderItem={renderItem}
+            onScroll={onScroll}
+            scrollEventThrottle={16}
+        />
+    );
+};
+```
+
+Replace any JS-thread `onScroll` on the list with this worklet handler — running the header off a JS-thread callback
+reintroduces the frame drops the package exists to avoid.
+
+### FlashList
+
+Wrap `FlashList` the same way. Its ref is an imperative handle rather than a component instance, which the ref contract
+accepts; snapping still reaches the native scrollable through the handle's `getScrollableNode()`.
+
+```tsx
+const AnimatedFlashList = Animated.createAnimatedComponent(FlashList<Transaction>);
+
+const TransactionList = () => {
+    const { onScroll, scrollRef } = useCollapsibleHeaderScroll();
+
+    return (
+        <AnimatedFlashList
+            ref={scrollRef}
+            data={transactions}
+            renderItem={renderItem}
+            onScroll={onScroll}
+            scrollEventThrottle={16}
+        />
+    );
+};
+```
+
+### LegendList
+
+`@legendapp/list` publishes its own Reanimated build. Pass the ref through `refScrollView` — it targets the inner
+animated `ScrollView`, the exact view `scrollTo` drives — and keep the list's own `ref` free for imperative calls:
+
+```tsx
+import { AnimatedLegendList } from '@legendapp/list/reanimated';
+
+const TransactionList = () => {
+    const { onScroll, scrollRef } = useCollapsibleHeaderScroll();
+
+    return (
+        <AnimatedLegendList
+            refScrollView={scrollRef}
+            data={transactions}
+            renderItem={renderItem}
+            onScroll={onScroll}
+            scrollEventThrottle={16}
+        />
+    );
+};
+```
+
+FlashList and LegendList are not dependencies of this package — the ref contract is structural, so nothing needs to be
+installed for the types above to line up.
+
+### Any other scrollable
+
+For a list that neither exposes a scrollable-resolving ref nor an inner ScrollView ref, render the animated ScrollView
+yourself through `renderScrollComponent` (both FlashList and LegendList support it) and attach `scrollRef` there — or
+drop `scrollRef` entirely and keep only `onScroll`, which animates the header while leaving snap off.
 
 ### react-native-web
 

--- a/packages/react-native-collapsible-header/src/index.ts
+++ b/packages/react-native-collapsible-header/src/index.ts
@@ -8,3 +8,4 @@ export type { CollapsibleHeaderMotionConfig } from './interface/collapsible-head
 export type { CollapsibleHeaderProps } from './interface/collapsible-header-props.interface';
 export type { CollapsibleHeaderScroll } from './interface/collapsible-header-scroll.interface';
 export type { CollapsibleHeaderMode } from './type/collapsible-header-mode.type';
+export type { CollapsibleHeaderScrollRef } from './type/collapsible-header-scroll-ref.type';

--- a/packages/react-native-collapsible-header/src/interface/collapsible-header-scroll-worklets-config.interface.ts
+++ b/packages/react-native-collapsible-header/src/interface/collapsible-header-scroll-worklets-config.interface.ts
@@ -1,0 +1,12 @@
+import type { CollapsibleHeaderSnapConfig } from './collapsible-header-snap-config.interface';
+import type { CollapsibleHeaderScrollRef } from '../type/collapsible-header-scroll-ref.type';
+import type { Maybe } from '@rnw-community/shared';
+import type { SharedValue } from 'react-native-reanimated';
+
+export interface CollapsibleHeaderScrollWorkletsConfig {
+    readonly scrollY: SharedValue<number>;
+    readonly scrollRef: CollapsibleHeaderScrollRef;
+    readonly snapConfig: SharedValue<Maybe<CollapsibleHeaderSnapConfig>>;
+    readonly snapSettleGeneration: SharedValue<number>;
+    readonly snapAnimated: boolean;
+}

--- a/packages/react-native-collapsible-header/src/interface/collapsible-header-scroll.interface.ts
+++ b/packages/react-native-collapsible-header/src/interface/collapsible-header-scroll.interface.ts
@@ -1,5 +1,5 @@
-import type Animated from 'react-native-reanimated';
-import type { AnimatedRef, ScrollHandlerProcessed, SharedValue } from 'react-native-reanimated';
+import type { CollapsibleHeaderScrollRef } from '../type/collapsible-header-scroll-ref.type';
+import type { ScrollHandlerProcessed, SharedValue } from 'react-native-reanimated';
 
 /**
  * Exposes the provider-owned scroll wiring for attaching a scrollable to a collapsible header.
@@ -11,5 +11,5 @@ export interface CollapsibleHeaderScroll {
     /** Scroll handler to attach to the scrollable's `onScroll`. */
     readonly onScroll: ScrollHandlerProcessed;
     /** Animated ref to attach to the scrollable so snapping can drive it. */
-    readonly scrollRef: AnimatedRef<Animated.ScrollView>;
+    readonly scrollRef: CollapsibleHeaderScrollRef;
 }

--- a/packages/react-native-collapsible-header/src/provider/collapsible-header-provider/collapsible-header-provider-reduced-motion.spec.tsx
+++ b/packages/react-native-collapsible-header/src/provider/collapsible-header-provider/collapsible-header-provider-reduced-motion.spec.tsx
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { Text } from 'react-native';
+import Animated, { scrollTo } from 'react-native-reanimated';
+
+import { CollapsibleHeader } from '../../collapsible-header/collapsible-header';
+import { useCollapsibleHeaderScroll } from '../../hooks/use-collapsible-header-scroll/use-collapsible-header-scroll.hook';
+
+import { CollapsibleHeaderProvider } from './collapsible-header-provider';
+
+let mockReducedMotion = false;
+
+jest.mock('react-native-reanimated', () => {
+    const actual = jest.requireActual<Record<string, unknown>>('react-native-reanimated');
+    const overrides: Record<string, unknown> = { scrollTo: jest.fn(), useReducedMotion: () => mockReducedMotion };
+
+    return new Proxy(actual, {
+        get: (target, property: string) => (property in overrides ? overrides[property] : target[property]),
+    });
+});
+
+type FrameCallback = (time: number) => void;
+
+const EXPANDED_HEIGHT = 156;
+const COLLAPSED_HEIGHT = 40;
+const COLLAPSE_START = 20;
+const COLLAPSE_DISTANCE = 80;
+const SETTLED_OFFSET = 40;
+const SETTLE_FRAME_COUNT = 3;
+
+let pendingFrames: FrameCallback[] = [];
+
+const runFrames = (count: number): void => {
+    Array.from({ length: count }).forEach(() => {
+        const frames = pendingFrames;
+        pendingFrames = [];
+        frames.forEach(frame => void frame(0));
+    });
+};
+
+const Scrollable = () => {
+    const { onScroll, scrollRef } = useCollapsibleHeaderScroll();
+
+    return <Animated.ScrollView testID="scrollable" ref={scrollRef} onScroll={onScroll} scrollEventThrottle={16} />;
+};
+
+const settleScrollMidTransition = (): void => {
+    const screen = render(
+        <CollapsibleHeaderProvider>
+            <CollapsibleHeader
+                snap
+                expandedHeight={EXPANDED_HEIGHT}
+                collapsedHeight={COLLAPSED_HEIGHT}
+                collapseStart={COLLAPSE_START}
+                collapseDistance={COLLAPSE_DISTANCE}
+                expandedContent={<Text>Expanded</Text>}
+                collapsedContent={<Text>Collapsed</Text>}
+            />
+            <Scrollable />
+        </CollapsibleHeaderProvider>
+    );
+    const element = screen.getByTestId('scrollable');
+    const nativeEvent = { nativeEvent: { contentOffset: { x: 0, y: SETTLED_OFFSET } } };
+
+    fireEvent.scroll(element, nativeEvent);
+    fireEvent(element, 'scrollEndDrag', nativeEvent);
+    runFrames(SETTLE_FRAME_COUNT);
+};
+
+describe('CollapsibleHeaderProvider reduced motion', () => {
+    beforeEach(() => {
+        pendingFrames = [];
+        jest.mocked(scrollTo).mockClear();
+        jest.spyOn(globalThis, 'requestAnimationFrame').mockImplementation(frame => pendingFrames.push(frame));
+    });
+
+    afterEach(() => void jest.restoreAllMocks());
+
+    it('snaps with animation while the system motion setting is untouched', () => {
+        expect.hasAssertions();
+        mockReducedMotion = false;
+
+        settleScrollMidTransition();
+
+        expect(jest.mocked(scrollTo)).toHaveBeenCalledWith(expect.anything(), 0, COLLAPSE_START, true);
+    });
+
+    it('snaps instantly while the system reduces motion', () => {
+        expect.hasAssertions();
+        mockReducedMotion = true;
+
+        settleScrollMidTransition();
+
+        expect(jest.mocked(scrollTo)).toHaveBeenCalledWith(expect.anything(), 0, COLLAPSE_START, false);
+    });
+});

--- a/packages/react-native-collapsible-header/src/provider/collapsible-header-provider/collapsible-header-provider-scrollables.spec.tsx
+++ b/packages/react-native-collapsible-header/src/provider/collapsible-header-provider/collapsible-header-provider-scrollables.spec.tsx
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React, { forwardRef, useImperativeHandle } from 'react';
+import { SectionList, Text } from 'react-native';
+import Animated, { scrollTo } from 'react-native-reanimated';
+
+import { emptyFn } from '@rnw-community/shared';
+
+import { CollapsibleHeader } from '../../collapsible-header/collapsible-header';
+import { useCollapsibleHeaderScroll } from '../../hooks/use-collapsible-header-scroll/use-collapsible-header-scroll.hook';
+
+import { CollapsibleHeaderProvider } from './collapsible-header-provider';
+
+import type { ComponentRef, ReactElement, Ref } from 'react';
+import type { ScrollHandlerProcessed } from 'react-native-reanimated';
+
+jest.mock('react-native-reanimated', () => {
+    const actual = jest.requireActual<Record<string, unknown>>('react-native-reanimated');
+    const overrides: Record<string, unknown> = { scrollTo: jest.fn() };
+
+    return new Proxy(actual, {
+        get: (target, property: string) => (property in overrides ? overrides[property] : target[property]),
+    });
+});
+
+type FrameCallback = (time: number) => void;
+
+interface ScrollableListHandle {
+    readonly getScrollableNode: () => null;
+    readonly scrollToOffset: (offset: number) => void;
+}
+
+const EXPANDED_HEIGHT = 156;
+const COLLAPSED_HEIGHT = 40;
+const COLLAPSE_START = 20;
+const COLLAPSE_DISTANCE = 80;
+const SETTLED_OFFSET = 90;
+const SNAP_END = COLLAPSE_START + COLLAPSE_DISTANCE;
+const SETTLE_FRAME_COUNT = 3;
+const CONTENT_HEIGHT = 1000;
+const CONTENT_WIDTH = 320;
+const LAYOUT_HEIGHT = 600;
+const SCROLLABLE_TEST_ID = 'scrollable';
+const ITEMS = ['first', 'second'];
+const SECTIONS = [{ data: ITEMS }];
+
+const AnimatedSectionList = Animated.createAnimatedComponent(SectionList<string>);
+
+const renderItem = () => <Text>Item</Text>;
+
+const HandleList = forwardRef<ScrollableListHandle, { readonly onScroll: ScrollHandlerProcessed }>(({ onScroll }, ref) => {
+    useImperativeHandle(ref, () => ({ getScrollableNode: () => null, scrollToOffset: emptyFn }));
+
+    return <Animated.ScrollView testID={SCROLLABLE_TEST_ID} onScroll={onScroll} scrollEventThrottle={16} />;
+});
+HandleList.displayName = 'HandleList';
+
+const ScrollViewRefList = ({
+    onScroll,
+    refScrollView,
+}: {
+    readonly onScroll: ScrollHandlerProcessed;
+    readonly refScrollView: Ref<ComponentRef<typeof Animated.ScrollView>>;
+}) => <Animated.ScrollView testID={SCROLLABLE_TEST_ID} ref={refScrollView} onScroll={onScroll} scrollEventThrottle={16} />;
+
+const ScrollViewProbe = () => {
+    const { onScroll, scrollRef } = useCollapsibleHeaderScroll();
+
+    return <Animated.ScrollView testID={SCROLLABLE_TEST_ID} ref={scrollRef} onScroll={onScroll} scrollEventThrottle={16} />;
+};
+
+const FlatListProbe = () => {
+    const { onScroll, scrollRef } = useCollapsibleHeaderScroll();
+
+    return (
+        <Animated.FlatList
+            testID={SCROLLABLE_TEST_ID}
+            ref={scrollRef}
+            data={ITEMS}
+            renderItem={renderItem}
+            onScroll={onScroll}
+            scrollEventThrottle={16}
+        />
+    );
+};
+
+const SectionListProbe = () => {
+    const { onScroll, scrollRef } = useCollapsibleHeaderScroll();
+
+    return (
+        <AnimatedSectionList
+            testID={SCROLLABLE_TEST_ID}
+            ref={scrollRef}
+            sections={SECTIONS}
+            renderItem={renderItem}
+            onScroll={onScroll}
+            scrollEventThrottle={16}
+        />
+    );
+};
+
+const HandleListProbe = () => {
+    const { onScroll, scrollRef } = useCollapsibleHeaderScroll();
+
+    return <HandleList ref={scrollRef} onScroll={onScroll} />;
+};
+
+const ScrollViewRefListProbe = () => {
+    const { onScroll, scrollRef } = useCollapsibleHeaderScroll();
+
+    return <ScrollViewRefList refScrollView={scrollRef} onScroll={onScroll} />;
+};
+
+let pendingFrames: FrameCallback[] = [];
+
+const runFrames = (count: number): void => {
+    Array.from({ length: count }).forEach(() => {
+        const frames = pendingFrames;
+        pendingFrames = [];
+        frames.forEach(frame => void frame(0));
+    });
+};
+
+const renderSnappingScreen = (scrollable: ReactElement): void => {
+    const screen = render(
+        <CollapsibleHeaderProvider>
+            <CollapsibleHeader
+                snap
+                expandedHeight={EXPANDED_HEIGHT}
+                collapsedHeight={COLLAPSED_HEIGHT}
+                collapseStart={COLLAPSE_START}
+                collapseDistance={COLLAPSE_DISTANCE}
+                expandedContent={<Text>Expanded</Text>}
+                collapsedContent={<Text>Collapsed</Text>}
+            />
+            {scrollable}
+        </CollapsibleHeaderProvider>
+    );
+    const element = screen.getByTestId(SCROLLABLE_TEST_ID);
+    const nativeEvent = {
+        nativeEvent: {
+            contentOffset: { x: 0, y: SETTLED_OFFSET },
+            contentSize: { height: CONTENT_HEIGHT, width: CONTENT_WIDTH },
+            layoutMeasurement: { height: LAYOUT_HEIGHT, width: CONTENT_WIDTH },
+        },
+    };
+
+    fireEvent.scroll(element, nativeEvent);
+    fireEvent(element, 'scrollEndDrag', nativeEvent);
+    runFrames(SETTLE_FRAME_COUNT);
+};
+
+describe('CollapsibleHeaderProvider scrollables', () => {
+    beforeEach(() => {
+        pendingFrames = [];
+        jest.mocked(scrollTo).mockClear();
+        jest.spyOn(globalThis, 'requestAnimationFrame').mockImplementation(frame => pendingFrames.push(frame));
+    });
+
+    afterEach(() => void jest.restoreAllMocks());
+
+    it.each([
+        { name: 'an animated ScrollView', scrollable: <ScrollViewProbe /> },
+        { name: 'an animated FlatList', scrollable: <FlatListProbe /> },
+        { name: 'an animated SectionList', scrollable: <SectionListProbe /> },
+        { name: 'a list exposing an imperative handle ref', scrollable: <HandleListProbe /> },
+        { name: 'a list exposing its animated ScrollView ref', scrollable: <ScrollViewRefListProbe /> },
+    ])('snaps $name attached to the provider ref', ({ scrollable }) => {
+        expect.hasAssertions();
+
+        renderSnappingScreen(scrollable);
+
+        expect(jest.mocked(scrollTo)).toHaveBeenCalledWith(expect.anything(), 0, SNAP_END, true);
+    });
+});

--- a/packages/react-native-collapsible-header/src/provider/collapsible-header-provider/collapsible-header-provider.tsx
+++ b/packages/react-native-collapsible-header/src/provider/collapsible-header-provider/collapsible-header-provider.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { useAnimatedRef, useAnimatedScrollHandler, useSharedValue } from 'react-native-reanimated';
+import { useAnimatedRef, useAnimatedScrollHandler, useReducedMotion, useSharedValue } from 'react-native-reanimated';
 
 import { CollapsibleHeaderScrollContext } from '../../context/collapsible-header-scroll.context';
 import { createCollapsibleHeaderScrollWorklets } from '../../util/create-collapsible-header-scroll-worklets/create-collapsible-header-scroll-worklets';
 
 import type { CollapsibleHeaderSnapConfig } from '../../interface/collapsible-header-snap-config.interface';
+import type { CollapsibleHeaderScrollRef } from '../../type/collapsible-header-scroll-ref.type';
 import type { Maybe } from '@rnw-community/shared';
-import type { PropsWithChildren, ReactElement } from 'react';
-import type Animated from 'react-native-reanimated';
+import type { Component, PropsWithChildren, ReactElement } from 'react';
 
 /**
  * Owns the scroll wiring so descendant headers and scrollables connect without manual plumbing.
@@ -15,11 +15,12 @@ import type Animated from 'react-native-reanimated';
  */
 export const CollapsibleHeaderProvider = ({ children }: PropsWithChildren): ReactElement => {
     const scrollY = useSharedValue(0);
-    const scrollRef = useAnimatedRef<Animated.ScrollView>();
+    const scrollRef: CollapsibleHeaderScrollRef = useAnimatedRef<Component>();
     const snapConfig = useSharedValue<Maybe<CollapsibleHeaderSnapConfig>>(null);
     const snapSettleGeneration = useSharedValue(0);
+    const snapAnimated = !useReducedMotion();
     const onScroll = useAnimatedScrollHandler(
-        createCollapsibleHeaderScrollWorklets(scrollY, scrollRef, snapConfig, snapSettleGeneration)
+        createCollapsibleHeaderScrollWorklets({ scrollY, scrollRef, snapConfig, snapSettleGeneration, snapAnimated })
     );
 
     return (

--- a/packages/react-native-collapsible-header/src/type/collapsible-header-scroll-ref.type.ts
+++ b/packages/react-native-collapsible-header/src/type/collapsible-header-scroll-ref.type.ts
@@ -1,0 +1,10 @@
+import type { Component } from 'react';
+import type { AnimatedRef } from 'react-native-reanimated';
+
+type AttachableToAnyScrollableRef = (instance: never) => void;
+
+/**
+ * Animated scroll ref that attaches to any Reanimated-animated scrollable, whatever instance type its `ref` prop declares.
+ * @see https://github.com/rnw-community/rnw-community/tree/master/packages/react-native-collapsible-header#collapsibleheaderscrollref
+ */
+export type CollapsibleHeaderScrollRef = AnimatedRef<Component> & AttachableToAnyScrollableRef;

--- a/packages/react-native-collapsible-header/src/util/create-collapsible-header-scroll-worklets/create-collapsible-header-scroll-worklets.spec.ts
+++ b/packages/react-native-collapsible-header/src/util/create-collapsible-header-scroll-worklets/create-collapsible-header-scroll-worklets.spec.ts
@@ -4,10 +4,9 @@ import { makeMutable, scrollTo } from 'react-native-reanimated';
 import { createCollapsibleHeaderScrollWorklets } from './create-collapsible-header-scroll-worklets';
 
 import type { CollapsibleHeaderSnapConfig } from '../../interface/collapsible-header-snap-config.interface';
+import type { CollapsibleHeaderScrollRef } from '../../type/collapsible-header-scroll-ref.type';
 import type { Maybe } from '@rnw-community/shared';
 import type { NativeScrollEvent } from 'react-native';
-import type Animated from 'react-native-reanimated';
-import type { AnimatedRef } from 'react-native-reanimated';
 
 jest.mock('react-native-reanimated', () => ({
     ...jest.requireActual<Record<string, unknown>>('react-native-reanimated'),
@@ -17,7 +16,7 @@ jest.mock('react-native-reanimated', () => ({
 type FrameCallback = (time: number) => void;
 
 const SNAP_CONFIG: CollapsibleHeaderSnapConfig = { snapStart: 20, snapEnd: 100 };
-const SCROLL_REF = {} as AnimatedRef<Animated.ScrollView>;
+const SCROLL_REF = {} as CollapsibleHeaderScrollRef;
 const SETTLE_FRAME_COUNT = 3;
 const BELOW_MIDPOINT_OFFSET = 40;
 const MID_FLING_OFFSET = 70;
@@ -38,7 +37,7 @@ const runFrames = (count: number): void => {
     Array.from({ length: count }).forEach(() => void runFrame());
 };
 
-const buildSubject = (snapConfigValue: Maybe<CollapsibleHeaderSnapConfig>) => {
+const buildSubject = (snapConfigValue: Maybe<CollapsibleHeaderSnapConfig>, snapAnimated = true) => {
     const scrollY = makeMutable(0);
     const snapConfig = makeMutable<Maybe<CollapsibleHeaderSnapConfig>>(snapConfigValue);
     const snapSettleGeneration = makeMutable(0);
@@ -47,7 +46,13 @@ const buildSubject = (snapConfigValue: Maybe<CollapsibleHeaderSnapConfig>) => {
     return {
         scrollY,
         snapSettleGeneration,
-        worklets: createCollapsibleHeaderScrollWorklets(scrollY, SCROLL_REF, snapConfig, snapSettleGeneration),
+        worklets: createCollapsibleHeaderScrollWorklets({
+            scrollY,
+            scrollRef: SCROLL_REF,
+            snapConfig,
+            snapSettleGeneration,
+            snapAnimated,
+        }),
     };
 };
 
@@ -101,6 +106,17 @@ describe('createCollapsibleHeaderScrollWorklets', () => {
         runFrame();
 
         expect(jest.mocked(scrollTo)).toHaveBeenCalledWith(SCROLL_REF, 0, snapped, true);
+    });
+
+    it('snaps without animation when the system reduces motion', () => {
+        expect.hasAssertions();
+        const { scrollY, worklets } = buildSubject(SNAP_CONFIG, false);
+
+        scrollY.set(BELOW_MIDPOINT_OFFSET);
+        worklets.onEndDrag(buildScrollEvent(BELOW_MIDPOINT_OFFSET));
+        runFrames(SETTLE_FRAME_COUNT);
+
+        expect(jest.mocked(scrollTo)).toHaveBeenCalledWith(SCROLL_REF, 0, SNAP_CONFIG.snapStart, false);
     });
 
     it('snaps from the settled offset instead of the release offset after a fling', () => {

--- a/packages/react-native-collapsible-header/src/util/create-collapsible-header-scroll-worklets/create-collapsible-header-scroll-worklets.ts
+++ b/packages/react-native-collapsible-header/src/util/create-collapsible-header-scroll-worklets/create-collapsible-header-scroll-worklets.ts
@@ -2,26 +2,24 @@ import { scrollTo } from 'react-native-reanimated';
 
 import { getCollapsibleHeaderSnapOffset } from '../get-collapsible-header-snap-offset/get-collapsible-header-snap-offset';
 
-import type { CollapsibleHeaderSnapConfig } from '../../interface/collapsible-header-snap-config.interface';
-import type { Maybe } from '@rnw-community/shared';
+import type { CollapsibleHeaderScrollWorkletsConfig } from '../../interface/collapsible-header-scroll-worklets-config.interface';
 import type { NativeScrollEvent } from 'react-native';
-import type Animated from 'react-native-reanimated';
-import type { AnimatedRef, SharedValue } from 'react-native-reanimated';
 
 const SNAP_SETTLE_FRAME_COUNT = 3;
 
-export const createCollapsibleHeaderScrollWorklets = (
-    scrollY: SharedValue<number>,
-    scrollRef: AnimatedRef<Animated.ScrollView>,
-    snapConfig: SharedValue<Maybe<CollapsibleHeaderSnapConfig>>,
-    snapSettleGeneration: SharedValue<number>
-) => {
+export const createCollapsibleHeaderScrollWorklets = ({
+    scrollY,
+    scrollRef,
+    snapConfig,
+    snapSettleGeneration,
+    snapAnimated,
+}: CollapsibleHeaderScrollWorkletsConfig) => {
     const snapToNearestEndpoint = (offsetY: number): void => {
         'worklet';
 
         const snapOffset = getCollapsibleHeaderSnapOffset(offsetY, snapConfig.get());
         if (snapOffset !== null) {
-            scrollTo(scrollRef, 0, snapOffset, true);
+            scrollTo(scrollRef, 0, snapOffset, snapAnimated);
         }
     };
 


### PR DESCRIPTION
Closes #588. Phase 2 of #582 — both capabilities land upstream so downstream screen-chrome work can peer-depend on them instead of duplicating motion code.

## Reduced-motion-aware snap

`CollapsibleHeaderProvider` now reads Reanimated's `useReducedMotion()` and threads the result into the scroll worklet factory as `snapAnimated`, which forwards it as `scrollTo`'s `animated` argument. With the system "reduce motion" setting on, snapping jumps to the endpoint instead of animating — an unrequested animation the user never initiated now follows the platform preference. There is no prop for it, deliberately.

The worklet factory moved from positional parameters to a single config object: a fifth positional parameter would have broken the repo's `max-params: 4` rule, and the object keeps the call site readable at the provider.

## Generic scrollable support

`CollapsibleHeaderScroll.scrollRef` was typed `AnimatedRef<Animated.ScrollView>`, which only fit `Animated.ScrollView`. It is now the new public type `CollapsibleHeaderScrollRef`:

```ts
type CollapsibleHeaderScrollRef = AnimatedRef<Component> & ((instance: never) => void);
```

`useAnimatedRef<Component>()` satisfies it with no cast (return-type-void assignability), and the extra call signature makes it assignable to `React.Ref<T>` for every `T` through `RefCallback`'s bivariant parameter. One ref therefore attaches to:

- component-instance refs — `Animated.FlatList` (`React.Ref<FlatList>`)
- `createAnimatedComponent` wrappers — `SectionList`, FlashList
- imperative handle refs — FlashList v2's `FlashListRef<T>`, LegendList v3's `LegendListRef`
- a list's inner animated ScrollView ref — LegendList's `refScrollView`

Two alternatives were rejected with evidence:

- A generic type parameter (`useCollapsibleHeaderScroll<TScrollable>()`) cannot cover FlashList or LegendList: Reanimated 3.17 constrains `AnimatedRef<T extends Component>`, and both libraries' refs are plain handle objects, not `Component` instances.
- Plain `AnimatedRef<Component>` fails on `Animated.FlatList` under `@types/react` 19 — `AnimatedRef`'s call signature returns `ShadowNodeWrapper | HTMLElement`, which no `RefCallback` accepts, and its `current: Component | null` fails the `RefObject` branch.

Snap keeps working for handle-based lists because Reanimated's animated ref resolves the native node via `ref.getScrollableNode?.()` / `getNativeScrollRef()`, which `FlashListRef` and `LegendListRef` both expose.

FlashList and LegendList are **not** added as dependencies (not even dev): the contract is structural, so support is type-level plus readme recipes, and the specs use locally declared handle-shaped stubs.

## Documentation

- Readme: new `CollapsibleHeaderScrollRef` section; one recipe per list type (FlatList, SectionList, FlashList, LegendList, plus a `renderScrollComponent` fallback); reduced-motion behavior under `CollapsibleHeaderProvider`; and an explicit "Snap requires a mounted CollapsibleHeader" section — the provider owns the snap slot, the header registers the geometry that fills it, so a provider alone never snaps.
- `AGENTS.md`: the ref-contract decision with its two rejected alternatives, the reduced-motion invariant, the mounted-header snap requirement, and the new files.
- `llms.txt`: the same three facts in the agent-facing summary.

## Verification

- `yarn ts && yarn lint && yarn test` green at the repo root.
- Package `yarn test:coverage`: 13 suites, 98 tests, **100% statements / branches / functions / lines** (threshold 99.9%).
- Package `yarn build`: bob module + commonjs + typescript trees, `assert-esm-extensions` (0 extensionless specifiers) and `assert-react-compiler-output` (15 memoized files per tree) both pass; `yarn ts:nodenext` clean.
- New spec `collapsible-header-provider-reduced-motion.spec.tsx` drives a real provider + snapping header + scrollable through drag-release and the rAF settle watch, asserting `scrollTo` receives `animated: true` normally and `false` under reduced motion.
- New spec `collapsible-header-provider-scrollables.spec.tsx` repeats that flow for five scrollable shapes — animated ScrollView, animated FlatList, animated SectionList, a list exposing an imperative handle ref, and a list exposing its inner animated ScrollView ref — so both the ref types and the snap wiring are checked per shape (specs are type-checked by `yarn ts`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add reduced-motion-aware snap and generic scrollable ref support to `react-native-collapsible-header`
> - Snap animation now respects the OS reduced-motion setting: `useReducedMotion()` derives a `snapAnimated` flag passed to `createCollapsibleHeaderScrollWorklets`, which replaces the hardcoded `animated=true` in `scrollTo` calls.
> - Introduces `CollapsibleHeaderScrollRef`, a new exported type that widens the scrollable ref contract to support `Animated.ScrollView`, `Animated.FlatList`, `SectionList` wrappers, imperative-handle refs (e.g. FlashList), and inner-ref patterns (e.g. LegendList).
> - `CollapsibleHeaderProvider` now instantiates `useAnimatedRef<Component>()` and passes a single config object to `createCollapsibleHeaderScrollWorklets`.
> - New test suites cover reduced-motion snap behavior and snapping across all supported scrollable shapes.
> - Behavioral Change: snap transitions are now instant (no animation) when the user has enabled "Reduce Motion" at the OS level.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39470ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->