### PR TITLE
feat(react-native-screen-chrome): export mergeRefs for custom scrollable wiring

### DIFF
--- a/packages/react-native-screen-chrome/readme.md
+++ b/packages/react-native-screen-chrome/readme.md
@@ -446,6 +446,21 @@ having to restate everything else. Six spec cases pin this: scalar overrides, pe
 sibling scheme, per-edge mask-stop merges that preserve the sibling edge, immutability of the source defaults and the
 caller's own overrides object, and non-sharing of nested mask-stop objects between the merged result and its inputs.
 
+## mergeRefs
+
+Fans one instance out to several refs, so a chrome scroll ref can be attached alongside consumer and local refs.
+
+```tsx
+const AnimatedKeyboardAwareScrollView = Animated.createAnimatedComponent(KeyboardAwareScrollView);
+const { scrollRef } = useScreenChrome();
+const localRef = useRef<KeyboardAwareScrollView>(null);
+
+<AnimatedKeyboardAwareScrollView ref={mergeRefs(scrollRef, localRef, props.ref)} />;
+```
+
+Object refs receive the instance on `.current`, function refs are called with it, and `null`/`undefined` entries are
+skipped — including the detach pass React makes with `null`.
+
 ## mergeScrollContentInset
 
 Prepends safe-area and chrome content padding while preserving consumer styles after generated padding.
@@ -456,7 +471,10 @@ const contentContainerStyle = mergeScrollContentInset(insets, 96, 48, { paddingH
 
 ## Public utilities
 
-`mergeScrollContentInset` composes safe-area and caller chrome padding while retaining consumer styles last.
+`mergeRefs` fans one instance out to several refs so the chrome scroll ref can coexist with consumer refs.
+`mergeScrollContentInset` composes safe-area and caller chrome padding while retaining consumer styles last;
+consumer padding is applied after the generated padding, so a consumer `paddingTop` replaces the computed
+safe-area+chrome inset rather than adding to it.
 `useScrollFadeStyle` creates a clamped opacity style from the collapsible-header provider scroll value and therefore
 requires a `ScreenChromeProvider` ancestor.
 

--- a/packages/react-native-screen-chrome/readme.md
+++ b/packages/react-native-screen-chrome/readme.md
@@ -451,15 +451,18 @@ caller's own overrides object, and non-sharing of nested mask-stop objects betwe
 Fans one instance out to several refs, so a chrome scroll ref can be attached alongside consumer and local refs.
 
 ```tsx
+import { useCollapsibleHeaderScroll } from '@rnw-community/react-native-collapsible-header';
+
 const AnimatedKeyboardAwareScrollView = Animated.createAnimatedComponent(KeyboardAwareScrollView);
-const { scrollRef } = useScreenChrome();
+const { scrollRef } = useCollapsibleHeaderScroll();
 const localRef = useRef<KeyboardAwareScrollView>(null);
 
 <AnimatedKeyboardAwareScrollView ref={mergeRefs(scrollRef, localRef, props.ref)} />;
 ```
 
-Object refs receive the instance on `.current`, function refs are called with it, and `null`/`undefined` entries are
-skipped — including the detach pass React makes with `null`.
+Object refs receive the instance on `.current`, function refs are called with it, and `null`/`undefined` entries in the
+ref list are skipped. On detach React passes `null` as the instance, and that `null` is forwarded to every provided ref
+so none is left holding a stale instance.
 
 ## mergeScrollContentInset
 

--- a/packages/react-native-screen-chrome/src/index.ts
+++ b/packages/react-native-screen-chrome/src/index.ts
@@ -24,5 +24,6 @@ export type { ScreenChromeConfigOverridesInterface } from './interface/screen-ch
 export type { ScreenChromeContextValueInterface } from './interface/screen-chrome-context-value.interface';
 export { getScreenChromeHeaderMetrics } from './util/get-screen-chrome-header-metrics/get-screen-chrome-header-metrics.util';
 export { assertValidScreenChromeConfig } from './util/assert-valid-screen-chrome-config/assert-valid-screen-chrome-config.util';
+export { mergeRefs } from './util/merge-refs/merge-refs.util';
 export { mergeScrollContentInset } from './util/merge-scroll-content-inset/merge-scroll-content-inset.util';
 export { mergeScreenChromeConfig } from './util/merge-screen-chrome-config/merge-screen-chrome-config.util';

--- a/packages/react-native-screen-chrome/src/util/merge-refs/merge-refs.spec.ts
+++ b/packages/react-native-screen-chrome/src/util/merge-refs/merge-refs.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { mergeRefs } from './merge-refs.util';
+
+import type { MutableRefObject, Ref } from 'react';
+
+describe('mergeRefs', () => {
+    it('assigns the instance to every object ref it is given', () => {
+        expect.assertions(2);
+
+        const first: MutableRefObject<string | null> = { current: null };
+        const second: MutableRefObject<string | null> = { current: null };
+
+        mergeRefs(first, second)('instance');
+
+        expect(first.current).toBe('instance');
+        expect(second.current).toBe('instance');
+    });
+
+    it('calls every function ref it is given with the instance', () => {
+        expect.assertions(2);
+
+        const first = jest.fn<(instance: string | null) => void>();
+        const second = jest.fn<(instance: string | null) => void>();
+
+        mergeRefs<string>(first, second)('instance');
+
+        expect(first).toHaveBeenCalledWith('instance');
+        expect(second).toHaveBeenCalledWith('instance');
+    });
+
+    it('fans a single instance out to mixed function and object refs together', () => {
+        expect.assertions(2);
+
+        const callback = jest.fn<(instance: string | null) => void>();
+        const object: MutableRefObject<string | null> = { current: null };
+
+        mergeRefs<string>(callback, object)('instance');
+
+        expect(callback).toHaveBeenCalledWith('instance');
+        expect(object.current).toBe('instance');
+    });
+
+    it('skips null and undefined refs instead of throwing', () => {
+        expect.assertions(2);
+
+        const object: MutableRefObject<string | null> = { current: null };
+        const refs: Ref<string>[] = [null, object];
+
+        expect(() => mergeRefs<string>(...refs)('instance')).not.toThrow();
+        expect(object.current).toBe('instance');
+    });
+
+    it('propagates the detach null to every ref when React clears the callback', () => {
+        expect.assertions(2);
+
+        const callback = jest.fn<(instance: string | null) => void>();
+        const object: MutableRefObject<string | null> = { current: 'instance' };
+
+        mergeRefs<string>(callback, object)(null);
+
+        expect(callback).toHaveBeenCalledWith(null);
+        expect(object.current).toBeNull();
+    });
+});

--- a/packages/react-native-screen-chrome/src/util/merge-refs/merge-refs.util.ts
+++ b/packages/react-native-screen-chrome/src/util/merge-refs/merge-refs.util.ts
@@ -1,0 +1,19 @@
+import { isDefined } from '@rnw-community/shared';
+
+import type { Ref, RefCallback } from 'react';
+
+/**
+ * Fans one instance out to several refs, so a chrome scroll ref can be attached alongside consumer and local refs.
+ * @see https://github.com/rnw-community/rnw-community/tree/master/packages/react-native-screen-chrome#mergerefs
+ */
+export const mergeRefs =
+    <T,>(...refs: readonly Ref<T>[]): RefCallback<T> =>
+    instance => {
+        refs.forEach(ref => {
+            if (typeof ref === 'function') {
+                ref(instance);
+            } else if (isDefined(ref)) {
+                ref.current = instance;
+            }
+        });
+    };


### PR DESCRIPTION
Addresses the first half of #609. The second half (additive `mergeScrollContentInset`) is deliberately left out — see below.

## What this adds

`CollapsibleHeaderScrollRef` is intentionally assignable to any `Ref<T>`, which invites attaching it alongside a consumer ref and a local animated ref — but every consumer had to hand-roll the merge. `mergeRefs` is now exported:

```tsx
<AnimatedKeyboardAwareScrollView ref={mergeRefs(scrollRef, localRef, props.ref)} />
```

Object refs receive the instance on `.current`, function refs are called with it, and `null`/`undefined` entries are skipped — including the detach pass React makes with `null`, which the specs cover explicitly so a future refactor cannot silently strand a ref at a stale instance.

## Placement

It lives in `react-native-screen-chrome`, matching where #609 filed it, rather than in `@rnw-community/shared`. The repo rule is to extend `shared` rather than create local helpers, but `shared` is deliberately framework-agnostic: it declares no `react` dependency in any section and contains no `react` import anywhere in `src/`. Putting a React ref utility there would pull React into the package every NestJS module depends on.

## Why `mergeScrollContentInset` is not changed here

#609's second point is that it replaces rather than adds — a consumer `contentContainerStyle.paddingTop` silently overrides the computed safe-area+chrome padding. That is real, but every way to fix it is a judgement call with consequences beyond this PR:

- Making it additive by default changes the behaviour of a shipped public export.
- Adding a mode flag pushes the signature to 5 parameters, over the repo's `@typescript-eslint/max-params` limit of 4, so it forces an options-object refactor that is itself breaking.

So this PR ships only the unambiguous, purely additive half, and documents the existing replace semantics explicitly in the readme's Public utilities section so consumers migrating from additive layouts get the signal #609 asks for. #609 stays open for the API decision.

Verified: 27 suites / 93 tests, 100% coverage on all four metrics; root `build`, `ts`, `lint`, `test` and `deadcode` all green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Export `mergeRefs` from `react-native-screen-chrome` for custom scrollable wiring
> Adds a `mergeRefs<T>(...refs)` utility that returns a ref callback forwarding an instance (including null) to all provided refs, supporting both function and object refs and ignoring null/undefined entries. Re-exports it from [index.ts](https://github.com/rnw-community/rnw-community/pull/615/files#diff-2aff6bc61496031e6e62771f825f5b66be4f0d41dc894c1a1f54426b9542d324), adds unit tests in [merge-refs.spec.ts](https://github.com/rnw-community/rnw-community/pull/615/files#diff-a651139f282d84c96646736e12fc072d9d1b20616f4c6432f2107f944cb3ce1c), and documents usage in the package readme.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c22e6e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public `mergeRefs` utility for combining multiple React refs, including function and object refs.
  * Supports mixed ref types, ignores empty refs, and handles ref cleanup automatically.

* **Documentation**
  * Added usage guidance for `mergeRefs`.
  * Clarified that consumer padding overrides generated safe-area and screen chrome insets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->