### PR TITLE
fix: link workspace packages so lerna release lockfile update resolves locally

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,10 +181,10 @@ importers:
     dependencies:
       '@rnw-community/object-field-tree':
         specifier: ^2.13.0
-        version: 2.13.0
+        version: link:../object-field-tree
       '@rnw-community/shared':
         specifier: ^2.13.0
-        version: 2.13.0
+        version: link:../shared
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -285,7 +285,7 @@ importers:
         version: 11.2.1(@nestjs/common@11.2.1(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@rnw-community/shared':
         specifier: ^2.13.0
-        version: 2.13.0
+        version: link:../shared
       ioredis:
         specifier: ^5.11.1
         version: 5.11.1(supports-color@8.1.1)
@@ -300,7 +300,7 @@ importers:
     dependencies:
       '@rnw-community/shared':
         specifier: ^2.13.0
-        version: 2.13.0
+        version: link:../shared
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.28
@@ -313,7 +313,7 @@ importers:
     dependencies:
       '@rnw-community/shared':
         specifier: ^2.13.0
-        version: 2.13.0
+        version: link:../shared
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.28
@@ -332,7 +332,7 @@ importers:
     dependencies:
       '@rnw-community/shared':
         specifier: ^2.13.0
-        version: 2.13.0
+        version: link:../shared
     devDependencies:
       '@nestjs-modules/ioredis':
         specifier: ^2.2.2
@@ -351,7 +351,7 @@ importers:
     dependencies:
       '@rnw-community/shared':
         specifier: ^2.13.0
-        version: 2.13.0
+        version: link:../shared
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.28
@@ -370,7 +370,7 @@ importers:
     dependencies:
       '@rnw-community/shared':
         specifier: ^2.13.0
-        version: 2.13.0
+        version: link:../shared
       '@swc/cli':
         specifier: ^0.1.57
         version: 0.1.65(@swc/core@1.16.1(@swc/helpers@0.4.37))
@@ -410,7 +410,7 @@ importers:
     dependencies:
       '@rnw-community/shared':
         specifier: ^2.13.0
-        version: 2.13.0
+        version: link:../shared
 
   packages/platform:
     devDependencies:
@@ -434,7 +434,7 @@ importers:
     dependencies:
       '@rnw-community/shared':
         specifier: ^2.13.0
-        version: 2.13.0
+        version: link:../shared
       react-compiler-runtime:
         specifier: ^1.0.0
         version: 1.0.0(react@19.2.3)
@@ -618,7 +618,7 @@ importers:
         version: 9.1.7(supports-color@8.1.1)
       '@rnw-community/shared':
         specifier: ^2.13.0
-        version: 2.13.0
+        version: link:../shared
       expo:
         specifier: 57.0.4
         version: 57.0.4(70c94e2f0f8f3342f4491993ce70adc1)
@@ -724,7 +724,7 @@ importers:
     dependencies:
       '@rnw-community/shared':
         specifier: ^2.12.10
-        version: 2.13.0
+        version: link:../shared
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -919,7 +919,7 @@ importers:
     dependencies:
       '@rnw-community/shared':
         specifier: ^2.13.0
-        version: 2.13.0
+        version: link:../shared
     devDependencies:
       expect-type:
         specifier: ^0.20.0
@@ -934,7 +934,7 @@ importers:
     dependencies:
       '@rnw-community/shared':
         specifier: ^2.13.0
-        version: 2.13.0
+        version: link:../shared
       '@wdio/globals':
         specifier: ^9.29.1
         version: 9.31.1(expect-webdriverio@6.0.7)(webdriverio@9.31.2(supports-color@8.1.1))
@@ -2966,14 +2966,6 @@ packages:
 
   '@react-navigation/routers@7.6.4':
     resolution: {integrity: sha512-GI7eJm8/KsZUQaYcXvEExikKurRZRgEsSzyZ7faENfi65yqJBCXjDMwyN1pF6pNW1MoLH1ErDwDivFxY6BzD3w==}
-
-  '@rnw-community/object-field-tree@2.13.0':
-    resolution: {integrity: sha512-nDQbLeCyuf1BJz01ldHBfzh3XVmAxdejId49iPQatcCZt6dlERrHiB5hPwQFjCfLFHb+jokze5/Hbg80S0AnTw==}
-    engines: {node: '>=22.0.0'}
-
-  '@rnw-community/shared@2.13.0':
-    resolution: {integrity: sha512-xgVYyRhl/9xNjQXbuseNvhh1EzuFZGYHlE6ZH/73T0QL9m1TawX+o078OfQXrUFKy9QN+bOdMjPLgDIhmfzRNw==}
-    engines: {node: '>=22.0.0'}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -7502,6 +7494,7 @@ packages:
   prom-client@15.1.3:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
+    deprecated: prom-client has been replaced by @prometheus-io/client
 
   promise-all-reject-late@1.0.1:
     resolution: {integrity: sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==}
@@ -12777,12 +12770,6 @@ snapshots:
   '@react-navigation/routers@7.6.4':
     dependencies:
       nanoid: 3.3.18
-
-  '@rnw-community/object-field-tree@2.13.0':
-    dependencies:
-      '@rnw-community/shared': 2.13.0
-
-  '@rnw-community/shared@2.13.0': {}
 
   '@rtsao/scc@1.1.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,8 @@ packages:
   - packages/react-native-payments-example/apps/*
   - packages/react-native-screen-chrome-example/apps/*
 
+linkWorkspacePackages: true
+
 overrides:
   "@expo/cli": 57.0.6
   "@expo/metro-runtime": 57.0.3


### PR DESCRIPTION
## Summary

Every release run since the yarn→pnpm migration (#602) has failed. Root cause:

- `lerna version` bumps intra-workspace dependency ranges to the new version (e.g. `@rnw-community/object-field-tree@^2.15.0` in `packages/fast-style`) and then runs `pnpm install --lockfile-only --ignore-scripts`.
- pnpm cannot resolve `@rnw-community/object-field-tree@^2.15.0` because that version does not exist on the npm registry yet (it is being released in this very run), and pnpm does not link workspace packages for bare semver ranges by default (`link-workspace-packages` defaults to `false`).
- Failure: `[ERR_PNPM_NO_MATCHING_VERSION] No matching version found for @rnw-community/object-field-tree@^2.15.0`.

Failed release runs:

- https://github.com/rnw-community/rnw-community/actions/runs/32835566851
- https://github.com/rnw-community/rnw-community/actions/runs/32887005141
- https://github.com/rnw-community/rnw-community/actions/runs/32950374972

This fix adds `linkWorkspacePackages: true` to `pnpm-workspace.yaml`, restoring the pre-migration yarn-workspace behavior where in-repo packages satisfy bare semver ranges locally instead of hitting the registry. This unblocks publishing `@rnw-community/react-native-screen-chrome` for the first time.

## Test plan

- [x] Reproduced the failure: bumped `packages/object-field-tree` to `2.15.0` and `packages/fast-style`'s dependency to `^2.15.0`, ran `pnpm install --lockfile-only --ignore-scripts` with `linkWorkspacePackages` commented out — reproduced `ERR_PNPM_NO_MATCHING_VERSION` exactly.
- [x] Restored `linkWorkspacePackages: true` and reran the same simulated bump — install succeeded, lockfile resolved `@rnw-community/object-field-tree` to `link:../object-field-tree`.
- [x] Reverted the simulated `package.json` bumps and confirmed a clean `pnpm install --lockfile-only --ignore-scripts` against the real repo state produces only the expected workspace-package re-links in `pnpm-lock.yaml` (registry resolutions of `@rnw-community/object-field-tree` and `@rnw-community/shared` across importers switched to local `link:` entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable `linkWorkspacePackages: true` in `pnpm-workspace.yaml`
> Adds the `linkWorkspacePackages: true` setting so pnpm links workspace packages locally during installs. This lets `lerna` release lockfile updates resolve against local workspace packages instead of published versions. The generated [pnpm-lock.yaml](https://github.com/rnw-community/rnw-community/pull/605/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb) is updated to reflect the new linking behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73f2bb8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->