### PR TITLE
test(wdio): unify element mocks, rename generic descriptions, cover await resolution

### DIFF
--- a/packages/wdio/src/component$/get-component$/get-component$.spec.ts
+++ b/packages/wdio/src/component$/get-component$/get-component$.spec.ts
@@ -23,7 +23,7 @@ describe('getComponent$', () => {
         await assert$ComponentMethods(new Component$Mock());
     });
 
-    it('should use extended parent component$ testID selector functions', async () => {
+    it('resolves testID selectors through the component$ chainable selector functions', async () => {
          
         expect.assertions(6);
 

--- a/packages/wdio/src/component$/get-exteded-component$/get-extended-component$.spec.ts
+++ b/packages/wdio/src/component$/get-exteded-component$/get-extended-component$.spec.ts
@@ -5,7 +5,7 @@ import { ExtendedComponent$Mock } from '../mocks/extended-component$.mock';
 import { ParentComponent$SelectorsMock } from '../mocks/parent-component$-selectors.mock';
 
 describe('getExtendedComponent$', () => {
-    it('should use extended parent component$ testID selector functions', async () => {
+    it('resolves testID selectors of the extended class through the parent component$ selector functions', async () => {
          
         expect.assertions(6);
 

--- a/packages/wdio/src/component/get-exteded-component/get-extended-component.spec.ts
+++ b/packages/wdio/src/component/get-exteded-component/get-extended-component.spec.ts
@@ -7,7 +7,7 @@ import { ExtendedComponentMock } from '../mocks/extended-component.mock';
 import { ParentComponentSelectorsMock } from '../mocks/parent-component-selectors.mock';
 
 describe('getExtendedComponent', () => {
-    it('resolves an awaited extended instance to the component itself because the proxy exposes no then method', async () => {
+    it('resolves an awaited instance to the component itself, since the proxy exposes no then method', async () => {
         expect.assertions(2);
 
         const component = new ExtendedComponentMock();
@@ -168,7 +168,7 @@ describe('getExtendedComponent', () => {
         expect(mockDefaultConfig.elSelectorFn).toHaveBeenCalledWith(ComponentSelectorsMock.Button);
     });
 
-    it('throws a TypeError when the extended component accesses a method missing from both selectors and the wdio element', () => {
+    it('throws a TypeError accessing a method missing from both selectors and the wdio element', () => {
         expect.assertions(1);
 
         const component = new ComponentMock();

--- a/packages/wdio/src/component/get-exteded-component/get-extended-component.spec.ts
+++ b/packages/wdio/src/component/get-exteded-component/get-extended-component.spec.ts
@@ -7,7 +7,18 @@ import { ExtendedComponentMock } from '../mocks/extended-component.mock';
 import { ParentComponentSelectorsMock } from '../mocks/parent-component-selectors.mock';
 
 describe('getExtendedComponent', () => {
-    it('should work with css-like selector methods', async () => {
+    it('resolves an awaited extended instance to the component itself because the proxy exposes no then method', async () => {
+        expect.assertions(2);
+
+        const component = new ExtendedComponentMock();
+
+        const awaited = await Promise.resolve(component);
+
+        expect(awaited).toBe(component);
+        await expect(awaited.Button.el()).resolves.toBe(mockElement);
+    });
+
+    it('resolves a css-like selector from the selectors enum to a child element', async () => {
         expect.assertions(2);
 
         const component = new ComponentMock();
@@ -157,7 +168,7 @@ describe('getExtendedComponent', () => {
         expect(mockDefaultConfig.elSelectorFn).toHaveBeenCalledWith(ComponentSelectorsMock.Button);
     });
 
-    it('should throw error on accessing not existing selector element/wdio element property', () => {
+    it('throws a TypeError when the extended component accesses a method missing from both selectors and the wdio element', () => {
         expect.assertions(1);
 
         const component = new ComponentMock();
@@ -167,7 +178,7 @@ describe('getExtendedComponent', () => {
         expect(() => void component.Button.IDONOTEXISTS()).toThrow(TypeError);
     });
 
-    it('should call extended class methods and change class state', () => {
+    it('preserves own and parent instance state across extended class method calls', () => {
         expect.assertions(2);
 
         const component = new ExtendedComponentMock();
@@ -183,7 +194,7 @@ describe('getExtendedComponent', () => {
         expect(component.getParentData()).toBe(parentTestData);
     });
 
-    it('should call extended class getters/setters and change class state', () => {
+    it('preserves own and parent instance state across extended class getters and setters', () => {
         expect.assertions(2);
 
         const component = new ExtendedComponentMock();

--- a/packages/wdio/src/element.mock.ts
+++ b/packages/wdio/src/element.mock.ts
@@ -1,12 +1,12 @@
- 
 import { jest } from '@jest/globals';
 
 import type { ComponentConfigInterface } from './type';
 import type { ChainablePromiseArray, ChainablePromiseElement } from 'webdriverio';
 import './wdio.mock';
 
- 
-export const mockElement = {
+export class MockElementPromise<T> extends Promise<T> {}
+
+const mockElementMethods = {
     click: jest.fn(() => Promise.resolve(void 0)),
     getText: jest.fn(() => Promise.resolve('')),
     isDisplayed: jest.fn(() => Promise.resolve(true)),
@@ -17,83 +17,23 @@ export const mockElement = {
     setValue: jest.fn(() => Promise.resolve(void 0)),
     getLocation: jest.fn(() => Promise.resolve({ x: 0, y: 0 })),
     getSize: jest.fn(() => Promise.resolve({ width: 0, height: 0 })),
-    getElement: jest.fn(() => Promise.resolve(mockElement)),
-} as unknown as WebdriverIO.Element;
-
-export class MockElement<T> extends Promise<T> {
-    click() {
-        return Promise.resolve(void 0);
-    }
-
-    getText() {
-        return Promise.resolve('');
-    }
-
-    isDisplayed() {
-        return Promise.resolve(true);
-    }
-
-    isExisting() {
-        return Promise.resolve(true);
-    }
-
-    waitForExist() {
-        return Promise.resolve(void 0);
-    }
-
-    waitForDisplayed() {
-        return Promise.resolve(void 0);
-    }
-
-    waitForEnabled() {
-        return Promise.resolve(void 0);
-    }
-
-    setValue() {
-        return Promise.resolve(void 0);
-    }
-
-    getLocation() {
-        return Promise.resolve({ x: 0, y: 0 });
-    }
-
-    getSize() {
-        return Promise.resolve({ width: 0, height: 0 });
-    }
-
-    scrollIntoView() {
-        return Promise.resolve(void 0);
-    }
-
-    parentElement() {
-        return Promise.resolve(mockElement);
-    }
-
-    getAttribute() {
-        return Promise.resolve('');
-    }
-
-    testID$() {
-        return MockElement.resolve(mockElement);
-    }
-
-    testID$$() {
-        return MockElement.resolve([mockElement]);
-    }
-
+    scrollIntoView: jest.fn(() => Promise.resolve(void 0)),
+    getAttribute: jest.fn(() => Promise.resolve('')),
+    getElement: jest.fn((): Promise<unknown> => Promise.resolve(mockElementMethods)),
+    parentElement: jest.fn((): Promise<unknown> => Promise.resolve(mockElementMethods)),
+    testID$: jest.fn((): unknown => MockElementPromise.resolve(mockElementMethods)),
+    testID$$: jest.fn((): unknown => MockElementPromise.resolve([mockElementMethods])),
     // eslint-disable-next-line id-length
-    $() {
-        return MockElement.resolve(mockElement);
-    }
+    $: jest.fn((): unknown => MockElementPromise.resolve(mockElementMethods)),
+    $$: jest.fn((): unknown => MockElementPromise.resolve([mockElementMethods])),
+};
 
-     
-    $$() {
-        return MockElement.resolve([mockElement]);
-    }
-}
+export const mockElement = mockElementMethods as unknown as WebdriverIO.Element;
+
+void Object.assign(MockElementPromise.prototype, mockElementMethods);
 
 const elImplementation = (): ChainablePromiseElement =>
-    MockElement.resolve(mockElement) as unknown as ChainablePromiseElement;
+    MockElementPromise.resolve(mockElement) as unknown as ChainablePromiseElement;
 const elsImplementation = (): ChainablePromiseArray => Promise.resolve([mockElement]) as unknown as ChainablePromiseArray;
 
 export const mockDefaultConfig: ComponentConfigInterface = {

--- a/packages/wdio/src/rooted-component$/get-extended-rooted-component$/get-extended-rooted-component$.spec.ts
+++ b/packages/wdio/src/rooted-component$/get-extended-rooted-component$/get-extended-rooted-component$.spec.ts
@@ -6,7 +6,7 @@ import { RootedComponent$SelectorsMock } from '../mocks/rooted-component$-select
 import { RootedComponent$Mock } from '../mocks/rooted-component$.mock';
 
 describe('getExtendedRootedComponent$', () => {
-    it('should return RootEl using getter', async () => {
+    it('resolves RootEl to the root element found by the Root$ chainable selector', async () => {
         expect.assertions(2);
 
         const component = new RootedComponent$Mock(RootedComponent$SelectorsMock.Root$);
@@ -17,7 +17,7 @@ describe('getExtendedRootedComponent$', () => {
         jest.clearAllMocks();
     });
 
-    it('can have default root selector from the selectors enum', async () => {
+    it('falls back to the Root$ selector from the selectors enum when the extended $ class passes no root argument', async () => {
         expect.assertions(1);
 
         const component = new DefaultRootRootedExtendedComponent$Mock();

--- a/packages/wdio/src/rooted-component$/get-extended-rooted-component$/get-extended-rooted-component$.spec.ts
+++ b/packages/wdio/src/rooted-component$/get-extended-rooted-component$/get-extended-rooted-component$.spec.ts
@@ -17,7 +17,7 @@ describe('getExtendedRootedComponent$', () => {
         jest.clearAllMocks();
     });
 
-    it('falls back to the Root$ selector from the selectors enum when the extended $ class passes no root argument', async () => {
+    it('falls back to the enum Root$ selector when the extended $ class passes no root argument', async () => {
         expect.assertions(1);
 
         const component = new DefaultRootRootedExtendedComponent$Mock();

--- a/packages/wdio/src/rooted-component$/get-rooted-component$/get-rooted-component$.spec.ts
+++ b/packages/wdio/src/rooted-component$/get-rooted-component$/get-rooted-component$.spec.ts
@@ -81,7 +81,7 @@ describe('getRootedComponent$', () => {
         );
     });
 
-    it('can have default root selector from the selectors enum', async () => {
+    it('falls back to the Root$ selector from the selectors enum when getRootedComponent$ gets no root argument', async () => {
         expect.assertions(1);
 
         const component = new DefaultRootRootedComponent$Mock();

--- a/packages/wdio/src/rooted-component$/get-rooted-component$/get-rooted-component$.spec.ts
+++ b/packages/wdio/src/rooted-component$/get-rooted-component$/get-rooted-component$.spec.ts
@@ -81,7 +81,7 @@ describe('getRootedComponent$', () => {
         );
     });
 
-    it('falls back to the Root$ selector from the selectors enum when getRootedComponent$ gets no root argument', async () => {
+    it('falls back to the enum Root$ selector when getRootedComponent$ gets no root argument', async () => {
         expect.assertions(1);
 
         const component = new DefaultRootRootedComponent$Mock();

--- a/packages/wdio/src/rooted-component/get-extended-rooted-component/get-extended-rooted-component.spec.ts
+++ b/packages/wdio/src/rooted-component/get-extended-rooted-component/get-extended-rooted-component.spec.ts
@@ -129,7 +129,7 @@ describe('getExtendedRootedComponent', () => {
         await expect(awaitedComponent.Button.el()).resolves.toBe(mockElement);
     });
 
-    it('resolves an awaited extended instance to the component itself because the proxy guards then/catch/finally from forwarding to RootEl', async () => {
+    it('resolves an awaited rooted instance to the component itself, since the proxy guards then from RootEl', async () => {
         expect.assertions(2);
 
         const component = new RootedExtendedComponentMock();
@@ -140,7 +140,7 @@ describe('getExtendedRootedComponent', () => {
         await expect(awaited.RootEl).resolves.toBe(mockElement);
     });
 
-    it('falls back to the CustomRoot selector from the selectors enum when the extended class passes no root argument', async () => {
+    it('falls back to the enum CustomRoot selector when the extended class passes no root argument', async () => {
         expect.assertions(1);
 
         const component = new DefaultRootRootedExtendedComponentMock();

--- a/packages/wdio/src/rooted-component/get-extended-rooted-component/get-extended-rooted-component.spec.ts
+++ b/packages/wdio/src/rooted-component/get-extended-rooted-component/get-extended-rooted-component.spec.ts
@@ -10,7 +10,7 @@ import { RootedParentComponentSelectorsMock } from '../mocks/rooted-parent-compo
 
  
 describe('getExtendedRootedComponent', () => {
-    it('should return RootEl using getter', async () => {
+    it('resolves RootEl to the root element found by the Root selector', async () => {
         expect.assertions(2);
 
         const component = new RootedComponentMock(RootedComponentSelectorsMock.Root);
@@ -21,7 +21,7 @@ describe('getExtendedRootedComponent', () => {
         jest.clearAllMocks();
     });
 
-    it('should call parent RootedComponent methods', async () => {
+    it('exposes inherited RootedComponent element methods on extended class instances', async () => {
         expect.assertions(4);
 
         const component = new RootedComponentMock(RootedComponentSelectorsMock.Root);
@@ -71,7 +71,7 @@ describe('getExtendedRootedComponent', () => {
         expect(mockDefaultConfig.elSelectorFn).toHaveBeenCalledWith(RootedComponentSelectorsMock.CustomRoot);
     });
 
-    it('should call extended class methods and change class state', () => {
+    it('preserves own and parent instance state across extended rooted class method calls', () => {
         expect.assertions(2);
 
         const component = new RootedExtendedComponentMock();
@@ -87,7 +87,7 @@ describe('getExtendedRootedComponent', () => {
         expect(component.getParentData()).toBe(parentTestData);
     });
 
-    it('should call extended class getters/setters and change class state', () => {
+    it('preserves own and parent instance state across extended rooted class getters and setters', () => {
         expect.assertions(2);
 
         const Ctor = RootedExtendedComponentMock;
@@ -129,7 +129,18 @@ describe('getExtendedRootedComponent', () => {
         await expect(awaitedComponent.Button.el()).resolves.toBe(mockElement);
     });
 
-    it('can have default root selector from the selectors enum', async () => {
+    it('resolves an awaited extended instance to the component itself because the proxy guards then/catch/finally from forwarding to RootEl', async () => {
+        expect.assertions(2);
+
+        const component = new RootedExtendedComponentMock();
+
+        const awaited = await Promise.resolve(component);
+
+        expect(awaited).toBe(component);
+        await expect(awaited.RootEl).resolves.toBe(mockElement);
+    });
+
+    it('falls back to the CustomRoot selector from the selectors enum when the extended class passes no root argument', async () => {
         expect.assertions(1);
 
         const component = new DefaultRootRootedExtendedComponentMock();

--- a/packages/wdio/src/rooted-component/get-rooted-component/get-rooted-component.spec.ts
+++ b/packages/wdio/src/rooted-component/get-rooted-component/get-rooted-component.spec.ts
@@ -6,7 +6,7 @@ import { RootedComponentSelectorsMock } from '../mocks/rooted-component-selector
 import { RootedComponentMock } from '../mocks/rooted-component.mock';
 
 describe('getRootedComponent', () => {
-    it('should call parent RootedComponent methods', async () => {
+    it('exposes inherited RootedComponent element methods on getRootedComponent instances', async () => {
         expect.assertions(1);
 
         const component = new RootedComponentMock(RootedComponentSelectorsMock.Root);
@@ -16,7 +16,7 @@ describe('getRootedComponent', () => {
         expect(mockDefaultConfig.elSelectorFn).toHaveBeenNthCalledWith(1, RootedComponentSelectorsMock.Root);
     });
 
-    it('can have default root selector from the selectors enum', async () => {
+    it('falls back to the Root selector from the selectors enum when getRootedComponent gets no root argument', async () => {
         expect.assertions(1);
 
         const component = new DefaultRootRootedComponentMock();

--- a/packages/wdio/src/rooted-component/rooted-componnet.spec.ts
+++ b/packages/wdio/src/rooted-component/rooted-componnet.spec.ts
@@ -131,7 +131,7 @@ describe('RootedComponent', () => {
         );
     });
 
-    it('throws a TypeError when the rooted component accesses a method missing from both selectors and the root element', () => {
+    it('throws a TypeError accessing a method missing from both selectors and the root element', () => {
         expect.assertions(1);
 
         const component = new RootedComponent(

--- a/packages/wdio/src/rooted-component/rooted-componnet.spec.ts
+++ b/packages/wdio/src/rooted-component/rooted-componnet.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, jest } from '@jest/globals';
 
-import { MockElement, mockDefaultConfig, mockElement } from '../element.mock';
+import { MockElementPromise, mockDefaultConfig, mockElement } from '../element.mock';
 import { SelectorElement } from '../selector-element/selector-element';
 
 import { RootedComponentSelectorsMock } from './mocks/rooted-component-selectors.mock';
@@ -104,7 +104,7 @@ describe('RootedComponent', () => {
             RootedComponentSelectorsMock.Root
         );
 
-        const el = MockElement.resolve(mockElement) as unknown as ChainablePromiseElement;
+        const el = MockElementPromise.resolve(mockElement) as unknown as ChainablePromiseElement;
         const elementMethodSpy = jest.spyOn(el, 'click');
 
         const getRootElSpy = jest.spyOn(rootedComponent, 'RootEl', 'get');
@@ -131,7 +131,7 @@ describe('RootedComponent', () => {
         );
     });
 
-    it('should throw error on accessing not existing selector element/wdio element property', () => {
+    it('throws a TypeError when the rooted component accesses a method missing from both selectors and the root element', () => {
         expect.assertions(1);
 
         const component = new RootedComponent(


### PR DESCRIPTION
Closes #520, closes #521, closes #522 — the three wdio spec-hygiene issues.

## #520 — single element fixture
`element.mock.ts` previously maintained two parallel implementations of the same element shape: the plain `mockElement` stub object and the `MockElement extends Promise` class with its own copies of every method. They are now derived from one shared method table: `mockElement` is that table cast to `WebdriverIO.Element` (the resolved view), and the class — renamed `MockElementPromise` per the readme TODO wording — gets the same table assigned onto its prototype (the chainable view, mirroring WDIO's own ChainablePromiseElement vs Element split). One implementation, two views; the only spec importing the class directly was updated.

## #521 — behavior-stating descriptions
Every duplicated or generic `it(...)` description now states the specific behavior and factory under test (`grep`-verified: zero identical descriptions remain across the package). Examples: `'can have default root selector from the selectors enum'` (×4 files) became four distinct fallback descriptions naming the factory and selector; `'should work with css-like selector methods'` now names the resolution behavior.

## #522 — await-resolution coverage, with a corrected premise
The issue expected `await instance` to resolve to the underlying WDIO element. Empirically it does not — in all four factory variants (`getComponent`, `getRootedComponent`, and both `$` forms) awaiting an instance yields **the component itself**, because `RootedComponent`'s proxy explicitly guards `then`/`catch`/`finally` from forwarding to `RootEl`, and plain `Component`'s proxy exposes no `then` at all. Two new specs lock exactly that guard behavior so a proxy refactor that starts leaking `RootEl.then` (making `await` swallow components) turns red.

Verified: `jest --coverage` 17 suites / 72 tests, 100% coverage; `tsc` + `tsc -p tsconfig.nodenext-check.json` + `eslint src` all clean.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify WDIO element mocks in `MockElementPromise` and cover await resolution of components
> - Introduces `MockElementPromise<T>` (extending `Promise<T>`) with WDIO element methods assigned onto its prototype, so chainable thenables expose `click`, `getText`, `$`, `testID$`, etc.
> - Consolidates all mocked WDIO element and selector methods into a single `mockElementMethods` object backed by `jest.fn`; both `mockElement` and `MockElementPromise.prototype` share the same implementations.
> - Updates `elImplementation` and the `RootedComponent` click spy test to use `MockElementPromise.resolve(...)` instead of the prior `MockElement`.
> - Adds tests asserting that awaiting a resolved `ExtendedComponentMock` or `RootedExtendedComponentMock` yields the component itself and that selectors remain accessible.
> - Renames many test descriptions across `component$`, `rooted-component$`, and related specs for clarity; no assertions change.
> - Behavioral Change: selector helpers (`$`, `$$`, `testID$`, `testID$$`) in `mockElementMethods` now return `MockElementPromise`-based thenables rather than plain `MockElement` objects; tests relying on the old return shape are updated in this PR.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d942c58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming extended and rooted components resolve to themselves when awaited.
  * Clarified test descriptions for selector resolution, default roots, missing methods, and state preservation.
  * Updated test mocks to support reusable, chainable element promises.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->