### PR TITLE
ci: run maestro on the amd64 fleet's kvm avd instead of arm64 redroid

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,5 +3,9 @@ self-hosted-runner:
         - macOS
         - ARM64
         - macos-maestro
+        # linux-tiered/linux-xl are the arm64 Redroid path the Android suite
+        # used to run on. Kept so a revert of the amd64 move still lints.
         - linux-tiered
         - linux-xl
+        - trf-linux-amd64-4x8
+        - trf-rnw-linux-amd64-4x8

--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -1,21 +1,34 @@
 name: Android Maestro E2E
 
 # Runs the Maestro suite of every example package that carries one. Building the
-# APK and running it against Redroid happen on two different runner pools, and
+# APK and running it against a device happen on two different runner pools, and
 # that split is load-bearing, not stylistic:
 #
 # - build-apk runs on a free GitHub-hosted ubuntu-24.04 (x86_64) runner. Native
 #   Android builds need the NDK's host clang, and Google publishes
 #   linux-x86_64 prebuilts only — no NDK release has ever shipped a
-#   linux-aarch64 host toolchain — so a Gradle build that touches native code
-#   cannot succeed on this repo's arm64 self-hosted fleet at all (confirmed
-#   live: "C compiler identification is unknown",
-#   toolchains/llvm/prebuilt/linux-x86_64/bin/clang missing). This repo is
-#   public, so the GitHub-hosted runner costs nothing.
-# - maestro runs on the self-hosted Linux fleet (issue #395, epic #372) purely
-#   to install the prebuilt APK into Redroid (Android-in-a-privileged-container,
-#   the fleet's only arm64-native way to run Android at all) and drive Maestro.
-#   No Gradle, SDK, or NDK step belongs in this job.
+#   linux-aarch64 host toolchain. That reasoning is unchanged by the runner
+#   move below: the self-hosted amd64 node could host a Gradle build now, but
+#   this repo is public, so the GitHub-hosted runner costs nothing and keeps
+#   fleet capacity for the part that actually needs a device.
+# - maestro runs on the self-hosted x86_64 Linux fleet (tart-runner-fleet
+#   scale set trf-rnw-linux-amd64-4x8) purely to install the prebuilt APK into
+#   a KVM-accelerated Android emulator and drive Maestro. No Gradle, SDK, or
+#   NDK step belongs in this job.
+#
+#   This used to say "arm64-native Redroid is the fleet's only way to run
+#   Android at all", and on the Apple-silicon Linux VMs that was true: no
+#   x86_64 host, no /dev/kvm, so the only option was Android-in-a-privileged-
+#   container on the host kernel. The amd64 node retires that constraint. It
+#   runs jobs in an ephemeral rootless Podman container with /dev/kvm passed
+#   through (`emulator -accel-check` reports accel 0, KVM version 12), so the
+#   real AOSP emulator boots — measured 23s cold, headless, for
+#   system-images;android-34;google_apis;x86_64. That is Google's own image
+#   with Google Play services present, which is what the payments suite needs
+#   and what forced the community GMS Redroid image before. It is also why
+#   Redroid cannot run here even as a fallback: no sudo, no privileged mode,
+#   no docker daemon, so binderfs can never be mounted. The arm64 Redroid path
+#   still exists on the macOS fleet if this ever needs reverting.
 #
 # The package/target matrix comes from .github/scripts/maestro-matrix.mjs,
 # which also decides which suites a pull request actually needs; add new
@@ -193,7 +206,13 @@ jobs:
         if: needs.detect.outputs.any == 'true'
         # Time-boxed: see the same flag in ios-maestro.yml and issue #601.
         continue-on-error: ${{ matrix.package == 'screen-chrome' }}
-        runs-on: [self-hosted, linux-tiered, linux-xl]
+        # 4x8, not 2x4: only the 4cpu/8GB profile of the amd64 scale set has
+        # /dev/kvm. On any other shape the emulator falls back to pure
+        # software emulation of x86_64-on-x86_64, which is slow enough that
+        # every step budget below is wrong. The scale set also advertises its
+        # own name (trf-rnw-linux-amd64-4x8) as a label if this ever has to be
+        # pinned harder than the shape.
+        runs-on: [self-hosted, trf-linux-amd64-4x8]
         # Self-hosted fleet capacity is shared with other repositories, so both the
         # job and every step below carry an explicit bound. See the step comments
         # for how each number was sized. No Gradle/SDK/NDK step runs here anymore
@@ -201,23 +220,27 @@ jobs:
         timeout-minutes: 30
         strategy:
             fail-fast: false
-            # One redroid at a time. Every leg that has ever died mid-boot overlapped
-            # another leg, and upstream reports that a second instance booting on the
-            # same host makes adb unresponsive on both (redroid-doc#904): privileged
-            # containers share the host kernel's binder devices, so the contention is
-            # across runners and no per-container limit can bound it. The legs are
-            # already serialized by fleet capacity most of the time; this makes it a
-            # property of the workflow rather than a coincidence of scheduling.
+            # One device at a time, for a different reason than before. The old
+            # redroid limit was about privileged containers sharing the host
+            # kernel's binder devices; nothing about an ephemeral rootless
+            # container running its own emulator process is shared that way.
+            # What is shared is the host: a booted API-34 AVD measured ~4.2 GB
+            # RSS in the 4x8 shape, so a handful of concurrent legs landing on
+            # one node would contend for RAM and KVM before they contend for
+            # anything else. The serialization stays until that headroom is
+            # measured rather than assumed.
             max-parallel: 1
             matrix:
                 include: ${{ fromJSON(needs.detect.outputs.matrix) }}
         env:
             MAESTRO_DEBUG_OUTPUT_DIRECTORY: ${{ github.workspace }}/${{ matrix.example_dir }}/artifacts/maestro-android-${{ matrix.package }}-${{ matrix.target }}
-            # Several legs can land on the same self-hosted host, so the container
-            # name is per-leg. The data directory and adb port are derived inside the
-            # redroid step: job-level env cannot read the runner context, and docker
-            # assigns the port.
-            REDROID_CONTAINER: redroid-${{ matrix.package }}-${{ matrix.target }}-${{ github.run_id }}
+            # The runner container is ephemeral and holds exactly one AVD, so a
+            # fixed name is unambiguous — no per-leg suffix is needed the way the
+            # shared-host redroid container needed one. The system image is named
+            # here so the create, the fallback SDK install, and the diagnostics
+            # can never disagree about which one this job wants.
+            AVD_NAME: e2e
+            ANDROID_SYSTEM_IMAGE: 'system-images;android-34;google_apis;x86_64'
 
         steps:
             -   name: Checkout repository
@@ -249,189 +272,229 @@ jobs:
                     name: apk-${{ matrix.package }}-${{ matrix.target }}
                     path: .ci-artifacts/apk
 
-            -   name: Install adb
-                # Google ships platform-tools for linux-x86_64 only. On this arm64
-                # fleet that adb cannot exec at all — the shell falls back to parsing
-                # the ELF as a script and reports "Syntax error: word unexpected".
-                # Gradle/SDK/NDK provisioning (and that whole problem) moved to
-                # build-apk's x86_64 runner; this job only needs a working adb to
-                # install the prebuilt APK and drive Maestro, so the distro package
-                # is enough on its own — no Android SDK setup at all here.
-                timeout-minutes: 10
+            -   name: Locate the preinstalled Android SDK
+                id: sdk
+                # The runner image bakes an SDK layer (cmdline-tools,
+                # platform-tools, emulator, platforms;android-34 and the x86_64
+                # system image), but nothing in the contract says ANDROID_HOME is
+                # exported into the job environment, and a future image revision
+                # may move it. So the location is probed instead of assumed, and a
+                # candidate only counts when it can do all three things this job
+                # needs: create an AVD, boot it, and talk to it. Anything short of
+                # that hands over to the setup-android fallback below rather than
+                # failing halfway through `avdmanager create`.
+                timeout-minutes: 3
+                shell: bash
                 run: |
                     set -euo pipefail
-                    if ! dpkg -s adb >/dev/null 2>&1; then
-                      sudo apt-get update -y
-                      sudo apt-get install -y adb
+                    image_dir="system-images/android-34/google_apis/x86_64"
+                    sdk=''
+                    cli_bin=''
+                    for candidate in "${ANDROID_HOME:-}" "${ANDROID_SDK_ROOT:-}" /opt/android-sdk /usr/local/lib/android/sdk "$HOME/Android/Sdk"; do
+                      [ -n "$candidate" ] && [ -d "$candidate" ] || continue
+                      [ -x "$candidate/emulator/emulator" ] || continue
+                      [ -x "$candidate/platform-tools/adb" ] || continue
+                      [ -d "$candidate/$image_dir" ] || continue
+                      cli_bin=''
+                      for bin in "$candidate/cmdline-tools/latest/bin" "$candidate/cmdline-tools/bin" "$candidate/tools/bin"; do
+                        if [ -x "$bin/avdmanager" ]; then cli_bin="$bin"; break; fi
+                      done
+                      [ -n "$cli_bin" ] || continue
+                      sdk="$candidate"
+                      break
+                    done
+                    if [ -z "$sdk" ]; then
+                      echo "sdk=" >> "$GITHUB_OUTPUT"
+                      echo "::warning::No Android SDK on this runner carries all of cmdline-tools, platform-tools, emulator and $ANDROID_SYSTEM_IMAGE; installing one with android-actions/setup-android instead. That still works, it just costs a download this image is supposed to have baked in."
+                      exit 0
                     fi
-                    adb version
+                    echo "Using the preinstalled Android SDK at $sdk"
+                    {
+                      echo "ANDROID_HOME=$sdk"
+                      echo "ANDROID_SDK_ROOT=$sdk"
+                    } >> "$GITHUB_ENV"
+                    {
+                      echo "$cli_bin"
+                      echo "$sdk/platform-tools"
+                      echo "$sdk/emulator"
+                    } >> "$GITHUB_PATH"
+                    echo "sdk=$sdk" >> "$GITHUB_OUTPUT"
 
-            -   name: Start redroid container
-                id: redroid
-                # redroid runs Android on the host kernel instead of emulating a
-                # foreign architecture, so it needs neither KVM nor an x86_64 host —
-                # the two things this arm64 fleet cannot offer. The image is
-                # arm64-native, so its ABI matches the arm64-v8a slice of the release
-                # APK.
-                #
-                # 20 minutes, not 15: a host whose prewarm manifest names a different
-                # image cold-pulls ~1.1 GB and pays Android's first boot plus GMS
-                # first-run initialization in this step.
-                timeout-minutes: 20
+            -   name: Set up Android SDK (fallback)
+                # Only when the probe above found nothing usable, so the job keeps
+                # working across runner image revisions instead of depending on one.
+                if: steps.sdk.outputs.sdk == ''
+                uses: android-actions/setup-android@v3
+                timeout-minutes: 25
+                with:
+                    # Explicit, because the action still defaults to
+                    # "tools platform-tools" and the obsolete "tools" package was
+                    # withdrawn from the Google SDK repository — see the same note
+                    # in build-apk. Unlike build-apk, this job needs the emulator
+                    # and a system image, and no Gradle run is here to resolve them.
+                    packages: 'platform-tools emulator platforms;android-34 ${{ env.ANDROID_SYSTEM_IMAGE }}'
+
+            -   name: Verify the Android SDK and KVM acceleration
+                timeout-minutes: 5
+                shell: bash
                 run: |
                     set -euo pipefail
-                    # darknightlab/redroid-gms overlays MindTheGapps onto the stock
-                    # redroid/redroid:14.0.0_64only-latest base this fleet already
-                    # knows how to run (same binder_linux, privileged-container, and
-                    # GPU-mode requirements). Stock redroid ships no Google Play
-                    # services at all, which made every PaymentRequest show()-path flow
-                    # fail deterministically with "Google Play services is invalid.
-                    # Cannot recover." in logcat. Android 14 instead of 15: no
-                    # maintained prebuilt GMS image for 15 exists, and the fleet
-                    # cannot build one. Pinned by digest because the tag is mutable
-                    # and the publisher is a community account.
-                    REDROID_IMAGE='darknightlab/redroid-gms:14.0.0_64only-latest@sha256:849bb5ec8d14e9409535ff1a2ca6c2c603555aeb4e36a47b6f984524095e6f0a'
-                    # binder_linux must load on every boot. /dev/binder* is not a
-                    # reliable presence signal: on 6.x binderfs kernels no
-                    # /dev/binder, /dev/hwbinder, or /dev/vndbinder node ever appears
-                    # on the host at all — the privileged container mounts binderfs
-                    # and creates its own — so /sys/module/binder_linux is the only
-                    # portable check, and it is checked only after modprobe rather
-                    # than instead of it. A precondition that only checks and never
-                    # loads is a false positive on exactly the hosts redroid needs it
-                    # most on, and that false positive is what let eight runners die.
-                    sudo modprobe binder_linux devices=binder,hwbinder,vndbinder 2>&1 || true
-                    if [ ! -d /sys/module/binder_linux ]; then
-                      echo "::error::binder_linux is not loaded on this host after modprobe. Redroid cannot run without it, and that is host-kernel provisioning a workflow run cannot self-heal safely."
+                    sdk="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+                    if [ -z "$sdk" ] || [ ! -d "$sdk" ]; then
+                      echo "::error::Neither the probe nor android-actions/setup-android left a usable Android SDK on this runner."
                       exit 1
                     fi
-                    # Every wait below can only fail as a timeout, which says nothing
-                    # about why Android did not come up. The container's own log does,
-                    # and so does whether this host's docker is rootless — under
-                    # rootless docker `--privileged` grants nothing, redroid cannot
-                    # mount binderfs, and the container stays up while adbd never
-                    # listens, which looks exactly like a slow boot.
-                    dump_redroid_state() {
-                      echo "::group::redroid diagnostics"
-                      docker info --format 'security options: {{.SecurityOptions}}' || true
-                      # Upstream wants binder_linux and ashmem_linux; Android 12+ uses
-                      # memfd instead of ashmem, so a missing ashmem is reported rather
-                      # than treated as fatal. Neighbouring containers matter too — a
-                      # second redroid booting on this kernel destabilizes both.
-                      lsmod | grep -E '^(binder_linux|ashmem_linux)' || echo "no binder/ashmem module rows"
-                      docker ps --filter "ancestor=$REDROID_IMAGE" --format 'neighbour: {{.Names}} {{.Status}}' || true
-                      docker ps -a --filter "name=$REDROID_CONTAINER" --format '{{.Names}}: {{.Status}}' || true
-                      docker logs --tail 200 "$REDROID_CONTAINER" 2>&1 || true
+                    # setup-android puts cmdline-tools and platform-tools on PATH
+                    # but not emulator/, and on the probe path GITHUB_PATH only
+                    # takes effect for later steps — this one included. Both routes
+                    # converge here.
+                    for dir in "$sdk/cmdline-tools/latest/bin" "$sdk/platform-tools" "$sdk/emulator"; do
+                      [ -d "$dir" ] || continue
+                      case ":$PATH:" in
+                        *":$dir:"*) ;;
+                        *) echo "$dir" >> "$GITHUB_PATH"; PATH="$dir:$PATH" ;;
+                      esac
+                    done
+                    adb version
+                    # sed -n '1p', not `head -n 1`: head exits at the first line
+                    # and the still-writing emulator then dies of SIGPIPE, which
+                    # under pipefail fails this step over a log line.
+                    emulator -version 2>&1 | sed -n '1p'
+                    # The one hard precondition of this job, checked rather than
+                    # assumed. /dev/kvm is passed into the runner container only on
+                    # the 4x8 profile of the scale set; anywhere else the emulator
+                    # still starts, at software-emulation speed, and every timeout
+                    # below becomes wrong for reasons no log would explain.
+                    # The exit status is checked *and* the message is matched:
+                    # accel-check has shipped builds that report a negative accel
+                    # code and still exit 0, and a precondition that only looks at
+                    # one of the two is a false positive on exactly the host it
+                    # exists to catch. A healthy node prints
+                    # "accel: 0 KVM (version 12) is installed and usable".
+                    accel_status=0
+                    accel_output="$(emulator -accel-check 2>&1)" || accel_status=$?
+                    echo "$accel_output"
+                    if [ "$accel_status" -ne 0 ] || ! grep -q 'is installed and usable' <<<"$accel_output"; then
+                      echo "::error::This runner has no usable KVM acceleration. The maestro job must run on the trf-linux-amd64-4x8 profile — it is the only one of the amd64 scale set's shapes that passes /dev/kvm into the job container."
+                      exit 1
+                    fi
+
+            -   name: Create the AVD
+                id: avd
+                # An AVD created with no --device inherits whatever skin the
+                # system image happens to ship, which is not a stable contract
+                # across image revisions. The suite's flows are written against a
+                # phone-shaped screen — they scroll by percentage, and several of
+                # them (see the "CI device profile" comments in the payments
+                # flows) care where the fold lands — so the profile is named. The
+                # fallbacks exist because the device catalogue belongs to
+                # cmdline-tools, not to this workflow.
+                timeout-minutes: 5
+                shell: bash
+                run: |
+                    set -euo pipefail
+                    devices="$(avdmanager list device -c)"
+                    device=''
+                    for candidate in pixel_6 pixel_5 pixel_4 pixel; do
+                      if grep -qx "$candidate" <<<"$devices"; then
+                        device="$candidate"
+                        break
+                      fi
+                    done
+                    if [ -z "$device" ]; then
+                      echo "::error::None of the expected phone device profiles (pixel_6, pixel_5, pixel_4, pixel) exist in this cmdline-tools' device catalogue."
+                      exit 1
+                    fi
+                    echo "Creating AVD '$AVD_NAME' from $ANDROID_SYSTEM_IMAGE on device profile $device"
+                    # `echo no`: avdmanager prompts for a custom hardware profile
+                    # even when --device is given, and an unanswered prompt is a
+                    # hang, not an error.
+                    echo no | avdmanager create avd --force -n "$AVD_NAME" -k "$ANDROID_SYSTEM_IMAGE" --device "$device"
+                    # ANDROID_AVD_HOME wins if the image sets it: avdmanager and
+                    # the emulator both honour it, so hardcoding ~/.android/avd
+                    # would edit a config.ini neither of them reads.
+                    config="${ANDROID_AVD_HOME:-$HOME/.android/avd}/$AVD_NAME.avd/config.ini"
+                    test -f "$config"
+                    # Appended, not edited: the AVD config parser keeps the last
+                    # occurrence of a key, so this overrides the generated values
+                    # without having to rewrite a file avdmanager owns.
+                    {
+                      echo "hw.ramSize=2048"
+                      # Maestro's driver types through the hardware keyboard; a
+                      # soft-keyboard-only AVD turns text input into flake.
+                      echo "hw.keyboard=yes"
+                      echo "hw.gpu.enabled=yes"
+                      echo "hw.gpu.mode=swiftshader_indirect"
+                    } >> "$config"
+                    avdmanager list avd
+
+            -   name: Boot the emulator
+                id: emulator
+                # 10 minutes against a 23s measured cold boot on this node: the
+                # budget is here to catch a wedged boot, not to bound a healthy
+                # one. The redroid step it replaces needed 20 because it could
+                # cold-pull a 1.1 GB image and then pay Android's plus GMS's first
+                # boot; a baked system image pays neither.
+                timeout-minutes: 10
+                shell: bash
+                run: |
+                    set -euo pipefail
+                    emulator_log="$RUNNER_TEMP/emulator.log"
+                    echo "EMULATOR_LOG=$emulator_log" >> "$GITHUB_ENV"
+                    # Every wait below can only fail as a timeout, which says
+                    # nothing about why Android did not come up. The emulator's own
+                    # stdout does — a refused /dev/kvm, a corrupt AVD, and a guest
+                    # kernel panic all look identical from the outside.
+                    dump_emulator_state() {
+                      echo "::group::emulator diagnostics"
+                      tail -n 200 "$emulator_log" 2>/dev/null || echo "no emulator log at $emulator_log"
+                      adb devices -l || true
                       echo "::endgroup::"
                     }
-                    trap dump_redroid_state ERR
-                    docker rm -f "$REDROID_CONTAINER" >/dev/null 2>&1 || true
-                    REDROID_DATA_DIR="$RUNNER_TEMP/$REDROID_CONTAINER"
-                    echo "REDROID_DATA_DIR=$REDROID_DATA_DIR" >> "$GITHUB_ENV"
-                    rm -rf "$REDROID_DATA_DIR"
-                    mkdir -p "$REDROID_DATA_DIR"
-                    # Seed /data from the fleet's prewarmed volume the same way
-                    # vitalyiegorov/suuudokuuu does (prewarm-redroid-linux.sh): a
-                    # first-boot-completed, animations-off /data cuts boot from
-                    # minutes to seconds. Cold-pulling and cold-booting redroid is
-                    # exactly the path three independent sources tie to the guest
-                    # kernel hard-locking on this fleet, so this is not optional on
-                    # runners that have been prewarmed.
-                    REDROID_PREWARM_MANIFEST="$HOME/.sudoku-ci/android-emulator.json"
-                    if [ -f "$REDROID_PREWARM_MANIFEST" ]; then
-                      # `|| true`: under pipefail, a manifest with no "dataDir"/"image"
-                      # key makes grep exit 1 with no output, and that failure
-                      # propagates through the pipe even though sed exits 0 — which
-                      # would abort the whole step here instead of reaching the
-                      # unusable-manifest fallback below. An empty PREWARM_DATA_DIR is
-                      # exactly what that fallback branch is for.
-                      PREWARM_DATA_DIR=$(grep -o '"dataDir"[[:space:]]*:[[:space:]]*"[^"]*"' "$REDROID_PREWARM_MANIFEST" | sed -E 's/.*:[[:space:]]*"([^"]*)"/\1/' || true)
-                      PREWARM_IMAGE=$(grep -o '"image"[[:space:]]*:[[:space:]]*"[^"]*"' "$REDROID_PREWARM_MANIFEST" | sed -E 's/.*:[[:space:]]*"([^"]*)"/\1/' || true)
-                      # A /data volume is only reusable by the exact image that booted
-                      # it: seeding the GMS image from a tree first-booted by a
-                      # different Android build (the fleet's manifests still name
-                      # stock redroid/redroid:15.0.0_64only-latest until they are
-                      # re-prewarmed) would boot Android 14 GMS on Android 15
-                      # first-boot state. That mismatch cold-pulls instead, which is
-                      # slower but correct, and is also what makes the first run after
-                      # this image bump possible before any host has been re-prewarmed.
-                      if [ "$PREWARM_IMAGE" != "$REDROID_IMAGE" ]; then
-                        echo "::warning::Prewarm manifest $REDROID_PREWARM_MANIFEST was built for image '$PREWARM_IMAGE', not '$REDROID_IMAGE'; ignoring its dataDir and falling back to a cold pull and cold boot until the host is re-prewarmed."
-                        PREWARM_DATA_DIR=''
-                      fi
-                      if [ -n "$PREWARM_DATA_DIR" ] && [ -d "$PREWARM_DATA_DIR" ]; then
-                        echo "Seeding redroid /data from the prewarmed volume at $PREWARM_DATA_DIR (manifest: $REDROID_PREWARM_MANIFEST)."
-                        # The prewarmed tree is root-owned (redroid writes it as root
-                        # inside a --privileged container), so a plain cp as the
-                        # unprivileged runner user fails "Permission denied" on most
-                        # of /data. mobile-ci's run-maestro-android-redroid action hits
-                        # the same requirement and also shells out through sudo, for
-                        # both the seed (here) and the teardown rm below.
-                        sudo cp -a "$PREWARM_DATA_DIR/." "$REDROID_DATA_DIR/"
-                      else
-                        # The image-mismatch branch above already explained itself; a
-                        # second warning here would misattribute the fallback to a
-                        # broken manifest.
-                        if [ "$PREWARM_IMAGE" = "$REDROID_IMAGE" ]; then
-                          echo "::warning::Prewarm manifest $REDROID_PREWARM_MANIFEST does not name a usable dataDir ($PREWARM_DATA_DIR); falling back to a cold pull and cold boot."
-                        fi
-                        docker pull "$REDROID_IMAGE"
-                      fi
-                    else
-                      echo "::warning::No prewarm manifest at $REDROID_PREWARM_MANIFEST; this runner was not prewarmed by the fleet, so redroid will cold-pull and cold-boot instead of seeding /data from a prewarmed volume."
-                      docker pull "$REDROID_IMAGE"
-                    fi
-                    # An unbounded container took every runner down with "the self-hosted
-                    # runner lost communication with the server" — the runner agent has to
-                    # keep reporting while Android boots, and in guest GPU mode that boot
-                    # is pure CPU work, so the container is held to all but two cores and
-                    # a memory ceiling. --memory-swap matches --memory (Docker otherwise
-                    # allows 2x swap) so a bloated redroid cannot page out the runner
-                    # agent instead of being OOM-killed itself. The display flags are
-                    # dropped: the prewarmed /data volume was created at redroid's
-                    # defaults, and booting it under a different display config is
-                    # untested; nothing in the suite depends on the pixel count anyway,
-                    # every gesture is expressed in percentages.
-                    container_cpus=$(( $(nproc) > 3 ? $(nproc) - 2 : 1 ))
-                    echo "host cores: $(nproc); container limited to ${container_cpus}"
-                    # 8g, not 6g: GMS adds its own service constellation on top of
-                    # stock Android, and a first boot additionally pays GMS
-                    # initialization; the ceiling still exists so a bloated redroid is
-                    # OOM-killed instead of paging out the runner agent.
-                    docker run -d --privileged \
-                      --name "$REDROID_CONTAINER" \
-                      --cpus "$container_cpus" \
-                      --memory 8g \
-                      --memory-swap 8g \
-                      -p 127.0.0.1::5555 \
-                      -v "$REDROID_DATA_DIR:/data" \
-                      "$REDROID_IMAGE" \
-                      androidboot.redroid_gpu_mode=guest
-                    # The export is load-bearing: the wait loops below run in a child
-                    # `bash -c`, whose single quotes defer expansion to that child, and
-                    # $GITHUB_ENV only reaches later steps. Unexported, the child saw an
-                    # empty port and polled `adb connect 127.0.0.1:` until the timeout —
-                    # a 124 that read as "redroid never booted" while it had booted fine.
-                    export ADB_PORT
-                    ADB_PORT=$(docker port "$REDROID_CONTAINER" 5555/tcp | head -1 | sed 's/.*://')
-                    test -n "$ADB_PORT"
-                    echo "ADB_PORT=$ADB_PORT" >> "$GITHUB_ENV"
+                    trap dump_emulator_state ERR
+                    # -no-window and swiftshader_indirect because the runner
+                    # container is headless with no GPU to pass through;
+                    # -no-snapshot so every leg boots the same way instead of
+                    # resuming whatever the previous one left behind.
+                    nohup emulator -avd "$AVD_NAME" \
+                      -no-window -no-audio -no-boot-anim \
+                      -gpu swiftshader_indirect \
+                      -no-snapshot -no-metrics \
+                      -netdelay none -netspeed full \
+                      > "$emulator_log" 2>&1 &
+                    echo "EMULATOR_PID=$!" >> "$GITHUB_ENV"
                     adb start-server
-                    timeout 180 bash -c 'until adb connect "127.0.0.1:$ADB_PORT" | grep -q connected; do sleep 3; done'
-                    timeout 300 adb -s "127.0.0.1:$ADB_PORT" wait-for-device
-                    # A killed runner uploads no log at all, so the boot narrates itself
-                    # into the live stream as it goes: load average beside the boot
-                    # properties is what separates "starved" from "stuck".
-                    device="127.0.0.1:$ADB_PORT"
-                    export device
-                    # 600, not 300: a cold first boot of the GMS image also runs GMS
-                    # first-run initialization before sys.boot_completed flips, and
-                    # that is the guaranteed path on every host until its prewarm
-                    # manifest is rebuilt for this image.
-                    timeout 600 bash -c 'until [ "$(adb -s "$device" shell getprop sys.boot_completed | tr -d "\r")" = "1" ]; do
-                      echo "booting: bootanim=$(adb -s "$device" shell getprop init.svc.bootanim | tr -d "\r") load=$(cut -d" " -f1-3 /proc/loadavg)"
-                      sleep 10
+                    timeout 120 adb wait-for-device
+                    # Derived, not assumed to be emulator-5554: the console port is
+                    # whatever was free when the emulator claimed it. The device
+                    # list is captured first because an awk that exits at the first
+                    # match would SIGPIPE adb, and under pipefail that is a step
+                    # failure rather than a match.
+                    devices="$(adb devices)"
+                    serial="$(awk '/^emulator-[0-9]+/ { print $1; exit }' <<<"$devices")"
+                    test -n "$serial"
+                    echo "ANDROID_SERIAL=$serial" >> "$GITHUB_ENV"
+                    # The export is load-bearing: the wait loop below runs in a
+                    # child `bash -c` whose single quotes defer expansion to that
+                    # child, and $GITHUB_ENV only reaches later steps.
+                    export ANDROID_SERIAL="$serial"
+                    # 300s against a measured 23s — generous on purpose. It
+                    # narrates itself as it goes because a killed runner uploads no
+                    # artifact at all, so the boot has to be readable in the live
+                    # log: load average beside the boot properties is what
+                    # separates "starved" from "stuck".
+                    timeout 300 bash -c 'until [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d "\r")" = "1" ]; do
+                      echo "booting: bootanim=$(adb shell getprop init.svc.bootanim 2>/dev/null | tr -d "\r") load=$(cut -d" " -f1-3 /proc/loadavg)"
+                      sleep 5
                     done'
+                    # Dismiss the lock screen the stock image boots into, then turn
+                    # animations off — the same property the prewarmed redroid
+                    # /data volume used to carry, and one Maestro's waits depend on
+                    # more than anything else here.
+                    adb shell input keyevent 82 || true
+                    for scale in window_animation_scale transition_animation_scale animator_duration_scale; do
+                      adb shell settings put global "$scale" 0 || true
+                    done
                     adb devices -l
 
             -   name: Install Maestro
@@ -583,14 +646,14 @@ jobs:
                     echo "Installed and using maestro $MAESTRO_VERSION at $pinned_bin"
 
             -   name: Install APK and run Maestro tests
-                id: emulator
+                id: tests
                 # Step-level flag (the job-level one is not honored for the check
                 # run conclusion on this runner): see the job-level comment.
                 continue-on-error: ${{ matrix.package == 'screen-chrome' }}
-                # redroid is already booted (previous step) and the APK is already
-                # built (build-apk, a GitHub-hosted x86_64 runner — see the
-                # top-of-file note on why native builds can't run here). This step
-                # is install + test only.
+                # The emulator is already booted (previous step) and the APK is
+                # already built (build-apk, a GitHub-hosted x86_64 runner — see the
+                # top-of-file note on why the build stays there). This step is
+                # install + test only.
                 timeout-minutes: 20
                 shell: bash
                 run: |
@@ -598,52 +661,64 @@ jobs:
                     set -x
                     apk=$(find .ci-artifacts/apk -name '*.apk' | head -1)
                     test -n "$apk"
-                    timeout 300 adb -s "127.0.0.1:$ADB_PORT" install -r "$apk"
+                    # The APK is universal (all four reactNativeArchitectures), so
+                    # the x86_64 slice this emulator needs is in the same artifact
+                    # the arm64 redroid path used to install.
+                    timeout 300 adb -s "$ANDROID_SERIAL" install -r "$apk"
                     cd "${{ matrix.example_dir }}"
                     pnpm e2e:android:${{ matrix.target }}
 
             -   name: Capture final device state
-                # Only meaningful when the redroid container booted and the test step
-                # then failed. If setup failed earlier, this is skipped instead of
+                # Only meaningful when the emulator booted and the test step then
+                # failed. If setup failed earlier, this is skipped instead of
                 # talking to an adb server that has no device.
-                if: failure() || steps.emulator.outcome == 'failure' || steps.redroid.outcome == 'failure'
+                if: failure() || steps.tests.outcome == 'failure' || steps.emulator.outcome == 'failure'
                 # A diagnostic must never outlive the test it is diagnosing.
                 timeout-minutes: 3
                 shell: bash
                 run: |
                     out="${{ env.MAESTRO_DEBUG_OUTPUT_DIRECTORY }}"
                     mkdir -p "$out"
-                    docker logs "$REDROID_CONTAINER" > "$out/redroid-container.log" 2>&1 || true
-                    if ! timeout 30 adb -s "127.0.0.1:$ADB_PORT" wait-for-device; then
+                    # The emulator's own stdout is what `docker logs` used to be
+                    # here: it is the only place a refused /dev/kvm, a corrupt AVD,
+                    # or a guest kernel panic is reported.
+                    if [ -n "${EMULATOR_LOG:-}" ] && [ -f "$EMULATOR_LOG" ]; then
+                      cp "$EMULATOR_LOG" "$out/emulator.log" || true
+                    fi
+                    # ANDROID_SERIAL is only set once the emulator has registered
+                    # with adb; a boot that failed before that leaves it unset, and
+                    # an empty -s argument is not a parseable adb target.
+                    if [ -z "${ANDROID_SERIAL:-}" ]; then
+                      echo "No emulator serial was recorded; skipping device state capture."
+                      exit 0
+                    fi
+                    if ! timeout 30 adb -s "$ANDROID_SERIAL" wait-for-device; then
                       echo "No device attached after 30s; skipping device state capture."
                       exit 0
                     fi
-                    device="127.0.0.1:$ADB_PORT"
-                    timeout 30 adb -s "$device" exec-out screencap -p > "$out/final-screen.png" || true
-                    timeout 60 adb -s "$device" logcat -d > "$out/logcat-full.txt" 2>&1 || true
-                    timeout 30 adb -s "$device" logcat -d -b crash > "$out/logcat-crash.txt" 2>&1 || true
+                    timeout 30 adb -s "$ANDROID_SERIAL" exec-out screencap -p > "$out/final-screen.png" || true
+                    timeout 60 adb -s "$ANDROID_SERIAL" logcat -d > "$out/logcat-full.txt" 2>&1 || true
+                    timeout 30 adb -s "$ANDROID_SERIAL" logcat -d -b crash > "$out/logcat-crash.txt" 2>&1 || true
 
-            -   name: Stop redroid container
-                # The fleet is shared, so a leaked privileged container (and its data
-                # directory) must never outlive the job that started it.
+            -   name: Stop the emulator
+                # The runner container is ephemeral, so this is not the leak guard
+                # the redroid teardown had to be — but a live emulator holds
+                # /dev/kvm and a lock on the AVD, and shutting it down cleanly is
+                # cheaper than making the container teardown do it by force.
                 if: always()
-                timeout-minutes: 5
+                timeout-minutes: 3
                 shell: bash
                 run: |
-                    # ADB_PORT is only set once the container is up and docker has
-                    # assigned it a host port; a redroid step that failed before that
-                    # point leaves it unset, and "127.0.0.1:0" is not a parseable adb
-                    # target, so this is skipped rather than logging a spurious error.
-                    if [ -n "${ADB_PORT:-}" ]; then adb disconnect "127.0.0.1:$ADB_PORT" || true; fi
-                    docker rm -f "$REDROID_CONTAINER" || true
-                    # sudo: seeding from the prewarmed volume (above) leaves this tree
-                    # root-owned, same as mobile-ci's run-maestro-android-redroid.
-                    if [ -n "${REDROID_DATA_DIR:-}" ]; then sudo rm -rf "$REDROID_DATA_DIR" || true; fi
+                    if [ -n "${ANDROID_SERIAL:-}" ]; then
+                      adb -s "$ANDROID_SERIAL" emu kill || true
+                    fi
+                    adb kill-server || true
+                    if [ -n "${EMULATOR_PID:-}" ]; then kill "$EMULATOR_PID" 2>/dev/null || true; fi
 
             -   name: Upload Maestro artifacts
                 # Matches the capture step's condition — gating this on the test step
-                # alone discarded the container log whenever setup was what failed.
-                if: failure() || steps.emulator.outcome == 'failure' || steps.redroid.outcome == 'failure'
+                # alone discarded the emulator log whenever setup was what failed.
+                if: failure() || steps.tests.outcome == 'failure' || steps.emulator.outcome == 'failure'
                 uses: actions/upload-artifact@v4
                 timeout-minutes: 5
                 with:

--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -216,8 +216,10 @@ jobs:
         # Self-hosted fleet capacity is shared with other repositories, so both the
         # job and every step below carry an explicit bound. See the step comments
         # for how each number was sized. No Gradle/SDK/NDK step runs here anymore
-        # (see build-apk), so this budget is boot + install + test only.
-        timeout-minutes: 30
+        # (see build-apk), so this budget is boot + settle + install + test only.
+        # 35, not 30: the boot step now waits for the device to settle as well as
+        # to boot, and a full suite measured ~3 minutes of Maestro on top.
+        timeout-minutes: 35
         strategy:
             fail-fast: false
             # One device at a time, for a different reason than before. The old
@@ -381,35 +383,44 @@ jobs:
 
             -   name: Create the AVD
                 id: avd
-                # An AVD created with no --device inherits whatever skin the
-                # system image happens to ship, which is not a stable contract
-                # across image revisions. The suite's flows are written against a
-                # phone-shaped screen — they scroll by percentage, and several of
-                # them (see the "CI device profile" comments in the payments
-                # flows) care where the fold lands — so the profile is named. The
-                # fallbacks exist because the device catalogue belongs to
-                # cmdline-tools, not to this workflow.
+                # The display is pinned to 720x1280 @ 320dpi because that is the
+                # display redroid presented, and the suite's flows are calibrated
+                # against it — not because it is a nice round number.
+                #
+                # The first amd64 run created this AVD from the `pixel_6` device
+                # profile (1080x2400 @ 420dpi) and three legs failed. Two proofs
+                # that the display was the cause:
+                #
+                #  1. snap_to_nearest_endpoint documents its own calibration:
+                #     the Android swipe releases between "the snap midpoint
+                #     (78dp) and the snap end (156dp)", with "offset =
+                #     travel/2". Its swipe travels 75%->37% = 38% of the
+                #     viewport height. At redroid's 640dp viewport that is
+                #     243dp of travel and a 122dp release — inside the window.
+                #     At pixel_6's 914dp viewport it is 347dp of travel and a
+                #     174dp release — past the snap end, so the flow no longer
+                #     tests a snap at all. The collapsible-header legs failed on
+                #     exactly the two flows that depend on where the release
+                #     lands.
+                #  2. pixel_6 has a punch-hole cutout redroid never had:
+                #     `displayCutoutSafeInsets=Rect(0, 128 - 0, 0)` in the
+                #     captured logcat of both failing collapsible-header legs.
+                #     128px at 420dpi is a 49dp top inset instead of the plain
+                #     24dp status bar, which moves every safe-area-inset layout —
+                #     and the expo apps render edge-to-edge, which is why the
+                #     expo leg lost its header buttons on all 7 flows.
+                #
+                # So no --device profile is used at all: a profile is exactly the
+                # thing that reintroduces a cutout and a resolution this suite is
+                # not written for. The geometry is stated outright instead.
                 timeout-minutes: 5
                 shell: bash
                 run: |
                     set -euo pipefail
-                    devices="$(avdmanager list device -c)"
-                    device=''
-                    for candidate in pixel_6 pixel_5 pixel_4 pixel; do
-                      if grep -qx "$candidate" <<<"$devices"; then
-                        device="$candidate"
-                        break
-                      fi
-                    done
-                    if [ -z "$device" ]; then
-                      echo "::error::None of the expected phone device profiles (pixel_6, pixel_5, pixel_4, pixel) exist in this cmdline-tools' device catalogue."
-                      exit 1
-                    fi
-                    echo "Creating AVD '$AVD_NAME' from $ANDROID_SYSTEM_IMAGE on device profile $device"
-                    # `echo no`: avdmanager prompts for a custom hardware profile
-                    # even when --device is given, and an unanswered prompt is a
-                    # hang, not an error.
-                    echo no | avdmanager create avd --force -n "$AVD_NAME" -k "$ANDROID_SYSTEM_IMAGE" --device "$device"
+                    echo "Creating AVD '$AVD_NAME' from $ANDROID_SYSTEM_IMAGE"
+                    # `echo no`: avdmanager prompts for a custom hardware profile,
+                    # and an unanswered prompt is a hang, not an error.
+                    echo no | avdmanager create avd --force -n "$AVD_NAME" -k "$ANDROID_SYSTEM_IMAGE"
                     # ANDROID_AVD_HOME wins if the image sets it: avdmanager and
                     # the emulator both honour it, so hardcoding ~/.android/avd
                     # would edit a config.ini neither of them reads.
@@ -419,6 +430,20 @@ jobs:
                     # occurrence of a key, so this overrides the generated values
                     # without having to rewrite a file avdmanager owns.
                     {
+                      # 720x1280 @ 320dpi = a 360x640dp viewport, density 2.0.
+                      # See the step comment: this is redroid's default display,
+                      # which is the display every flow in this suite was
+                      # calibrated on.
+                      echo "hw.lcd.width=720"
+                      echo "hw.lcd.height=1280"
+                      echo "hw.lcd.density=320"
+                      # No skin file and no cutout. skin.name doubles as the
+                      # emulator's window geometry, so it has to agree with
+                      # hw.lcd.* or the guest is letterboxed into a display the
+                      # flows' percentages no longer describe.
+                      echo "skin.name=720x1280"
+                      echo "skin.path=_no_skin"
+                      echo "hw.displayCutout=none"
                       echo "hw.ramSize=2048"
                       # Maestro's driver types through the hardware keyboard; a
                       # soft-keyboard-only AVD turns text input into flake.
@@ -430,12 +455,13 @@ jobs:
 
             -   name: Boot the emulator
                 id: emulator
-                # 10 minutes against a 23s measured cold boot on this node: the
+                # 12 minutes against a 23s measured cold boot on this node: the
                 # budget is here to catch a wedged boot, not to bound a healthy
-                # one. The redroid step it replaces needed 20 because it could
-                # cold-pull a 1.1 GB image and then pay Android's plus GMS's first
-                # boot; a baked system image pays neither.
-                timeout-minutes: 10
+                # one, and it has to cover the two bounded settling waits at the
+                # end of the step as well. The redroid step it replaces needed 20
+                # because it could cold-pull a 1.1 GB image and then pay Android's
+                # plus GMS's first boot; a baked system image pays neither.
+                timeout-minutes: 12
                 shell: bash
                 run: |
                     set -euo pipefail
@@ -495,6 +521,37 @@ jobs:
                     for scale in window_animation_scale transition_animation_scale animator_duration_scale; do
                       adb shell settings put global "$scale" 0 || true
                     done
+                    # sys.boot_completed flips well before the device is settled:
+                    # the launcher is still starting and GMS has not finished its
+                    # first-run initialization. The redroid path never saw this
+                    # because it booted a prewarmed /data volume that had already
+                    # been through both. On the first amd64 run one payments flow
+                    # burned its whole 60s launch budget waiting for an app that
+                    # was competing with that background work, while the seven
+                    # flows around it passed. These are the device's own readiness
+                    # signals, not a sleep: bootanim stopping means the launcher is
+                    # up, and broadcast-idle means the boot broadcast queue (GMS
+                    # first-run receivers included) has drained.
+                    timeout 180 bash -c 'until [ "$(adb shell getprop init.svc.bootanim | tr -d "\r")" = "stopped" ]; do sleep 5; done' \
+                      || echo "::warning::init.svc.bootanim never reported 'stopped'; continuing, but the device may still be starting its launcher."
+                    # Non-fatal and bounded: `am wait-for-broadcast-idle` is the
+                    # right signal but it is a debug command, so an image that does
+                    # not implement it must not fail the job over a settling hint.
+                    timeout 180 adb shell am wait-for-broadcast-idle \
+                      || echo "::warning::'am wait-for-broadcast-idle' did not complete within 180s; continuing with a device that may still be draining boot broadcasts."
+                    # The flows are calibrated against a 360x640dp viewport (see
+                    # the AVD step). A config.ini key that stopped being honoured
+                    # would otherwise surface as a handful of unrelated-looking
+                    # flow failures twenty minutes later, so the geometry is
+                    # asserted here, where the cause is still obvious.
+                    size="$(adb shell wm size | tr -d '\r')"
+                    density="$(adb shell wm density | tr -d '\r')"
+                    echo "$size"
+                    echo "$density"
+                    if ! grep -q '720x1280' <<<"$size" || ! grep -q '320' <<<"$density"; then
+                      echo "::error::The emulator came up as '$size' / '$density', not the 720x1280 @ 320dpi display this suite's Maestro flows are calibrated against. Check the hw.lcd.* keys in the Create the AVD step."
+                      exit 1
+                    fi
                     adb devices -l
 
             -   name: Install Maestro


### PR DESCRIPTION
## What moved

The `maestro` job of `.github/workflows/android-maestro.yml` moves off the arm64 Redroid path (`runs-on: [self-hosted, linux-tiered, linux-xl]`, the fleet's Apple-silicon Linux VMs) onto the new self-hosted x86_64 node, running the real Android emulator under KVM.

`build-apk` does not move. Its reasoning is unchanged: Google ships no arm64-Linux host clang for the NDK, this repo is public so the GitHub-hosted `ubuntu-24.04` runner costs nothing, and fleet capacity is better spent on the part that actually needs a device.

## Why

The old top-of-file rationale — "arm64-native Redroid is the fleet's only way to run Android at all" — was true of the Apple-silicon VMs and is now obsolete. Redroid was a workaround for two missing things, an x86_64 host and `/dev/kvm`, and it cost:

- a community-published GMS image pinned by digest, because stock Redroid ships no Play services and every `PaymentRequest.show()` flow failed deterministically with "Google Play services is invalid. Cannot recover.";
- a `sudo modprobe binder_linux` precondition on the host kernel, plus a privileged container;
- a prewarmed `/data` volume, an image/manifest match check, and a `sudo cp -a`/`sudo rm -rf` seeding-and-teardown dance;
- `max-parallel: 1` forced by binder-device contention *across* runners (redroid-doc#904), which no per-container limit can bound.

The new node deletes all of that. Jobs run in an ephemeral rootless Podman container with `/dev/kvm` passed through, so `system-images;android-34;google_apis;x86_64` boots headless in a measured 23s cold. That is Google's own image with Play services present — the exact thing that forced the community GMS image before — with no community publisher in the trust path and nothing privileged anywhere.

Redroid is not a fallback on this node: no sudo, no privileged mode, no docker daemon, so binderfs can never be mounted. AVD is the only path, which is why the job checks its KVM precondition explicitly instead of assuming it.

## The 4x8 / KVM constraint

`runs-on: [self-hosted, trf-linux-amd64-4x8]`. **Only the 4cpu/8GB profile passes `/dev/kvm` into the job container.** On the 2x4 profile the emulator still starts — at software-emulation speed, which makes every step budget in the job wrong for reasons no log explains. So the "Verify the Android SDK and KVM acceleration" step gates on `emulator -accel-check`, checking both its exit status and its message, and fails loudly with the profile name if acceleration is missing. The scale set also advertises `trf-rnw-linux-amd64-4x8` if this ever needs pinning harder than the shape.

`max-parallel: 1` stays, with a new justification. The binder reason is gone; the capacity reason is not — a booted AVD measured ~4.2 GB RSS in the 4x8 shape, so concurrent legs landing on one node contend for RAM and KVM. The serialization stays until that headroom is measured rather than assumed.

## APK ABI verification

The APKs already carry x86_64 native libs. **No gradle change was needed in this PR.**

- All three bare apps (`packages/react-native-{payments,collapsible-header,screen-chrome}-example/apps/bare/android/gradle.properties`) set `reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64`.
- No `abiFilters`, no `splits { abi }`, and no `ndk {}` block exists in any `android/app/build.gradle` in the repo, so nothing narrows that list at the variant level.
- The expo targets have no committed `android/`; `expo prebuild` generates it from `expo-template-bare-minimum`, whose `android/gradle.properties` carries the same four-ABI default (verified against the published 57.x template matching this repo's `expo ~57.0.9`). None of the three `app.json` files use `expo-build-properties` or anything else that would restrict ABIs.

This is what the "4-ABI CMake" note in `build-apk` was already describing — the arm64 Redroid path was installing the `arm64-v8a` slice of a universal APK, and the emulator installs the `x86_64` slice of the same artifact. Same artifact, same job, different slice.

## Rollback

Revert this commit. The arm64 Redroid path is unchanged on the macOS/`linux-xl` fleet and the `linux-tiered`/`linux-xl` labels are deliberately kept in `.github/actionlint.yaml` (alongside the new ones) so a revert still lints.

## Other self-hosted workflows

Checked, not touched: `.github/workflows/ios-maestro.yml` uses `[self-hosted, macOS, ARM64, macos-maestro]`, which is a different fleet and out of scope here. Every other job in every other workflow is `ubuntu-latest`. `android-maestro.yml` was the only `linux-tiered`/`linux-xl` consumer.

## First live run, and what it proved

Run [32892585974](https://github.com/rnw-community/rnw-community/actions/runs/32892585974) on the amd64 node: **all 6 APK builds green, and the KVM AVD worked** — every leg booted, installed and drove Maestro. 3 of 6 legs passed outright (screen-chrome bare + expo, payments expo). The 3 failures were the *display*, not the runner move, and are fixed in `d15375e`.

The logs turned risks #1/#2 below from "likely" into measured facts:

**The AVD's display was wrong.** It was created from the `pixel_6` profile — 1080x2400 @ 420dpi, a **411x914dp** viewport. Redroid ran at its own defaults, 720x1280 @ 320dpi, a **360x640dp** viewport, and this suite is calibrated against that. `snap_to_nearest_endpoint` documents its own calibration: the release "must land between the snap midpoint (78dp) and the snap end (156dp)", with "offset = travel/2". Its swipe travels 38% of the viewport height:

| viewport | travel | release offset | inside the flow's own 78–156dp window? |
|---|---|---|---|
| redroid, 640dp | 243dp | **122dp** | yes |
| pixel_6, 914dp | 347dp | **174dp** | no — past the snap end |

Both collapsible-header legs failed on exactly the flows that depend on where that release lands (`snap_to_nearest_endpoint`, `collapse_on_scroll`).

**pixel_6 also has a cutout redroid never had.** The captured logcat of both failing collapsible-header legs carries `displayCutoutSafeInsets=Rect(0, 128 - 0, 0)` — 128px at 420dpi is a **49dp** top inset instead of the plain 24dp status bar. The expo apps render edge-to-edge, so that inset moved their header out from under Maestro: the expo leg failed all 7 flows, two of them with the header's own buttons simply *not found*, and the captured screenshot shows them drawn under the status bar.

**Fix:** the AVD is now created with **no `--device` profile at all** — a profile is precisely what reintroduces a cutout and a resolution this suite is not written for — and `hw.lcd.width/height/density`, `skin.name`, `skin.path` and `hw.displayCutout` are stated outright as redroid's 720x1280 @ 320dpi. The boot step then asserts the resulting `wm size` / `wm density`, so a config key that stops being honoured fails at boot rather than as a handful of unrelated-looking flow failures twenty minutes later.

**The one non-geometry failure** was payments/bare's `async_update_toggle_state`, which burned its whole 60s launch budget while the seven flows around it passed on the same emulator. `sys.boot_completed` flips well before the device is settled — the launcher is still starting and GMS has not finished first-run initialization — and the redroid path never saw this because it booted a *prewarmed* `/data` volume that had already been through both. The boot step now waits for the device's own readiness signals, bounded and non-fatal: `init.svc.bootanim` reaching `stopped`, then `am wait-for-broadcast-idle`. No sleeps.

**Also confirmed by the run:** the APK's x86_64 slice is what actually loads — `nativeloader: ... library_path=.../lib/x86_64` for every app — so the ABI finding below is verified live, not just read off gradle.properties.

## Remaining risks

- **The 720x1280 pin is now load-bearing.** Any future change to the AVD's display silently re-breaks the dp-calibrated snap flows. That is why the boot step asserts it — but the assertion is the guard, the comment block in the AVD step is the reason.
- **Settling waits are bounded and non-fatal.** If `am wait-for-broadcast-idle` is missing or slow on a future system image, the job warns and continues rather than failing; a genuinely unsettled device would then show up as a launch-timeout flake again, not as a clear error.
- **First run is un-cached.** The runner container is ephemeral, so `$HOME` is fresh every job: the pinned Maestro release downloads each run (the `$HOME`-shared install lock in that step is now vacuous but harmless), and `pnpm install` has no warm store.
- **Maestro's own debug output did not land in the artifacts** — only this workflow's own capture (emulator log, screenshot, logcat) did, despite `MAESTRO_DEBUG_OUTPUT_DIRECTORY` being set. Diagnosis worked from the screenshot and logcat instead, but per-flow view hierarchies would have been faster. Same mechanism as `ios-maestro.yml`, so this is pre-existing and out of scope here.
- **Google Play services parity.** `google_apis` is not `google_apis_playstore`: Play services are present but the device is uncertified and has no account — the state `sheet_opens_on_show.yaml` already documents and asserts around. Confirmed fine in practice: payments/expo passed all 8 flows and payments/bare passed 7 of 8.
- **`unzip` and `curl`** are present on the image (the Maestro install step succeeded on all 6 legs). Resolved.

Part of vitalyiegorov/tart-runner-fleet#200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testing**
  * Android Maestro tests now run on x86_64 Android emulators with KVM acceleration.
  * Added automatic Android SDK and API 34 emulator setup.
  * Improved diagnostics and failure reporting, including emulator logs and device state.
* **Chores**
  * Updated runner configuration to support the new Android testing infrastructure.
  * Removed reliance on privileged Redroid containers.
  * Improved emulator startup, device readiness checks, APK installation, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run Android `maestro` CI job on amd64 KVM emulator instead of arm64 Redroid
> - Switches the `workflow.maestro` job in [android-maestro.yml](https://github.com/rnw-community/rnw-community/pull/604/files#diff-55335efdf44cf2f549475f95db0a3c18a4cd462466e0062fb3597da7bfbf87e7) from a Redroid Docker container on arm64 to an AOSP x86_64 emulator (android-34, google_apis) with KVM acceleration on a `trf-linux-amd64-4x8` self-hosted runner
> - Adds SDK probe/install, AVD creation with fixed geometry (720x1280 @ 320dpi), and a dynamic serial-discovery boot sequence that waits for `sys.boot_completed`, disables animations, and verifies display size/density
> - Updates diagnostics to capture the emulator log and teardown to stop the emulator and adb server instead of removing a Docker container; increases job timeout from 30 to 35 minutes
> - Adds the new runner labels to the allowed self-hosted list in [actionlint.yaml](https://github.com/rnw-community/rnw-community/pull/604/files#diff-2f3192c2d25d2b15166a77ea94cd49e18cd97a7862b6e3d67ff5062c097bacb4)
> - Risk: job now fails if `/dev/kvm` is unavailable (`emulator -accel-check` step); any amd64 fleet node missing KVM support will block the job
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fd6a019. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->