### PR TITLE
fix(react-native-collapsible-header): active layer uses box-none so touches pass through to content

### DIFF
--- a/packages/react-native-collapsible-header/src/collapsible-header/collapsible-header-freeze.spec.tsx
+++ b/packages/react-native-collapsible-header/src/collapsible-header/collapsible-header-freeze.spec.tsx
@@ -68,7 +68,7 @@ describe('CollapsibleHeader under react-freeze', () => {
         const scrollY = makeMutable(COLLAPSE_DISTANCE);
         render(<Subject frozen={false} scrollY={scrollY} />);
 
-        expect(getAnimatedStyle(getLayer('collapsed'))).toMatchObject({ opacity: 1, pointerEvents: 'auto' });
+        expect(getAnimatedStyle(getLayer('collapsed'))).toMatchObject({ opacity: 1, pointerEvents: 'box-none' });
 
         screen.rerender(<Subject frozen scrollY={scrollY} />);
 
@@ -76,7 +76,7 @@ describe('CollapsibleHeader under react-freeze', () => {
 
         screen.rerender(<Subject frozen={false} scrollY={scrollY} />);
 
-        expect(getAnimatedStyle(getLayer('collapsed'))).toMatchObject({ opacity: 1, pointerEvents: 'auto' });
+        expect(getAnimatedStyle(getLayer('collapsed'))).toMatchObject({ opacity: 1, pointerEvents: 'box-none' });
         expect(getAnimatedStyle(getLayer('expanded'))).toMatchObject({ opacity: 0, pointerEvents: 'none' });
         expect((getLayer('expanded').props as ViewProps).accessibilityElementsHidden).toBe(true);
         expect((getLayer('collapsed').props as ViewProps).accessibilityElementsHidden).toBe(false);

--- a/packages/react-native-collapsible-header/src/collapsible-header/collapsible-header-motion.spec.tsx
+++ b/packages/react-native-collapsible-header/src/collapsible-header/collapsible-header-motion.spec.tsx
@@ -247,9 +247,9 @@ describe('CollapsibleHeader endpoint animation', () => {
 
 describe('CollapsibleHeader interaction', () => {
     it.each([
-        [0, 'auto', 'none'],
-        [COLLAPSE_DISTANCE * 0.5, 'auto', 'none'],
-        [COLLAPSE_DISTANCE, 'none', 'auto'],
+        [0, 'box-none', 'none'],
+        [COLLAPSE_DISTANCE * 0.5, 'box-none', 'none'],
+        [COLLAPSE_DISTANCE, 'none', 'box-none'],
     ])(
         'keeps only the visible content interactive at scroll offset %s',
         (scrollOffset, expandedPointer, collapsedPointer) => {
@@ -262,8 +262,8 @@ describe('CollapsibleHeader interaction', () => {
     );
 
     it.each([
-        [CUSTOM_POINTER_EVENTS_SWITCH_SCROLL_OFFSET, 'auto', 'none'],
-        [CUSTOM_POINTER_EVENTS_SWITCH_SCROLL_OFFSET + 1, 'none', 'auto'],
+        [CUSTOM_POINTER_EVENTS_SWITCH_SCROLL_OFFSET, 'box-none', 'none'],
+        [CUSTOM_POINTER_EVENTS_SWITCH_SCROLL_OFFSET + 1, 'none', 'box-none'],
     ])('uses the custom pointer-event threshold at scroll offset %s', (scrollOffset, expandedPointer, collapsedPointer) => {
         expect.hasAssertions();
         render(

--- a/packages/react-native-collapsible-header/src/hooks/use-collapsible-header-animated-layers/use-collapsible-header-animated-layers.hook.ts
+++ b/packages/react-native-collapsible-header/src/hooks/use-collapsible-header-animated-layers/use-collapsible-header-animated-layers.hook.ts
@@ -57,7 +57,7 @@ export const useCollapsibleHeaderAnimatedLayers = ({
     const pointerEventsSwitchOffset = collapseStart + collapseDistance * motionConfig.pointerEventsSwitchProgress;
     const expandedAnimatedStyle = useAnimatedStyle(() => ({
         opacity: interpolateProgressFadeOut(progress.get(), motionConfig.expandedOpacityEndProgress),
-        pointerEvents: scrollY.get() <= pointerEventsSwitchOffset ? 'auto' : 'none',
+        pointerEvents: scrollY.get() <= pointerEventsSwitchOffset ? 'box-none' : 'none',
         transform: [
             {
                 translateY: interpolate(progress.get(), [0, 1], [0, motionConfig.expandedTranslateY], Extrapolation.CLAMP),
@@ -67,7 +67,7 @@ export const useCollapsibleHeaderAnimatedLayers = ({
     }));
     const collapsedAnimatedStyle = useAnimatedStyle(() => ({
         opacity: interpolateProgressFadeIn(progress.get(), motionConfig.collapsedOpacityStartProgress),
-        pointerEvents: scrollY.get() <= pointerEventsSwitchOffset ? 'none' : 'auto',
+        pointerEvents: scrollY.get() <= pointerEventsSwitchOffset ? 'none' : 'box-none',
         transform: [
             {
                 translateY: interpolateCollapsedProgressTranslateY(

--- a/packages/react-native-collapsible-header/src/hooks/use-collapsible-header-animated-layers/use-collapsible-header-animated-layers.spec.ts
+++ b/packages/react-native-collapsible-header/src/hooks/use-collapsible-header-animated-layers/use-collapsible-header-animated-layers.spec.ts
@@ -83,7 +83,7 @@ describe('useCollapsibleHeaderAnimatedLayers', () => {
 
         expect(result.current.progress.get()).toBe(0);
         expect(result.current.headerAnimatedStyle).toEqual({ height: EXPANDED_HEIGHT });
-        expect(result.current.expandedAnimatedStyle).toMatchObject({ opacity: 1, pointerEvents: 'auto' });
+        expect(result.current.expandedAnimatedStyle).toMatchObject({ opacity: 1, pointerEvents: 'box-none' });
         expect(result.current.collapsedAnimatedStyle).toMatchObject({ opacity: 0, pointerEvents: 'none' });
         expect(result.current.expandedAnimatedProps).toEqual({
             accessibilityElementsHidden: false,
@@ -113,7 +113,7 @@ describe('useCollapsibleHeaderAnimatedLayers', () => {
         expect(result.current.progress.get()).toBe(1);
         expect(result.current.headerAnimatedStyle).toEqual({ height: COLLAPSED_HEIGHT });
         expect(result.current.expandedAnimatedStyle).toMatchObject({ opacity: 0, pointerEvents: 'none' });
-        expect(result.current.collapsedAnimatedStyle).toMatchObject({ opacity: 1, pointerEvents: 'auto' });
+        expect(result.current.collapsedAnimatedStyle).toMatchObject({ opacity: 1, pointerEvents: 'box-none' });
         expect(result.current.expandedAnimatedProps).toMatchObject({ accessibilityElementsHidden: true });
         expect(result.current.collapsedAnimatedProps).toMatchObject({ accessibilityElementsHidden: false });
     });


### PR DESCRIPTION
## Summary

Fixes #606.

`useCollapsibleHeaderAnimatedLayers` toggles the expanded/collapsed content layer's `pointerEvents` between `'auto'` (active layer) and `'none'` (inactive layer) as the header collapses. Because both layers are absolute, full-bleed `View`s stacked over the header band, `'auto'` on the active layer makes its container intercept every touch across the entire header area — including taps that land on content scrolled underneath translucent chrome, not just on the layer's own interactive children.

- Active layer: `'auto'` → `'box-none'` — the container stops intercepting touches itself, while its children (buttons, links, etc.) still receive touches normally.
- Inactive layer: unchanged, stays `'none'`.
- This matches the existing `persistentContent` layer in `collapsible-header.tsx`, which already renders with `pointerEvents="box-none"` for the same reason.
- Accessibility semantics are untouched — `accessibilityElementsHidden` / `importantForAccessibility` still switch on the same `pointerEventsSwitchOffset` threshold, independent of the `pointerEvents` style value.

## Scope check

- `@rnw-community/react-native-screen-chrome` consumes this primitive but its specs only assert `pointerEvents="box-none"` on its own static wrapper views (`screen-chrome-header.tsx`, `collapsible-header-title-slot.tsx`), never the dynamic `'auto'`/`'none'` values from this hook — no changes needed there.

## Test plan

- [x] `pnpm --filter @rnw-community/react-native-collapsible-header test:coverage` — 13 suites / 98 tests passed, 100% statements/branches/functions/lines
- [x] `pnpm --filter @rnw-community/react-native-collapsible-header lint` — clean
- [x] `pnpm --filter @rnw-community/react-native-collapsible-header ts` / `ts:nodenext` — clean
- [x] `pnpm --filter @rnw-community/react-native-screen-chrome test:coverage` — 26 suites / 88 tests passed, 100% coverage (no changes needed)
- [x] `pnpm --filter @rnw-community/react-native-screen-chrome lint` / `ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set collapsible header active layer `pointerEvents` to `box-none` so touches pass through
> Changes `expandedAnimatedStyle` and `collapsedAnimatedStyle` in the `useCollapsibleHeaderAnimatedLayers` hook to use `'box-none'` instead of `'auto'` when their respective layers are visible. This lets touch events pass through the active layer to underlying content. Updates the matching specs in the freeze, motion, and hook test suites to assert the new value. Risk: callers or tests outside this package that assert `pointerEvents` of `'auto'` on these animated styles will need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b51a2b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touch interaction for collapsible headers by allowing touches to pass through visible header layers when appropriate.
  * Prevented inactive or hidden header layers from intercepting user input.
  * Updated behavior consistently across expanded, collapsed, frozen, and custom-threshold states.

* **Tests**
  * Updated interaction coverage to verify correct touch handling across supported header states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->