### PR TITLE
fix(react-native-screen-chrome): preserve child ref cleanups in mergeRefs

### DIFF
--- a/packages/react-native-screen-chrome/readme.md
+++ b/packages/react-native-screen-chrome/readme.md
@@ -463,6 +463,7 @@ Fans one instance out to several refs, so a chrome scroll ref can be attached al
 
 ```tsx
 import { useCollapsibleHeaderScroll } from '@rnw-community/react-native-collapsible-header';
+import { mergeRefs } from '@rnw-community/react-native-screen-chrome';
 
 const AnimatedKeyboardAwareScrollView = Animated.createAnimatedComponent(KeyboardAwareScrollView);
 const { scrollRef } = useCollapsibleHeaderScroll();
@@ -472,8 +473,9 @@ const localRef = useRef<KeyboardAwareScrollView>(null);
 ```
 
 Object refs receive the instance on `.current`, function refs are called with it, and `null`/`undefined` entries in the
-ref list are skipped. On detach React passes `null` as the instance, and that `null` is forwarded to every provided ref
-so none is left holding a stale instance.
+ref list are skipped. Detach is handled both ways React 19 can request it: the returned cleanup runs each child ref's
+own cleanup where one was returned and clears the rest, and calling the merged callback with `null` directly forwards
+that `null` to every ref — so no ref is left holding a stale instance and no child cleanup is dropped.
 
 ## mergeScrollContentInset
 

--- a/packages/react-native-screen-chrome/src/util/merge-refs/merge-refs.spec.ts
+++ b/packages/react-native-screen-chrome/src/util/merge-refs/merge-refs.spec.ts
@@ -6,7 +6,7 @@ import type { MutableRefObject, Ref } from 'react';
 
 describe('mergeRefs', () => {
     it('assigns the instance to every object ref it is given', () => {
-        expect.assertions(2);
+        expect.hasAssertions();
 
         const first: MutableRefObject<string | null> = { current: null };
         const second: MutableRefObject<string | null> = { current: null };
@@ -18,7 +18,7 @@ describe('mergeRefs', () => {
     });
 
     it('calls every function ref it is given with the instance', () => {
-        expect.assertions(2);
+        expect.hasAssertions();
 
         const first = jest.fn<(instance: string | null) => void>();
         const second = jest.fn<(instance: string | null) => void>();
@@ -30,7 +30,7 @@ describe('mergeRefs', () => {
     });
 
     it('fans a single instance out to mixed function and object refs together', () => {
-        expect.assertions(2);
+        expect.hasAssertions();
 
         const callback = jest.fn<(instance: string | null) => void>();
         const object: MutableRefObject<string | null> = { current: null };
@@ -42,17 +42,44 @@ describe('mergeRefs', () => {
     });
 
     it('skips null and undefined refs instead of throwing', () => {
-        expect.assertions(2);
+        expect.hasAssertions();
 
         const object: MutableRefObject<string | null> = { current: null };
-        const refs: Ref<string>[] = [null, object];
+        const refs: (Ref<string> | undefined)[] = [null, void 0, object];
+        const cleanup = mergeRefs<string>(...refs)('instance');
 
-        expect(() => mergeRefs<string>(...refs)('instance')).not.toThrow();
         expect(object.current).toBe('instance');
+        expect(() => cleanup?.()).not.toThrow();
+        expect(object.current).toBeNull();
     });
 
-    it('propagates the detach null to every ref when React clears the callback', () => {
-        expect.assertions(2);
+    it('detaches refs that returned no cleanup by clearing them from the returned cleanup', () => {
+        expect.hasAssertions();
+
+        const callback = jest.fn<(instance: string | null) => void>();
+        const object: MutableRefObject<string | null> = { current: null };
+
+        mergeRefs<string>(callback, object)('instance')?.();
+
+        expect(callback).toHaveBeenLastCalledWith(null);
+        expect(object.current).toBeNull();
+    });
+
+    it('runs a child ref cleanup instead of detaching that ref with null', () => {
+        expect.hasAssertions();
+
+        const cleanup = jest.fn();
+        const callback = jest.fn<(instance: string | null) => () => void>(() => cleanup);
+
+        mergeRefs<string>(callback)('instance')?.();
+
+        expect(cleanup).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).not.toHaveBeenCalledWith(null);
+    });
+
+    it('propagates the detach null to every ref when React clears the callback directly', () => {
+        expect.hasAssertions();
 
         const callback = jest.fn<(instance: string | null) => void>();
         const object: MutableRefObject<string | null> = { current: 'instance' };

--- a/packages/react-native-screen-chrome/src/util/merge-refs/merge-refs.util.ts
+++ b/packages/react-native-screen-chrome/src/util/merge-refs/merge-refs.util.ts
@@ -2,18 +2,38 @@ import { isDefined } from '@rnw-community/shared';
 
 import type { Ref, RefCallback } from 'react';
 
+type RefCleanup = ReturnType<RefCallback<unknown>>;
+
+const detach = <T,>(ref: Ref<T> | undefined, cleanup: RefCleanup): void => {
+    if (typeof cleanup === 'function') {
+        cleanup();
+    } else if (typeof ref === 'function') {
+        ref(null);
+    } else if (isDefined(ref)) {
+        ref.current = null;
+    }
+};
+
 /**
  * Fans one instance out to several refs, so a chrome scroll ref can be attached alongside consumer and local refs.
  * @see https://github.com/rnw-community/rnw-community/tree/master/packages/react-native-screen-chrome#mergerefs
  */
 export const mergeRefs =
-    <T,>(...refs: readonly Ref<T>[]): RefCallback<T> =>
+    <T,>(...refs: readonly (Ref<T> | undefined)[]): RefCallback<T> =>
     instance => {
-        refs.forEach(ref => {
+        const cleanups = refs.map(ref => {
             if (typeof ref === 'function') {
-                ref(instance);
-            } else if (isDefined(ref)) {
+                return ref(instance);
+            }
+
+            if (isDefined(ref)) {
                 ref.current = instance;
             }
+
+            return void 0;
         });
+
+        return () => {
+            refs.forEach((ref, index) => void detach(ref, cleanups[index]));
+        };
     };


### PR DESCRIPTION
Follow-up to #615, addressing review findings that landed after I merged it. My mistake: I re-checked thread state before merging but a new review round arrived between that check and the merge, so three threads went unanswered. Fixing them here rather than leaving them.

## 1. Child ref cleanups were dropped (the real bug)

`RefCallback<T>` in `@types/react` 19.2.18 may return `() => VoidOrUndefinedOnly`. React 19 calls that cleanup on detach **instead of** invoking the ref with `null`. The previous implementation discarded each child's return value and returned nothing itself, so any child ref that used the cleanup form never got cleaned up — React would call the merged callback with `null`, which the child never sees because it expects its cleanup to run.

`mergeRefs` now collects each child's return value and returns a cleanup that, per ref, runs that child's cleanup where one was returned and otherwise performs the legacy `null` detach. Both React 19 paths are covered, and specs assert each: a child returning a cleanup has it invoked and is *not* additionally called with `null`; a child returning nothing is cleared.

## 2. `undefined` entries were documented but not typed

The readme said `null`/`undefined` entries are skipped, but `Ref<T> = RefCallback<T> | RefObject<T | null> | null` excludes `undefined`, so passing one was a type error. The parameter is now `readonly (Ref<T> | undefined)[]`, matching the documented contract and the common `props.ref` shape. The skip spec now passes `[null, undefined, object]`.

## 3. Missing import in the readme example

The snippet called `mergeRefs` without importing it, so a copied example would not resolve. Added.

## Not applied

The same finding asked to delete the TSDoc block as a forbidden comment. Declining: AGENTS.md designates scoped TSDoc as "the one sanctioned documentation comment" and requires it on every export reachable from `index.ts`, in exactly the shape used here — one sentence plus `@see`. The sibling public util `mergeScrollContentInset` carries an identical block. Removing it would break the documented rule, not satisfy it.

Also switched the spec's `expect.assertions(N)` to `expect.hasAssertions()` — this package uses `hasAssertions` 83 times versus 5, so the new file was the outlier.

Verified: 27 suites / 98 tests, 100% coverage on all four metrics; root `ts`, `lint`, `test` green.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve child ref cleanups in `mergeRefs` utility
> - Updates `mergeRefs` in [merge-refs.util.ts](https://github.com/rnw-community/rnw-community/pull/617/files#diff-ba19ff1556a26e830c3c49e36c6dd757ade255a08bd89cb6b64bfcf6caa0f60d) to collect cleanup functions returned by each child ref when called with the instance
> - Adds a `detach` helper that runs a ref's returned cleanup function when available, and falls back to calling function refs with `null` or clearing `object refs` otherwise
> - The returned `RefCallback` now returns a cleanup function that iterates over all refs and detaches each one using the new helper
> - Tolerates `undefined` entries in the refs array
> - Behavioral Change: detachment now prefers a ref's own returned cleanup function over a `null` callback; `mergeRefs` callers that relied solely on the `null` path should verify their refs handle the cleanup-first ordering
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a9ce392. 2 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>packages/react-native-screen-chrome/readme.md — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 478](https://github.com/rnw-community/rnw-community/blob/a9ce392ac93fcd030c97d6db2c626fb9a1ef5a65/packages/react-native-screen-chrome/readme.md#L478): The new claim that a direct `merged(null)` detach leaves no child cleanup dropped is false. Each invocation creates a fresh local `cleanups` array: after `const detach = mergeRefs(child)(instance)`, calling `mergeRefs`' returned callback with `null` only calls `child(null)` and cannot invoke the cleanup returned by the earlier `child(instance)` call. Thus consumers using the documented direct-null detach path can leak the child cleanup despite this documentation promising otherwise. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->