### PR TITLE
feat(react-native-screen-chrome): forward per-layer content container styles

### DIFF
--- a/packages/react-native-screen-chrome/readme.md
+++ b/packages/react-native-screen-chrome/readme.md
@@ -121,6 +121,17 @@ expanded-layer scale) without widening the config surface:
 <CollapsibleHeader motion={{ backgroundOpacityStartProgress: 0.7, expandedScale: 0.9 }}>{/* slots */}</CollapsibleHeader>
 ```
 
+Both title layers default to centered content behind a 72pt gutter that keeps the title clear of the leading and
+trailing controls. `expandedContentContainerStyle`, `collapsedContentContainerStyle` and
+`persistentContentContainerStyle` are forwarded to the primitive and merged after that default, so a consumer style
+wins without needing to know or cancel the gutter value — an iOS-style left-aligned large title is just:
+
+```tsx
+<CollapsibleHeader expandedContentContainerStyle={{ alignItems: 'flex-start', paddingHorizontal: 16 }}>
+    {/* slots */}
+</CollapsibleHeader>
+```
+
 ## Compound header contract
 
 `CollapsibleHeaderSlot`, `CollapsibleHeaderTitleSlot`, and a second `CollapsibleHeaderSlot` must be direct children of

--- a/packages/react-native-screen-chrome/src/collapsible-header/collapsible-header.spec.tsx
+++ b/packages/react-native-screen-chrome/src/collapsible-header/collapsible-header.spec.tsx
@@ -12,6 +12,8 @@ import { SCREEN_CHROME_DEFAULT_CONFIG } from '../constant/screen-chrome-default-
 
 import { CollapsibleHeader } from './collapsible-header';
 
+import type { StyleProp, ViewStyle } from 'react-native';
+
 const mockConfig = { ...SCREEN_CHROME_DEFAULT_CONFIG, snapToCollapse: true };
 const mockTopInset = 59;
 
@@ -29,6 +31,35 @@ const renderDelegatedProps = (motion?: {
 }) => {
     render(
         <CollapsibleHeader testID="chrome-header" motion={motion}>
+            <CollapsibleHeaderSlot>
+                <Text>Back</Text>
+            </CollapsibleHeaderSlot>
+            <CollapsibleHeaderTitleSlot>
+                <Text>Large</Text>
+                <Text>Small</Text>
+            </CollapsibleHeaderTitleSlot>
+            <CollapsibleHeaderSlot>
+                <Text>Menu</Text>
+            </CollapsibleHeaderSlot>
+        </CollapsibleHeader>
+    );
+
+    const [props] = jest.mocked(GenericCollapsibleHeader).mock.calls[0] ?? [];
+
+    if (!isDefined(props)) {
+        throw new Error('Generic collapsible header was not rendered');
+    }
+
+    return props;
+};
+
+const renderWithContainerStyles = (containerStyles: {
+    readonly expandedContentContainerStyle?: StyleProp<ViewStyle>;
+    readonly collapsedContentContainerStyle?: StyleProp<ViewStyle>;
+    readonly persistentContentContainerStyle?: StyleProp<ViewStyle>;
+}) => {
+    render(
+        <CollapsibleHeader {...containerStyles}>
             <CollapsibleHeaderSlot>
                 <Text>Back</Text>
             </CollapsibleHeaderSlot>
@@ -138,5 +169,51 @@ describe('CollapsibleHeader', () => {
         expect(markers.getByText('Expanded')).toBeTruthy();
         expect(markers.getByText('Collapsed')).toBeTruthy();
         expect(markers.getByText('Trailing')).toBeTruthy();
+    });
+});
+
+describe('CollapsibleHeader content container styles', () => {
+    beforeEach(() => {
+        jest.mocked(GenericCollapsibleHeader).mockClear();
+    });
+
+    it('centers both title layers behind the control gutter when no container style is given', () => {
+        expect.hasAssertions();
+
+        const props = renderWithContainerStyles({});
+
+        expect(StyleSheet.flatten(props.expandedContentContainerStyle)).toEqual({
+            alignItems: 'center',
+            justifyContent: 'center',
+            paddingHorizontal: 72,
+        });
+        expect(StyleSheet.flatten(props.collapsedContentContainerStyle)).toEqual({
+            alignItems: 'center',
+            justifyContent: 'center',
+            paddingHorizontal: 72,
+        });
+        expect(props.persistentContentContainerStyle).toBeUndefined();
+    });
+
+    it('lets a consumer container style override the derived title layer for a left-aligned large title', () => {
+        expect.hasAssertions();
+
+        const props = renderWithContainerStyles({
+            expandedContentContainerStyle: { alignItems: 'flex-start', paddingHorizontal: 16 },
+        });
+        const expanded = StyleSheet.flatten(props.expandedContentContainerStyle);
+
+        expect(expanded.alignItems).toBe('flex-start');
+        expect(expanded.paddingHorizontal).toBe(16);
+        expect(expanded.justifyContent).toBe('center');
+        expect(StyleSheet.flatten(props.collapsedContentContainerStyle).alignItems).toBe('center');
+    });
+
+    it('forwards the persistent container style straight through to the primitive', () => {
+        expect.hasAssertions();
+
+        const props = renderWithContainerStyles({ persistentContentContainerStyle: { paddingHorizontal: 8 } });
+
+        expect(StyleSheet.flatten(props.persistentContentContainerStyle)).toEqual({ paddingHorizontal: 8 });
     });
 });

--- a/packages/react-native-screen-chrome/src/collapsible-header/collapsible-header.tsx
+++ b/packages/react-native-screen-chrome/src/collapsible-header/collapsible-header.tsx
@@ -12,18 +12,29 @@ import { collapsibleHeaderStyles } from './collapsible-header.styles';
 
 import type { CollapsibleHeaderMotionConfig } from '@rnw-community/react-native-collapsible-header';
 import type { ReactNode } from 'react';
-import type { ViewProps } from 'react-native';
+import type { StyleProp, ViewProps, ViewStyle } from 'react-native';
 
 interface Props extends Omit<ViewProps, 'children'> {
     readonly children: ReactNode;
     readonly motion?: Partial<CollapsibleHeaderMotionConfig>;
+    readonly expandedContentContainerStyle?: StyleProp<ViewStyle>;
+    readonly collapsedContentContainerStyle?: StyleProp<ViewStyle>;
+    readonly persistentContentContainerStyle?: StyleProp<ViewStyle>;
 }
 
 /**
  * Composes safe-area-aware title and control slots through the generic collapsible-header primitive.
  * @see https://github.com/rnw-community/rnw-community/tree/master/packages/react-native-screen-chrome#collapsibleheader
  */
-export const CollapsibleHeader = ({ children, motion, style, ...viewProps }: Props): ReactNode => {
+export const CollapsibleHeader = ({
+    children,
+    motion,
+    style,
+    expandedContentContainerStyle,
+    collapsedContentContainerStyle,
+    persistentContentContainerStyle,
+    ...viewProps
+}: Props): ReactNode => {
     const { config } = useScreenChrome();
     const insets = useSafeAreaInsets();
     const { leading, expandedTitle, collapsedTitle, trailing } = getCollapsibleHeaderSlots(children);
@@ -51,8 +62,9 @@ export const CollapsibleHeader = ({ children, motion, style, ...viewProps }: Pro
             persistentContent={persistentContent}
             motion={{ ...getCollapsibleHeaderMotion(config), ...motion }}
             headerStyle={{ paddingTop: insets.top }}
-            expandedContentContainerStyle={collapsibleHeaderStyles.titleLayer}
-            collapsedContentContainerStyle={collapsibleHeaderStyles.titleLayer}
+            expandedContentContainerStyle={[collapsibleHeaderStyles.titleLayer, expandedContentContainerStyle]}
+            collapsedContentContainerStyle={[collapsibleHeaderStyles.titleLayer, collapsedContentContainerStyle]}
+            persistentContentContainerStyle={persistentContentContainerStyle}
         />
     );
 };


### PR DESCRIPTION
Closes #608.

Screen-chrome's `CollapsibleHeader` hardcoded `{ alignItems: 'center', justifyContent: 'center', paddingHorizontal: 72 }` on both title layers and swallowed the generic primitive's per-layer container style props, so a left-aligned iOS-style large title was only reachable by cancelling the private `72` constant with `marginHorizontal: -72` from consumer code.

`expandedContentContainerStyle`, `collapsedContentContainerStyle` and `persistentContentContainerStyle` are now accepted and forwarded, merged **after** the derived title layer so a consumer style wins by normal RN style precedence:

```tsx
<CollapsibleHeader expandedContentContainerStyle={{ alignItems: 'flex-start', paddingHorizontal: 16 }}>
```

That replaces the gutter without the consumer knowing its value, which is what coupled Budgie's wrapper to the constant. The centered 72pt default is unchanged when the props are omitted, so this is purely additive.

Specs cover the three cases that matter, in a sibling describe block (the original one would have crossed the 85-line function limit):
- omitted → both layers still flatten to the centered 72pt gutter, and the persistent style stays `undefined`
- expanded override → `alignItems`/`paddingHorizontal` win while the untouched `justifyContent` still comes from the default, and the collapsed layer is unaffected
- persistent override → forwarded straight through

The readme's CollapsibleHeader section documents the merge order and the left-aligned example.

Verified: 26 suites / 91 tests, 100% coverage on all four metrics; root `ts`, `lint` and `test` green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-layer content container styles to `CollapsibleHeader`
> - `CollapsibleHeader` now accepts `expandedContentContainerStyle`, `collapsedContentContainerStyle`, and `persistentContentContainerStyle` props
> - Expanded and collapsed styles are merged as style arrays with the internal default title-layer styles, so consumer-provided styles override defaults
> - Persistent container style is forwarded directly to `GenericCollapsibleHeader` without merging
> - Tests in [collapsible-header.spec.tsx](https://github.com/rnw-community/rnw-community/pull/616/files#diff-2ad9df345a2468248446908116d6880d8b938d4a396d7a1fc9661b703e5d7e1d) verify default alignment, consumer override behavior, and direct forwarding of persistent style
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 018e836.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->