### PR TITLE
fix: collapsible header safe-area layout, accessibility handoff, and shell hit testing

### DIFF
--- a/packages/react-native-collapsible-header/AGENTS.md
+++ b/packages/react-native-collapsible-header/AGENTS.md
@@ -23,6 +23,7 @@ src/
     collapsible-header.tsx       — public component, layer composition, scroll-source resolution
     collapsible-header.spec.tsx  — rendering, a11y, mode, defaults, and validation coverage
     collapsible-header-motion.spec.tsx — animation, clamping, and interaction coverage
+    collapsible-header-accessibility.spec.tsx — pointer-event and accessibility handoff across the cross-fade
   config/
     default-collapsible-header-motion.config.ts — public original-compatible motion preset
     resolve-collapsible-header-motion.config.ts — partial motion override resolution
@@ -113,7 +114,11 @@ src/
 - `collapseDistance` defaults to `expandedHeight - collapsedHeight`; `collapseStart` is optional, non-negative, and
   defaults to `0`.
 - `motion` is additive and partial; missing fields resolve against `DefaultCollapsibleHeaderMotionConfig` (public)
-  before validation, so omitted options preserve existing behavior.
+  before validation, so omitted options preserve existing behavior. The one derived field is
+  `pointerEventsSwitchProgress`: omitted, it resolves to `(collapsedOpacityStartProgress + expandedOpacityEndProgress) / 2`
+  from the already-resolved thresholds, so pointer events and the accessibility tree never move to a layer that is
+  still transparent. A fixed switch point cannot satisfy that for every threshold pair, and the exported preset keeps
+  its literal `0.5` so spreading it stays byte-compatible.
 - Worklet bodies use plain `=== null` checks — `@rnw-community/shared` guards are not workletized and must not be
   called on the UI runtime.
 - `react`, `react-native`, and `react-native-reanimated` remain peer dependencies. Never bundle a second Reanimated copy.

--- a/packages/react-native-collapsible-header/AGENTS.md
+++ b/packages/react-native-collapsible-header/AGENTS.md
@@ -24,6 +24,7 @@ src/
     collapsible-header.spec.tsx  — rendering, a11y, mode, defaults, and validation coverage
     collapsible-header-motion.spec.tsx — animation, clamping, and interaction coverage
     collapsible-header-accessibility.spec.tsx — pointer-event and accessibility handoff across the cross-fade
+    collapsible-header-hit-testing.spec.tsx — header shell pointer-event defaulting and caller override
   config/
     default-collapsible-header-motion.config.ts — public original-compatible motion preset
     resolve-collapsible-header-motion.config.ts — partial motion override resolution
@@ -83,6 +84,13 @@ src/
 - The package owns header height, background opacity, expanded opacity/translation/scale, collapsed opacity/translation,
   clamping, persistent layer placement, visible-layer pointer events, and visible-layer accessibility focus (the hidden
   transition layer is removed from the accessibility tree).
+- Every layer is transparent to touches it does not own, the height-animated shell included: background `none`,
+  persistent and visible transition layer `box-none`, shell `box-none`. An `auto` shell hit-tests across the whole
+  header rectangle and eats taps meant for the scrollable beneath it — a non-interactive title would then stop
+  dismissing the keyboard through `keyboardShouldPersistTaps`. The shell default lives in `styles.header`, ahead of
+  `headerStyle` in the style array, so a caller-supplied `pointerEvents` wins; the library's animated shell style is
+  merged last but only ever sets `height`. The style channel is deliberate — a `pointerEvents` prop is resolved ahead
+  of the style value, so a prop default could not be overridden by `headerStyle` at all.
 - All layer animations are expressed in normalized progress space via one `useDerivedValue`; the same progress shared
   value is provided to slot content through `useCollapsibleHeaderProgress`.
 - **One provider per scrollable, mounted inside each screen — never once around a navigator.** A provider owns exactly

--- a/packages/react-native-collapsible-header/llms.txt
+++ b/packages/react-native-collapsible-header/llms.txt
@@ -51,6 +51,9 @@ reduce-motion setting: instant instead of animated when it is on.
   midpoint `(collapsedOpacityStartProgress + expandedOpacityEndProgress) / 2`.
 - The invisible layer is removed from the accessibility tree (accessibilityElementsHidden /
   importantForAccessibility='no-hide-descendants' / aria-hidden on web).
+- Every layer is transparent to touches it does not own: background 'none', persistent and visible transition layer
+  'box-none', and the height-animated shell 'box-none' — taps on empty header space reach the scrollable beneath.
+  Descendants stay tappable; headerStyle={{ pointerEvents: 'auto' }} overrides the shell default.
 - Testing-library queries for content in the hidden layer require `{ includeHiddenElements: true }`.
 - When testID is set, layers derive their own: {testID}-background/-header/-expanded/-collapsed/-persistent —
   usable from RNTL, Maestro, or Detox.

--- a/packages/react-native-collapsible-header/llms.txt
+++ b/packages/react-native-collapsible-header/llms.txt
@@ -47,6 +47,8 @@ reduce-motion setting: instant instead of animated when it is on.
 - Consumer owns scroll (or delegates to the provider), safe-area, typography, and colors; package owns geometry
   animation, crossfade, pointer-event and accessibility switching between layers, and clamping.
 - Motion thresholds are normalized progress values in [0, 1] over [collapseStart, collapseStart + collapseDistance].
+- Pointer events and accessibility focus switch at `pointerEventsSwitchProgress`, which defaults to the cross-fade
+  midpoint `(collapsedOpacityStartProgress + expandedOpacityEndProgress) / 2`.
 - The invisible layer is removed from the accessibility tree (accessibilityElementsHidden /
   importantForAccessibility='no-hide-descendants' / aria-hidden on web).
 - Testing-library queries for content in the hidden layer require `{ includeHiddenElements: true }`.

--- a/packages/react-native-collapsible-header/readme.md
+++ b/packages/react-native-collapsible-header/readme.md
@@ -259,6 +259,10 @@ The baseline motion preset. Spread it when building named presets so omitted fie
 const subtleMotion = { ...DefaultCollapsibleHeaderMotionConfig, expandedScale: 1, expandedTranslateY: 0 };
 ```
 
+Every field carries the value applied when `motion` is omitted, except `pointerEventsSwitchProgress`: an omitted
+switch progress resolves to the cross-fade midpoint of the thresholds actually in use, while spreading the preset
+passes its `0.5` explicitly.
+
 ## CollapsibleHeaderMotionConfig
 
 Motion progress fields are normalized within the active collapse interval
@@ -270,10 +274,17 @@ to the collapsed endpoint. Omitted `motion` fields use the defaults below, prese
 | `expandedOpacityEndProgress`     | `0.6`   | Progress where expanded content finishes fading from opacity `1` to `0`.     |
 | `collapsedOpacityStartProgress`  | `0.5`   | Progress where collapsed content begins fading from opacity `0` to `1`.      |
 | `backgroundOpacityStartProgress` | `0.7`   | Progress where the background begins fading from opacity `0` to `1`.         |
-| `pointerEventsSwitchProgress`    | `0.5`   | Progress where pointer events and accessibility focus switch between layers. |
+| `pointerEventsSwitchProgress`    | derived | Progress where pointer events and accessibility focus switch between layers. |
 | `expandedTranslateY`             | `-20`   | Expanded content translateY at the collapsed endpoint.                       |
 | `expandedScale`                  | `0.9`   | Expanded content scale at the collapsed endpoint; must be greater than `0`.  |
 | `collapsedTranslateY`            | `10`    | Collapsed content translateY at the fade-in start endpoint.                  |
+
+`pointerEventsSwitchProgress` defaults to the cross-fade midpoint,
+`(collapsedOpacityStartProgress + expandedOpacityEndProgress) / 2`, so the layer that owns pointer events and
+accessibility focus is always the layer the user can actually see. A fixed switch point combined with a late
+`collapsedOpacityStartProgress` hands interaction and the accessibility tree to a layer that is still fully
+transparent, leaving no title exposed for that part of the scroll. Setting the field explicitly wins over the derived
+midpoint; with the default thresholds the derived value is `0.55`.
 
 Opacity progress fields must be between `0` and `1`, and `collapsedOpacityStartProgress` must be less than or equal to
 `expandedOpacityEndProgress`. Translation endpoints must be finite numbers.

--- a/packages/react-native-collapsible-header/readme.md
+++ b/packages/react-native-collapsible-header/readme.md
@@ -127,6 +127,12 @@ offsets after `collapseStart + collapseDistance` to the collapsed state. Only th
 pointer events and accessibility focus — the hidden layer is removed from the accessibility tree, so screen readers
 never announce both layers. Persistent content uses `box-none`.
 
+Every layer is transparent to touches it does not own: the background layer uses `none`, the persistent layer and the
+visible transition layer use `box-none`, and the height-animated shell that hosts them all defaults to `box-none` too,
+so a tap on empty header space reaches the scrollable underneath instead of dying on the header rectangle. Descendants
+stay tappable — `box-none` excludes only the shell itself. Pass `headerStyle={{ pointerEvents: 'auto' }}` to make the
+shell swallow those taps; the caller value wins because `headerStyle` is merged after the default.
+
 Content taller than the shrinking header can paint outside it mid-transition; pass
 `headerStyle={{ overflow: 'hidden' }}` to clip (clipping also cuts shadows, which is why it is not the default).
 

--- a/packages/react-native-collapsible-header/src/collapsible-header/collapsible-header-accessibility.spec.tsx
+++ b/packages/react-native-collapsible-header/src/collapsible-header/collapsible-header-accessibility.spec.tsx
@@ -1,0 +1,139 @@
+import { describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react-native';
+import React from 'react';
+import { Text } from 'react-native';
+import { getAnimatedStyle, useSharedValue } from 'react-native-reanimated';
+
+import { CollapsibleHeader } from './collapsible-header';
+
+import type { CollapsibleHeaderMotionConfig } from '../interface/collapsible-header-motion-config.interface';
+import type { CollapsibleHeaderProps } from '../interface/collapsible-header-props.interface';
+import type { ViewProps, ViewStyle } from 'react-native';
+
+const EXPANDED_HEIGHT = 156;
+const COLLAPSED_HEIGHT = 40;
+const COLLAPSE_DISTANCE = 100;
+const LATE_CROSS_FADE_MOTION: Partial<CollapsibleHeaderMotionConfig> = {
+    expandedOpacityEndProgress: 0.75,
+    collapsedOpacityStartProgress: 0.5,
+};
+const LATE_CROSS_FADE_SWITCH_SCROLL_OFFSET = 62.5;
+const AFTER_LATE_CROSS_FADE_SWITCH_SCROLL_OFFSET = 63;
+const PAST_COLLAPSE_INTERVAL_MIDPOINT_SCROLL_OFFSET = 51;
+const DEFAULT_CROSS_FADE_SWITCH_SCROLL_OFFSET = 55;
+const AFTER_DEFAULT_CROSS_FADE_SWITCH_SCROLL_OFFSET = 56;
+
+type SubjectProps = Partial<Pick<CollapsibleHeaderProps, 'motion'>> & {
+    readonly scrollOffset?: number;
+};
+
+const Subject = ({ scrollOffset = 0, motion }: SubjectProps) => {
+    const scrollY = useSharedValue(scrollOffset);
+
+    return (
+        <CollapsibleHeader
+            testID="header"
+            scrollY={scrollY}
+            expandedHeight={EXPANDED_HEIGHT}
+            collapsedHeight={COLLAPSED_HEIGHT}
+            collapseDistance={COLLAPSE_DISTANCE}
+            motion={motion}
+            expandedContent={<Text>Expanded</Text>}
+            collapsedContent={<Text>Collapsed</Text>}
+        />
+    );
+};
+
+const getLayerStyle = (layer: string): ViewStyle =>
+    getAnimatedStyle(screen.getByTestId(`header-${layer}`, { includeHiddenElements: true }));
+const getLayerAccessibility = (
+    layer: string
+): Pick<ViewProps, 'accessibilityElementsHidden' | 'importantForAccessibility'> =>
+    screen.getByTestId(`header-${layer}`, { includeHiddenElements: true }).props;
+
+describe('CollapsibleHeader accessibility handoff', () => {
+    it.each([
+        { name: 'expanded endpoint', scrollOffset: 0, exposed: 'expanded', hidden: 'collapsed', opacity: 1 },
+        {
+            name: 'collapse interval midpoint before the cross-fade midpoint',
+            scrollOffset: PAST_COLLAPSE_INTERVAL_MIDPOINT_SCROLL_OFFSET,
+            exposed: 'expanded',
+            hidden: 'collapsed',
+            opacity: 0.32,
+        },
+        {
+            name: 'cross-fade midpoint',
+            scrollOffset: LATE_CROSS_FADE_SWITCH_SCROLL_OFFSET,
+            exposed: 'expanded',
+            hidden: 'collapsed',
+            opacity: 1 / 6,
+        },
+        {
+            name: 'offset past the cross-fade midpoint',
+            scrollOffset: AFTER_LATE_CROSS_FADE_SWITCH_SCROLL_OFFSET,
+            exposed: 'collapsed',
+            hidden: 'expanded',
+            opacity: 0.26,
+        },
+        {
+            name: 'collapsed endpoint',
+            scrollOffset: COLLAPSE_DISTANCE,
+            exposed: 'collapsed',
+            hidden: 'expanded',
+            opacity: 1,
+        },
+    ])('exposes only visible content at the $name', ({ scrollOffset, exposed, hidden, opacity }) => {
+        expect.hasAssertions();
+        render(<Subject scrollOffset={scrollOffset} motion={LATE_CROSS_FADE_MOTION} />);
+        const exposedStyle = getLayerStyle(exposed);
+        const hiddenStyle = getLayerStyle(hidden);
+
+        expect(getLayerAccessibility(exposed)).toMatchObject({
+            accessibilityElementsHidden: false,
+            importantForAccessibility: 'auto',
+        });
+        expect(getLayerAccessibility(hidden)).toMatchObject({
+            accessibilityElementsHidden: true,
+            importantForAccessibility: 'no-hide-descendants',
+        });
+        expect(exposedStyle.opacity).toBeCloseTo(opacity);
+        expect(exposedStyle.opacity).toBeGreaterThan(0);
+        expect(exposedStyle.pointerEvents).toBe('box-none');
+        expect(hiddenStyle.pointerEvents).toBe('none');
+    });
+
+    it.each([
+        {
+            name: 'at the default cross-fade midpoint',
+            scrollOffset: DEFAULT_CROSS_FADE_SWITCH_SCROLL_OFFSET,
+            expandedPointer: 'box-none',
+            collapsedPointer: 'none',
+        },
+        {
+            name: 'past the default cross-fade midpoint',
+            scrollOffset: AFTER_DEFAULT_CROSS_FADE_SWITCH_SCROLL_OFFSET,
+            expandedPointer: 'none',
+            collapsedPointer: 'box-none',
+        },
+    ])('switches layers $name', ({ scrollOffset, expandedPointer, collapsedPointer }) => {
+        expect.hasAssertions();
+        render(<Subject scrollOffset={scrollOffset} />);
+
+        expect(getLayerStyle('expanded').pointerEvents).toBe(expandedPointer);
+        expect(getLayerStyle('collapsed').pointerEvents).toBe(collapsedPointer);
+    });
+
+    it('keeps an explicit switch progress ahead of the derived cross-fade midpoint', () => {
+        expect.hasAssertions();
+        render(
+            <Subject
+                scrollOffset={PAST_COLLAPSE_INTERVAL_MIDPOINT_SCROLL_OFFSET}
+                motion={{ ...LATE_CROSS_FADE_MOTION, pointerEventsSwitchProgress: 0.5 }}
+            />
+        );
+
+        expect(getLayerStyle('expanded').pointerEvents).toBe('none');
+        expect(getLayerStyle('collapsed').pointerEvents).toBe('box-none');
+        expect(getLayerAccessibility('collapsed')).toMatchObject({ accessibilityElementsHidden: false });
+    });
+});

--- a/packages/react-native-collapsible-header/src/collapsible-header/collapsible-header-hit-testing.spec.tsx
+++ b/packages/react-native-collapsible-header/src/collapsible-header/collapsible-header-hit-testing.spec.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import React from 'react';
+import { Pressable, StyleSheet, Text } from 'react-native';
+import { useSharedValue } from 'react-native-reanimated';
+
+import { CollapsibleHeader } from './collapsible-header';
+
+import type { CollapsibleHeaderProps } from '../interface/collapsible-header-props.interface';
+import type { ViewProps, ViewStyle } from 'react-native';
+
+const EXPANDED_HEIGHT = 156;
+const COLLAPSED_HEIGHT = 40;
+const COLLAPSE_DISTANCE = 100;
+
+type SubjectProps = Partial<Pick<CollapsibleHeaderProps, 'headerStyle' | 'persistentContent'>>;
+
+const Subject = ({ headerStyle, persistentContent }: SubjectProps) => {
+    const scrollY = useSharedValue(0);
+
+    return (
+        <CollapsibleHeader
+            testID="header"
+            scrollY={scrollY}
+            expandedHeight={EXPANDED_HEIGHT}
+            collapsedHeight={COLLAPSED_HEIGHT}
+            collapseDistance={COLLAPSE_DISTANCE}
+            headerStyle={headerStyle}
+            persistentContent={persistentContent}
+            expandedContent={<Text>Expanded</Text>}
+            collapsedContent={<Text>Collapsed</Text>}
+        />
+    );
+};
+
+const getShellProps = (): Pick<ViewProps, 'style'> =>
+    screen.getByTestId('header-header', { includeHiddenElements: true }).props;
+const getShellPointerEvents = (): ViewStyle['pointerEvents'] =>
+    StyleSheet.flatten<ViewStyle>(getShellProps().style).pointerEvents;
+
+describe('CollapsibleHeader shell hit testing', () => {
+    it('leaves empty header space transparent so touches reach the content beneath', () => {
+        expect.hasAssertions();
+        render(<Subject />);
+
+        expect(getShellPointerEvents()).toBe('box-none');
+    });
+
+    it('keeps header controls tappable through the transparent shell', () => {
+        expect.hasAssertions();
+        const onPress = jest.fn();
+        render(
+            <Subject
+                persistentContent={
+                    <Pressable testID="action" onPress={onPress}>
+                        <Text>Action</Text>
+                    </Pressable>
+                }
+            />
+        );
+        fireEvent.press(screen.getByTestId('action'));
+
+        expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('lets a caller-supplied shell pointer events value win over the default', () => {
+        expect.hasAssertions();
+        render(<Subject headerStyle={{ pointerEvents: 'auto' }} />);
+
+        expect(getShellPointerEvents()).toBe('auto');
+    });
+});

--- a/packages/react-native-collapsible-header/src/collapsible-header/collapsible-header.tsx
+++ b/packages/react-native-collapsible-header/src/collapsible-header/collapsible-header.tsx
@@ -35,7 +35,7 @@ const getLayerTestIDs = (testID?: string): CollapsibleHeaderLayerTestIDs =>
 
 const styles = StyleSheet.create({
     background: { position: 'absolute', top: 0, right: 0, bottom: 0, left: 0 },
-    header: { position: 'relative' },
+    header: { position: 'relative', pointerEvents: 'box-none' },
     content: { position: 'absolute', top: 0, right: 0, bottom: 0, left: 0 },
     overlayContainer: { position: 'absolute', top: 0, right: 0, left: 0 },
 });

--- a/packages/react-native-collapsible-header/src/config/default-collapsible-header-motion.config.ts
+++ b/packages/react-native-collapsible-header/src/config/default-collapsible-header-motion.config.ts
@@ -1,7 +1,7 @@
 import type { CollapsibleHeaderMotionConfig } from '../interface/collapsible-header-motion-config.interface';
 
 /**
- * Baseline motion preset applied when partial `motion` overrides omit fields.
+ * Baseline motion preset applied when partial `motion` overrides omit fields, except the derived pointer-events switch.
  * @see https://github.com/rnw-community/rnw-community/tree/master/packages/react-native-collapsible-header#defaultcollapsibleheadermotionconfig
  */
 export const DefaultCollapsibleHeaderMotionConfig: CollapsibleHeaderMotionConfig = {

--- a/packages/react-native-collapsible-header/src/config/resolve-collapsible-header-motion.config.ts
+++ b/packages/react-native-collapsible-header/src/config/resolve-collapsible-header-motion.config.ts
@@ -4,16 +4,21 @@ import type { CollapsibleHeaderMotionConfig } from '../interface/collapsible-hea
 
 export const resolveCollapsibleHeaderMotionConfig = (
     motion: Partial<CollapsibleHeaderMotionConfig> | undefined
-): CollapsibleHeaderMotionConfig => ({
-    expandedOpacityEndProgress:
-        motion?.expandedOpacityEndProgress ?? DefaultCollapsibleHeaderMotionConfig.expandedOpacityEndProgress,
-    collapsedOpacityStartProgress:
-        motion?.collapsedOpacityStartProgress ?? DefaultCollapsibleHeaderMotionConfig.collapsedOpacityStartProgress,
-    backgroundOpacityStartProgress:
-        motion?.backgroundOpacityStartProgress ?? DefaultCollapsibleHeaderMotionConfig.backgroundOpacityStartProgress,
-    pointerEventsSwitchProgress:
-        motion?.pointerEventsSwitchProgress ?? DefaultCollapsibleHeaderMotionConfig.pointerEventsSwitchProgress,
-    expandedTranslateY: motion?.expandedTranslateY ?? DefaultCollapsibleHeaderMotionConfig.expandedTranslateY,
-    expandedScale: motion?.expandedScale ?? DefaultCollapsibleHeaderMotionConfig.expandedScale,
-    collapsedTranslateY: motion?.collapsedTranslateY ?? DefaultCollapsibleHeaderMotionConfig.collapsedTranslateY,
-});
+): CollapsibleHeaderMotionConfig => {
+    const expandedOpacityEndProgress =
+        motion?.expandedOpacityEndProgress ?? DefaultCollapsibleHeaderMotionConfig.expandedOpacityEndProgress;
+    const collapsedOpacityStartProgress =
+        motion?.collapsedOpacityStartProgress ?? DefaultCollapsibleHeaderMotionConfig.collapsedOpacityStartProgress;
+
+    return {
+        expandedOpacityEndProgress,
+        collapsedOpacityStartProgress,
+        backgroundOpacityStartProgress:
+            motion?.backgroundOpacityStartProgress ?? DefaultCollapsibleHeaderMotionConfig.backgroundOpacityStartProgress,
+        pointerEventsSwitchProgress:
+            motion?.pointerEventsSwitchProgress ?? (collapsedOpacityStartProgress + expandedOpacityEndProgress) / 2,
+        expandedTranslateY: motion?.expandedTranslateY ?? DefaultCollapsibleHeaderMotionConfig.expandedTranslateY,
+        expandedScale: motion?.expandedScale ?? DefaultCollapsibleHeaderMotionConfig.expandedScale,
+        collapsedTranslateY: motion?.collapsedTranslateY ?? DefaultCollapsibleHeaderMotionConfig.collapsedTranslateY,
+    };
+};

--- a/packages/react-native-collapsible-header/src/interface/collapsible-header-motion-config.interface.ts
+++ b/packages/react-native-collapsible-header/src/interface/collapsible-header-motion-config.interface.ts
@@ -20,7 +20,7 @@ export interface CollapsibleHeaderMotionConfig {
     readonly backgroundOpacityStartProgress: number;
     /**
      * Progress where pointer events and accessibility focus move from expanded to collapsed content.
-     * @defaultValue `0.5`
+     * @defaultValue `(collapsedOpacityStartProgress + expandedOpacityEndProgress) / 2`
      */
     readonly pointerEventsSwitchProgress: number;
     /**

--- a/packages/react-native-screen-chrome/AGENTS.md
+++ b/packages/react-native-screen-chrome/AGENTS.md
@@ -35,10 +35,16 @@ pnpm test && pnpm test:coverage && pnpm build && pnpm ts && pnpm ts:nodenext && 
 - `snapToCollapse` only takes effect while a `CollapsibleHeader` is mounted: the header registers the snap geometry
   with the provider. Reduced-motion-aware snapping is upstream scope, not a local reimplementation.
 - Native peer dependencies remain external so applications own native versions and linking.
-- `CollapsibleHeader` sizes the generic header container to `safeAreaInsets.top + config.headerHeight` and reserves the
-  inset as `paddingTop`. The generic primitive positions its content layers inside that padding, so leaving the inset
-  out of `expandedHeight`/`collapsedHeight` compresses the title and controls to whatever the notch does not consume.
-  It is the same composition `mergeScrollContentInset` applies, which keeps overlay content padding aligned.
+- `CollapsibleHeader` sizes the generic header container to `safeAreaInsets.top + config.headerHeight` and offsets every
+  content layer by `top: safeAreaInsets.top`. Leaving the inset out of `expandedHeight`/`collapsedHeight` compresses the
+  title and controls to whatever the notch does not consume, and `paddingTop` on `headerStyle` does not move them at
+  all: the primitive renders the expanded, collapsed, and persistent layers as `position: absolute` boxes with inset
+  `0`, which resolve against the container box and ignore its padding, centering the content over the inset band. The
+  container height is the same composition `mergeScrollContentInset` applies, which keeps overlay content padding
+  aligned.
+- The generic `motion` mapping omits `pointerEventsSwitchProgress` on purpose so the primitive derives it from the
+  cross-fade midpoint of the mapped `smallTitleStart`/`largeTitleEnd` windows; pinning it to a fixed progress hands
+  pointer events and the accessibility tree to a title layer that is still transparent.
 - The `expo-blur` peer floor is `>=55`: `blurMethod` and the `BlurMethod` type only exist from that release (it renamed
   `experimentalBlurMethod`), and the same release made `dimezisBlurView` require a `BlurTargetView`. `EdgeFade`
   therefore defaults `blurMethod` from `blurTarget` presence rather than hard-coding a targeted method.

--- a/packages/react-native-screen-chrome/readme.md
+++ b/packages/react-native-screen-chrome/readme.md
@@ -108,10 +108,13 @@ from `useScreenChrome`.
 </CollapsibleHeader>
 ```
 
-The header container is sized to `safeAreaInsets.top + config.headerHeight` and reserves the top inset as padding, so
-`config.headerHeight` is always the usable content height regardless of notch or dynamic-island depth. It is the same
-composition `ScreenChromeScrollView` applies to `contentInsetTop`, so passing `contentInsetTop={config.headerHeight}`
-clears the overlay header exactly.
+The header container is sized to `safeAreaInsets.top + config.headerHeight`, and both title layers and the persistent
+control row start at `safeAreaInsets.top`, so `config.headerHeight` is always the usable content height regardless of
+notch or dynamic-island depth. The primitive positions those layers absolutely inside the animated header, so the
+offset is a layer `top` rather than container padding — padding leaves absolute layers resolving against the full
+container box and centers their content over the inset instead of below it. It is the same composition
+`ScreenChromeScrollView` applies to `contentInsetTop`, so passing `contentInsetTop={config.headerHeight}` clears the
+overlay header exactly.
 
 Pass `motion` to override individual per-layer animation windows or transforms derived from config — any key you set
 wins, the rest stay config-driven. This covers app-specific motion (for example an earlier background fade start, or
@@ -407,7 +410,10 @@ positions, colors, and transition ordering are validated. The required threshold
 `collapseStart <= smallTitleStart <= largeTitleEnd <= collapseEnd` with a non-zero collapse interval.
 
 Thresholds are mapped to normalized collapse progress and handed to the generic header as its `motion` config, so
-`smallTitleStart` and `largeTitleEnd` keep their meaning while the transition itself is owned upstream.
+`smallTitleStart` and `largeTitleEnd` keep their meaning while the transition itself is owned upstream. The
+pointer-event and accessibility switch is deliberately left unset so the primitive derives it from the mapped
+cross-fade midpoint, which keeps the interactive, accessibility-exposed title the one that is actually visible for
+every threshold pair.
 
 `snapToCollapse` is forwarded to the generic header's `snap` prop, which snaps the scrollable toward the nearest
 endpoint once a released scroll holds still for three frames — momentum events are never relied on, because a

--- a/packages/react-native-screen-chrome/src/collapsible-header/collapsible-header.integration.spec.tsx
+++ b/packages/react-native-screen-chrome/src/collapsible-header/collapsible-header.integration.spec.tsx
@@ -1,7 +1,8 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import { render } from '@testing-library/react-native';
+import { render, screen } from '@testing-library/react-native';
 import React from 'react';
-import { Text } from 'react-native';
+import { StyleSheet, Text } from 'react-native';
+import { getAnimatedStyle } from 'react-native-reanimated';
 
 import { CollapsibleHeaderProvider } from '@rnw-community/react-native-collapsible-header';
 
@@ -11,10 +12,13 @@ import { SCREEN_CHROME_DEFAULT_CONFIG } from '../constant/screen-chrome-default-
 
 import { CollapsibleHeader } from './collapsible-header';
 
+import type { StyleProp, ViewStyle } from 'react-native';
+
 const mockConfig = { ...SCREEN_CHROME_DEFAULT_CONFIG, snapToCollapse: true };
+const mockTopInset = 12;
 
 jest.mock('react-native-safe-area-context', () => ({
-    useSafeAreaInsets: () => ({ top: 12, right: 0, bottom: 0, left: 0 }),
+    useSafeAreaInsets: () => ({ top: mockTopInset, right: 0, bottom: 0, left: 0 }),
 }));
 jest.mock('../hooks/use-screen-chrome/use-screen-chrome.hook', () => ({
     useScreenChrome: () => ({ config: mockConfig }),
@@ -24,9 +28,9 @@ describe('CollapsibleHeader integration', () => {
     it('mounts title and control slots once through the provider-driven generic header', () => {
         expect.hasAssertions();
 
-        const screen = render(
+        render(
             <CollapsibleHeaderProvider>
-                <CollapsibleHeader>
+                <CollapsibleHeader testID="chrome-header">
                     <CollapsibleHeaderSlot>
                         <Text>Back</Text>
                     </CollapsibleHeaderSlot>
@@ -45,5 +49,42 @@ describe('CollapsibleHeader integration', () => {
         expect(screen.getAllByText('Menu')).toHaveLength(1);
         expect(screen.getAllByText('Expanded')).toHaveLength(1);
         expect(screen.getAllByText('Collapsed', { includeHiddenElements: true })).toHaveLength(1);
+    });
+
+    it('lays every rendered content layer out in the header band below the top inset', () => {
+        expect.hasAssertions();
+
+        render(
+            <CollapsibleHeaderProvider>
+                <CollapsibleHeader testID="chrome-header">
+                    <CollapsibleHeaderSlot>
+                        <Text>Back</Text>
+                    </CollapsibleHeaderSlot>
+                    <CollapsibleHeaderTitleSlot>
+                        <Text>Expanded</Text>
+                        <Text>Collapsed</Text>
+                    </CollapsibleHeaderTitleSlot>
+                    <CollapsibleHeaderSlot>
+                        <Text>Menu</Text>
+                    </CollapsibleHeaderSlot>
+                </CollapsibleHeader>
+            </CollapsibleHeaderProvider>
+        );
+        const getLayerStyle = (layer: string): ViewStyle =>
+            StyleSheet.flatten(
+                (
+                    screen.getByTestId(`chrome-header-${layer}`, { includeHiddenElements: true }).props as {
+                        style: StyleProp<ViewStyle>;
+                    }
+                ).style
+            );
+
+        expect(getAnimatedStyle(screen.getByTestId('chrome-header-header')).height).toBe(
+            mockTopInset + mockConfig.headerHeight
+        );
+        expect(getLayerStyle('expanded').top).toBe(mockTopInset);
+        expect(getLayerStyle('collapsed').top).toBe(mockTopInset);
+        expect(getLayerStyle('persistent').top).toBe(mockTopInset);
+        expect(getLayerStyle('header').paddingTop).toBeUndefined();
     });
 });

--- a/packages/react-native-screen-chrome/src/collapsible-header/collapsible-header.spec.tsx
+++ b/packages/react-native-screen-chrome/src/collapsible-header/collapsible-header.spec.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { render } from '@testing-library/react-native';
 import React from 'react';
 import { StyleSheet, Text } from 'react-native';
@@ -15,7 +15,9 @@ import { CollapsibleHeader } from './collapsible-header';
 import type { StyleProp, ViewStyle } from 'react-native';
 
 const mockConfig = { ...SCREEN_CHROME_DEFAULT_CONFIG, snapToCollapse: true };
-const mockTopInset = 59;
+const DEVICE_TOP_INSET = 59;
+const NO_TOP_INSET = 0;
+let mockTopInset = DEVICE_TOP_INSET;
 
 jest.mock('@rnw-community/react-native-collapsible-header', () => ({ CollapsibleHeader: jest.fn(() => null) }));
 jest.mock('react-native-safe-area-context', () => ({
@@ -104,12 +106,10 @@ describe('CollapsibleHeader', () => {
                 collapsedHeight: mockTopInset + mockConfig.headerHeight,
                 collapseStart: mockConfig.collapseStart,
                 collapseDistance: mockConfig.collapseEnd - mockConfig.collapseStart,
-                headerStyle: { paddingTop: mockTopInset },
                 motion: {
                     expandedOpacityEndProgress: 0.75,
                     collapsedOpacityStartProgress: 0.5,
                     backgroundOpacityStartProgress: 1,
-                    pointerEventsSwitchProgress: 0.5,
                     expandedTranslateY: 0,
                     expandedScale: 1,
                     collapsedTranslateY: 0,
@@ -120,15 +120,19 @@ describe('CollapsibleHeader', () => {
         expect(controls.getAllByText('Menu')).toHaveLength(1);
     });
 
-    it('reserves the configured content height above the safe-area top inset', () => {
+    it('starts every content layer below the safe-area top inset', () => {
         expect.hasAssertions();
 
         const props = renderDelegatedProps();
-        const headerPaddingTop = Number(StyleSheet.flatten(props.headerStyle).paddingTop);
+        const expandedTop = Number(StyleSheet.flatten(props.expandedContentContainerStyle).top);
+        const collapsedTop = Number(StyleSheet.flatten(props.collapsedContentContainerStyle).top);
+        const persistentTop = Number(StyleSheet.flatten(props.persistentContentContainerStyle).top);
 
-        expect(headerPaddingTop).toBe(mockTopInset);
-        expect(props.expandedHeight - headerPaddingTop).toBe(mockConfig.headerHeight);
-        expect(props.collapsedHeight - headerPaddingTop).toBe(mockConfig.headerHeight);
+        expect(expandedTop).toBe(mockTopInset);
+        expect(collapsedTop).toBe(mockTopInset);
+        expect(persistentTop).toBe(mockTopInset);
+        expect(props.expandedHeight - expandedTop).toBe(mockConfig.headerHeight);
+        expect(props.collapsedHeight - collapsedTop).toBe(mockConfig.headerHeight);
     });
 
     it('lets the motion override win over derived windows while the rest stays config-driven', () => {
@@ -140,7 +144,6 @@ describe('CollapsibleHeader', () => {
             expandedOpacityEndProgress: 0.75,
             collapsedOpacityStartProgress: 0.5,
             backgroundOpacityStartProgress: 0.7,
-            pointerEventsSwitchProgress: 0.5,
             expandedTranslateY: 0,
             expandedScale: 0.9,
             collapsedTranslateY: 0,
@@ -186,13 +189,15 @@ describe('CollapsibleHeader content container styles', () => {
             alignItems: 'center',
             justifyContent: 'center',
             paddingHorizontal: 72,
+            top: mockTopInset,
         });
         expect(StyleSheet.flatten(props.collapsedContentContainerStyle)).toEqual({
             alignItems: 'center',
             justifyContent: 'center',
             paddingHorizontal: 72,
+            top: mockTopInset,
         });
-        expect(props.persistentContentContainerStyle).toBeUndefined();
+        expect(StyleSheet.flatten(props.persistentContentContainerStyle)).toEqual({ top: mockTopInset });
     });
 
     it('lets a consumer container style override the derived title layer for a left-aligned large title', () => {
@@ -214,6 +219,31 @@ describe('CollapsibleHeader content container styles', () => {
 
         const props = renderWithContainerStyles({ persistentContentContainerStyle: { paddingHorizontal: 8 } });
 
-        expect(StyleSheet.flatten(props.persistentContentContainerStyle)).toEqual({ paddingHorizontal: 8 });
+        expect(StyleSheet.flatten(props.persistentContentContainerStyle)).toEqual({
+            paddingHorizontal: 8,
+            top: mockTopInset,
+        });
+    });
+});
+
+describe('CollapsibleHeader without a safe-area top inset', () => {
+    beforeEach(() => {
+        jest.mocked(GenericCollapsibleHeader).mockClear();
+        mockTopInset = NO_TOP_INSET;
+    });
+
+    afterEach(() => {
+        mockTopInset = DEVICE_TOP_INSET;
+    });
+
+    it('keeps the content layers flush with the header container', () => {
+        expect.hasAssertions();
+
+        const props = renderDelegatedProps();
+
+        expect(props.expandedHeight).toBe(mockConfig.headerHeight);
+        expect(StyleSheet.flatten(props.expandedContentContainerStyle).top).toBe(NO_TOP_INSET);
+        expect(StyleSheet.flatten(props.collapsedContentContainerStyle).top).toBe(NO_TOP_INSET);
+        expect(StyleSheet.flatten(props.persistentContentContainerStyle).top).toBe(NO_TOP_INSET);
     });
 });

--- a/packages/react-native-screen-chrome/src/collapsible-header/collapsible-header.tsx
+++ b/packages/react-native-screen-chrome/src/collapsible-header/collapsible-header.tsx
@@ -39,6 +39,7 @@ export const CollapsibleHeader = ({
     const insets = useSafeAreaInsets();
     const { leading, expandedTitle, collapsedTitle, trailing } = getCollapsibleHeaderSlots(children);
     const containerHeight = insets.top + config.headerHeight;
+    const contentLayerStyle = { top: insets.top };
     const persistentContent = (
         <View style={collapsibleHeaderStyles.persistentRow} pointerEvents="box-none">
             {leading}
@@ -61,10 +62,17 @@ export const CollapsibleHeader = ({
             collapsedContent={collapsedTitle}
             persistentContent={persistentContent}
             motion={{ ...getCollapsibleHeaderMotion(config), ...motion }}
-            headerStyle={{ paddingTop: insets.top }}
-            expandedContentContainerStyle={[collapsibleHeaderStyles.titleLayer, expandedContentContainerStyle]}
-            collapsedContentContainerStyle={[collapsibleHeaderStyles.titleLayer, collapsedContentContainerStyle]}
-            persistentContentContainerStyle={persistentContentContainerStyle}
+            expandedContentContainerStyle={[
+                collapsibleHeaderStyles.titleLayer,
+                contentLayerStyle,
+                expandedContentContainerStyle,
+            ]}
+            collapsedContentContainerStyle={[
+                collapsibleHeaderStyles.titleLayer,
+                contentLayerStyle,
+                collapsedContentContainerStyle,
+            ]}
+            persistentContentContainerStyle={[contentLayerStyle, persistentContentContainerStyle]}
         />
     );
 };

--- a/packages/react-native-screen-chrome/src/util/get-collapsible-header-motion/get-collapsible-header-motion.spec.ts
+++ b/packages/react-native-screen-chrome/src/util/get-collapsible-header-motion/get-collapsible-header-motion.spec.ts
@@ -17,7 +17,6 @@ describe('getCollapsibleHeaderMotion', () => {
             expandedOpacityEndProgress: 0.75,
             collapsedOpacityStartProgress: 0.5,
             backgroundOpacityStartProgress: 1,
-            pointerEventsSwitchProgress: 0.5,
             expandedTranslateY: 0,
             expandedScale: 1,
             collapsedTranslateY: 0,
@@ -37,6 +36,12 @@ describe('getCollapsibleHeaderMotion', () => {
 
         expect(motion.collapsedOpacityStartProgress).toBe(0.2);
         expect(motion.expandedOpacityEndProgress).toBe(0.6);
+    });
+
+    it('leaves the pointer-event and accessibility switch to the derived cross-fade midpoint', () => {
+        expect.hasAssertions();
+
+        expect(getCollapsibleHeaderMotion(SCREEN_CHROME_DEFAULT_CONFIG)).not.toHaveProperty('pointerEventsSwitchProgress');
     });
 
     it('keeps title layers free of endpoint translation and scaling', () => {

--- a/packages/react-native-screen-chrome/src/util/get-collapsible-header-motion/get-collapsible-header-motion.util.ts
+++ b/packages/react-native-screen-chrome/src/util/get-collapsible-header-motion/get-collapsible-header-motion.util.ts
@@ -2,7 +2,6 @@ import type { ScreenChromeConfigInterface } from '../../interface/screen-chrome-
 import type { CollapsibleHeaderMotionConfig } from '@rnw-community/react-native-collapsible-header';
 
 const BACKGROUND_OPACITY_START_PROGRESS = 1;
-const POINTER_EVENTS_SWITCH_PROGRESS = 0.5;
 const FLAT_TRANSLATE_Y = 0;
 const NEUTRAL_SCALE = 1;
 
@@ -13,7 +12,6 @@ export const getCollapsibleHeaderMotion = (config: ScreenChromeConfigInterface):
         expandedOpacityEndProgress: (config.largeTitleEnd - config.collapseStart) / collapseDistance,
         collapsedOpacityStartProgress: (config.smallTitleStart - config.collapseStart) / collapseDistance,
         backgroundOpacityStartProgress: BACKGROUND_OPACITY_START_PROGRESS,
-        pointerEventsSwitchProgress: POINTER_EVENTS_SWITCH_PROGRESS,
         expandedTranslateY: FLAT_TRANSLATE_Y,
         expandedScale: NEUTRAL_SCALE,
         collapsedTranslateY: FLAT_TRANSLATE_Y,


### PR DESCRIPTION
Three defects found while migrating a real app onto the published screen chrome packages. The app currently carries local workarounds for all of them; this PR removes the need for them.

## #618 — collapsible header content is centered over the safe-area inset

`CollapsibleHeader` (screen-chrome) sizes its container to `safeAreaInsets.top + config.headerHeight` and reserved the inset as `headerStyle={{ paddingTop: insets.top }}`. The expanded, collapsed, and persistent layers are rendered by the generic primitive as `position: absolute` boxes with inset `0`, so they resolve against the container box and ignore that padding. Every piece of header content was therefore centered over `insets.top + headerHeight` rather than over the `headerHeight` band below the inset.

Measured on device with a 62pt top inset and a 64pt header height:

| header | back button frame | center y |
| ------ | ----------------- | -------- |
| `CollapsibleHeader` (before) | `[18,43][58,83]` | 63 |
| `ScreenChromeHeader` (correct) | `[20,62][60,102]` | 82 |
| target band | — | 74..114 |

Every content layer now carries `top: safeAreaInsets.top`, so the layer box is exactly the `config.headerHeight` band the readme promises. Container height, `getScreenChromeHeaderMetrics`, and `mergeScrollContentInset` composition are unchanged, and a zero top inset collapses to the previous geometry. Applying the offset as a layer `top` rather than container padding also keeps the result independent of how Yoga resolves padding for absolutely positioned children.

## #619 — accessibility handoff to a fully transparent layer

`pointerEventsSwitchProgress` defaulted to a fixed `0.5` and drives both pointer events and the accessibility handoff (`accessibilityElementsHidden` / `importantForAccessibility`), while the opacity ramps are driven independently by `expandedOpacityEndProgress` and `collapsedOpacityStartProgress`. When the collapsed layer's fade-in starts at or after `0.5`, there is a scroll window where the accessibility-owning layer has opacity ~0 and the visible layer is hidden from the accessibility tree — no title exposed at all.

Reproduced with `expandedOpacityEndProgress: 0.75` / `collapsedOpacityStartProgress: 0.5`, which is exactly what screen-chrome derives from its default `smallTitleStart: 40` / `largeTitleEnd: 60` / `collapseEnd: 80` config: at progress `0.5+` the collapsed layer owned pointer events and accessibility focus with an opacity of `0.0…`.

An omitted `pointerEventsSwitchProgress` now resolves to the cross-fade midpoint `(collapsedOpacityStartProgress + expandedOpacityEndProgress) / 2` of the already-resolved thresholds — `0.625` for that config, `0.55` for the shipped defaults. An explicitly passed value still wins.

`DefaultCollapsibleHeaderMotionConfig` is a public export whose numeric values consumers match exactly, so it keeps its shape and every value, `pointerEventsSwitchProgress: 0.5` included: spreading the preset into `motion` passes the field explicitly and reproduces the previous behavior byte-for-byte. Only omitting the field opts into the derived midpoint. The default is therefore computed at resolve time rather than baked into the exported constant.

screen-chrome's `getCollapsibleHeaderMotion` stops pinning the field to `0.5` so the mapped title windows drive the switch.

## #621 — the header shell hit-tests across the whole header rectangle

`CollapsibleHeader` (the generic primitive) sets `pointerEvents` on four of its five layers: the background layer `none`, the persistent layer `box-none`, and both transition layers `box-none` through their animated styles. The inner height-animated `Animated.View` that hosts all of them — styled `[styles.header, headerStyle, layers.headerAnimatedStyle]` — set nothing, so it defaulted to `auto` and became a touch target across the whole header rectangle.

Every tap on empty header space was consumed there and never reached the scrollable underneath. In the app this showed up as tapping a non-interactive page title no longer dismissing the keyboard: the scroll view's `keyboardShouldPersistTaps="handled"` never received the touch.

The shell now defaults to `box-none`, consistent with the persistent layer and with the transition-layer values. `box-none` excludes only the shell itself, so leading and trailing controls inside the header stay tappable.

The default is written into the `styles.header` entry rather than a `pointerEvents` prop on purpose. Both React Native and React Native Testing Library resolve `props.pointerEvents` ahead of the flattened style value, so a prop default could not be overridden by `headerStyle` at all. Placed where it is — ahead of `headerStyle` in the style array, with the library's animated shell style merged last and only ever setting `height` — a caller-supplied `headerStyle={{ pointerEvents: 'auto' }}` wins. `collapsible-header-hit-testing.spec.tsx` pins the default, the caller override, and that descendants stay tappable through the transparent shell.

## Validation

`test:coverage`, `lint`, `ts`, `ts:nodenext`, and `build` pass for both packages; coverage stays at 100% statements/branches/functions/lines, and both React Compiler builds emit memoized output without panicking. Each new spec was verified to fail against the pre-fix source.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix safe-area layout, accessibility handoff, and shell hit testing in collapsible header
> - Repositions expanded, collapsed, and persistent content layers below the safe-area top inset using a `top` offset on `contentLayerStyle`, replacing the old `headerStyle={{ paddingTop: insets.top }}` which did not affect absolutely-positioned layers in [collapsible-header.tsx](https://github.com/rnw-community/rnw-community/pull/620/files#diff-af55f0924369a65cbec7f357c7e7eea00966602f88ba962611bee65371459aae)
> - Sets the header shell to `pointerEvents: 'box-none'` in [collapsible-header.tsx](https://github.com/rnw-community/rnw-community/pull/620/files#diff-3d0f2881788cfdb3fbed5138daaa7082fcf59b305b7b03889aa4a1d8c47c4afc) so empty header space no longer intercepts touches; callers can still override via `headerStyle.pointerEvents`
> - Derives `pointerEventsSwitchProgress` as the cross-fade midpoint `(collapsedOpacityStartProgress + expandedOpacityEndProgress) / 2` in [resolve-collapsible-header-motion.config.ts](https://github.com/rnw-community/rnw-community/pull/620/files#diff-5399b9b98bb3176440aa960b02951c986bfbeb645f3ec3327c219cad8c3c6bb4) unless an explicit value is provided, and removes the static `POINTER_EVENTS_SWITCH_PROGRESS` constant from [get-collapsible-header-motion.util.ts](https://github.com/rnw-community/rnw-community/pull/620/files#diff-a8c027e0916247650ff59d0539acf810a49bd510d4fe9f52ff3d1d2d13b3b54f)
> - Adds test suites for accessibility handoff, hit testing, and safe-area integration layout
> - Behavioral Change: `get-collapsible-header-motion.util.ts` no longer returns `pointerEventsSwitchProgress`; any out-of-tree consumer relying on that field from the mapper will now get the primitive's derived default instead
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79dca84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved collapsible header accessibility so screen readers and pointer interactions follow the currently visible title layer.
  - Pointer events and accessibility handoff now align with the cross-fade midpoint by default, while supporting customization.
  - Empty header space now allows touches to pass through, with caller overrides supported.
  - Corrected safe-area positioning so header content consistently appears below the top inset, including with zero insets.

- **Tests**
  - Added coverage for accessibility, interaction routing, motion thresholds, and safe-area layout behavior.

- **Documentation**
  - Clarified motion defaults, touch handling, accessibility behavior, and safe-area positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
