### PR TITLE
fix(react-native-payments): type AndroidIntermediateSigningKey.signatures as string[]

### DIFF
--- a/packages/react-native-payments/docs/api/android-payment-method-token.md
+++ b/packages/react-native-payments/docs/api/android-payment-method-token.md
@@ -12,7 +12,7 @@ to your payment gateway.
 | --- | --- | --- |
 | `cardInfo.cardNetwork` | `string` | The card network of the tokenized card. |
 | `cardInfo.cardDetails` | `string` | The last four digits or similar display detail, as returned by Google Pay. |
-| `intermediateSigningKey` | `{ signatures: string; signedKey: AndroidSignedKey }` | The intermediate signing key used to verify the token signature — see Pitfalls for a known type/runtime mismatch on `signatures`. |
+| `intermediateSigningKey` | `{ signatures: string[]; signedKey: AndroidSignedKey }` | The intermediate signing key used to verify the token signature. |
 | `protocolVersion` | `string` | The protocol version of the signed message (e.g. `ECv2`). |
 | `signature` | `string` | The signature over `signedMessage`. |
 | `signedMessage` | `{ encryptedMessage: string; ephemeralPublicKey: string; tag: string }` | The encrypted message envelope — see [Google Pay payment data cryptography](https://developers.google.com/pay/api/android/guides/resources/payment-data-cryptography#signed-message). |
@@ -39,13 +39,6 @@ if (response instanceof AndroidPaymentResponse) {
   [`AndroidPaymentResponse`](./android-payment-response.md) when it parses a malformed or incomplete native JSON
   payload (including direct construction of `AndroidPaymentResponse` with malformed tokenization data), not by
   this token type — see [guides/errors.md](../guides/errors.md).
-- **`intermediateSigningKey.signatures` is declared `string` in this package's shipped type
-  (`AndroidIntermediateSigningKey`/`AndroidRawIntermediateSigningKey`), but the real Google Pay payload sends an
-  array of signatures** — this package's own test fixtures construct the raw native payload with
-  `signatures: ['testSignature']`, and Google's own Payment Data Cryptography reference documents
-  `IntermediateSigningKey.signatures` as `string[]`. The value is passed through unparsed (nothing in this
-  package reads `.signatures`), so treat the declared `string` type as unreliable until the type is corrected —
-  check the actual runtime value's shape before assuming either type.
 
 ## References
 

--- a/packages/react-native-payments/llms-full.txt
+++ b/packages/react-native-payments/llms-full.txt
@@ -654,7 +654,7 @@ to your payment gateway.
 | --- | --- | --- |
 | `cardInfo.cardNetwork` | `string` | The card network of the tokenized card. |
 | `cardInfo.cardDetails` | `string` | The last four digits or similar display detail, as returned by Google Pay. |
-| `intermediateSigningKey` | `{ signatures: string; signedKey: AndroidSignedKey }` | The intermediate signing key used to verify the token signature — see Pitfalls for a known type/runtime mismatch on `signatures`. |
+| `intermediateSigningKey` | `{ signatures: string[]; signedKey: AndroidSignedKey }` | The intermediate signing key used to verify the token signature. |
 | `protocolVersion` | `string` | The protocol version of the signed message (e.g. `ECv2`). |
 | `signature` | `string` | The signature over `signedMessage`. |
 | `signedMessage` | `{ encryptedMessage: string; ephemeralPublicKey: string; tag: string }` | The encrypted message envelope — see [Google Pay payment data cryptography](https://developers.google.com/pay/api/android/guides/resources/payment-data-cryptography#signed-message). |
@@ -681,13 +681,6 @@ if (response instanceof AndroidPaymentResponse) {
   [`AndroidPaymentResponse`](docs/api/android-payment-response.md) when it parses a malformed or incomplete native JSON
   payload (including direct construction of `AndroidPaymentResponse` with malformed tokenization data), not by
   this token type — see [guides/errors.md](docs/guides/errors.md).
-- **`intermediateSigningKey.signatures` is declared `string` in this package's shipped type
-  (`AndroidIntermediateSigningKey`/`AndroidRawIntermediateSigningKey`), but the real Google Pay payload sends an
-  array of signatures** — this package's own test fixtures construct the raw native payload with
-  `signatures: ['testSignature']`, and Google's own Payment Data Cryptography reference documents
-  `IntermediateSigningKey.signatures` as `string[]`. The value is passed through unparsed (nothing in this
-  package reads `.signatures`), so treat the declared `string` type as unreliable until the type is corrected —
-  check the actual runtime value's shape before assuming either type.
 
 ## References
 

--- a/packages/react-native-payments/src/@standard/android/response/android-intermediate-signing-key.ts
+++ b/packages/react-native-payments/src/@standard/android/response/android-intermediate-signing-key.ts
@@ -8,11 +8,11 @@ import type { AndroidSignedKey } from './android-signed-key';
  * @see https://developers.google.com/pay/api/android/guides/resources/payment-data-cryptography#intermediate-signing-key
  */
 export interface AndroidIntermediateSigningKey {
-    signatures: string;
+    signatures: string[];
     signedKey: AndroidSignedKey;
 }
 
 export const emptyAndroidIntermediateSigningKey: AndroidIntermediateSigningKey = {
-    signatures: '',
+    signatures: [],
     signedKey: emptyAndroidSignedKey,
 };

--- a/packages/react-native-payments/src/@standard/android/response/android-raw-intermediate-signing-key.ts
+++ b/packages/react-native-payments/src/@standard/android/response/android-raw-intermediate-signing-key.ts
@@ -4,6 +4,6 @@
  * @see https://developers.google.com/pay/api/android/guides/resources/payment-data-cryptography#intermediate-signing-key
  */
 export interface AndroidRawIntermediateSigningKey {
-    signatures: string;
+    signatures: string[];
     signedKey: string;
 }

--- a/packages/react-native-payments/src/class/payment-response/payment-response.spec.ts
+++ b/packages/react-native-payments/src/class/payment-response/payment-response.spec.ts
@@ -53,7 +53,7 @@ describe('PaymentResponse', () => {
                     keyExpiration: '',
                     keyValue: 'mockSignedKeyValue',
                 },
-                signatures: 'mockSignature1',
+                signatures: ['mockSignature1'],
             },
             protocolVersion: 'EC_v1',
             rawToken: 'mockRawToken',


### PR DESCRIPTION
Closes #525.

`AndroidIntermediateSigningKey.signatures` and `AndroidRawIntermediateSigningKey.signatures` were declared `string`, but the real Google Pay payload carries an array of base64 signatures — Google's Payment Data Cryptography reference documents `IntermediateSigningKey.signatures` as `string[]`, and this package's own raw-payload fixtures already used `['testSignature']`.

- Both interfaces now declare `signatures: string[]`; `emptyAndroidIntermediateSigningKey` resolves to `[]`.
- The one fixture that followed the wrong declared type (`payment-response.spec.ts`) now uses an array like the raw-payload fixtures.
- Removed the interim Pitfall note from `docs/api/android-payment-method-token.md` (added by #499 to warn about exactly this mismatch) and the mirrored copy in `llms-full.txt`; the parameter tables now show the corrected shape.

Nothing internal reads `.signatures` — the value passes through unparsed — so this is a type-level correction only. Semver note per the issue: `string` → `string[]` is a breaking type change for consumers who annotated against the wrong type; call it out in the next minor's release notes.

Verified: `jest --coverage` 15 suites / 242 tests green, `tsc` and `eslint src` clean.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AndroidIntermediateSigningKey.signatures` type to `string[]`
> Updates the `signatures` field from `string` to `string[]` on both `AndroidIntermediateSigningKey` and `AndroidRawIntermediateSigningKey` interfaces, matching the actual runtime value. The `emptyAndroidIntermediateSigningKey` constant now defaults to `[]` instead of `''`, and test fixtures and docs are updated to match.
> - Risk: `emptyAndroidIntermediateSigningKey.signatures` now returns an empty array instead of an empty string; any consumers expecting a `string` will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 838d5d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->